### PR TITLE
reduce the sample frequency for analog inputs following the change in HEARTBEAT_HZ (r1172).

### DIFF
--- a/libUDB/heartbeat.c
+++ b/libUDB/heartbeat.c
@@ -117,9 +117,12 @@ static void heartbeat_pulse(void)
 	vref_adj = 0;
 #endif // VREF
 
-	calculate_analog_sensor_values();
 	udb_callback_read_sensors();
-	udb_flags._.a2d_read = 1; // signal the A/D to start the next summation
+	if ((udb_heartbeat_counter % (HEARTBEAT_HZ/40)) == 1)
+	{
+		calculate_analog_sensor_values();
+		udb_flags._.a2d_read = 1; // signal the A/D to start the next summation
+	}
 
 	// process sensor data, run flight controller, generate outputs. implemented in libDCM.c
 	udb_heartbeat_callback(); // this was called udb_servo_callback_prepare_outputs()


### PR DESCRIPTION
fix to reduce the sample frequency for analog inputs following the change in HEARTBEAT_HZ (r1172).

- r1155 (abstract the flightplan handler) crippled LOGO. Available modes where manual, stabilized, and manual.
  I reported this before: https://groups.google.com/forum/#!topic/uavdevboard/dKxv509p060, apr 16.
  I have not tested FP_WAYPOINTS
- the analog fix adresses that after the change form  HEARTBEAT_HZ=40 to HEARTBEAT_HZ=200 for Udb5 and Auav3,  heartbeat_pulse(void) is run at 200Hz.
  This leaves too little time for analog samples to be completed. The fix brings te sample rate back to 40Hz. I only tested this on a Auav3 board.
  without the fix, the first sample is correct, but no updates follow. This can easily go unnoticed. So testing should be done by changing the applied voltage repeatedly.
