### PR TITLE
Improve support in for battery voltage and power monitoring 

### DIFF
--- a/MatrixPilot/flightplan.c
+++ b/MatrixPilot/flightplan.c
@@ -54,14 +54,16 @@ void flightplan_init(void)
 {
 #if (FLIGHT_PLAN_TYPE == FP_LOGO)
 	flightplan_logo_active = true;
-#endif
 	flightplan_logo_init();
+#else   
 	flightplan_waypoints_init();
+#endif
 	DPRINT("flightplan_init() - %s\r\n", flightplan_logo_active ? "LOGO" : "WAYPOINTS");
 }
 
 void flightplan_begin(int16_t flightplanNum)
 {
+    flightplan_init();
 	DPRINT("flightplan_begin(%u)\r\n", flightplanNum);
 
 	if (flightplan_logo_active) {

--- a/MatrixPilot/telemetry.c
+++ b/MatrixPilot/telemetry.c
@@ -676,14 +676,14 @@ void telemetry_output_8hz(void)
 			{
 				serial_output("F2:T%li:S%d%d%d:N%li:E%li:A%li:W%i:"
 				              "a%i:b%i:c%i:d%i:e%i:f%i:g%i:h%i:i%i:"
-				              "c%u:s%i:cpu%u:bmv%i:"
+				              "c%u:s%i:cpu%u:"
 				              "as%u:wvx%i:wvy%i:wvz%i:ma%i:mb%i:mc%i:svs%i:hd%i:",
 				    tow.WW, udb_flags._.radio_on, dcm_flags._.nav_capable, state_flags._.GPS_steering,
 				    lat_gps.WW, lon_gps.WW, alt_sl_gps.WW, waypointIndex,
 				    rmat[0], rmat[1], rmat[2],
 				    rmat[3], rmat[4], rmat[5],
 				    rmat[6], rmat[7], rmat[8],
-				    (uint16_t)cog_gps.BB, sog_gps.BB, (uint16_t)udb_cpu_load(), voltage_milis.BB,
+				    (uint16_t)cog_gps.BB, sog_gps.BB, (uint16_t)udb_cpu_load(), 
 				    air_speed_3DIMU,
 				    estimatedWind[0], estimatedWind[1], estimatedWind[2],
 #if (MAG_YAW_DRIFT == 1)
@@ -719,6 +719,17 @@ void telemetry_output_8hz(void)
 //				serial_output("tmp%i:prs%li:alt%li:agl%li:",
 //				    get_barometer_temperature(), get_barometer_pressure(), 
 //				    get_barometer_alt(), get_barometer_agl());
+				serial_output("bmv%i:mA%i:mAh%i:",
+#if (ANALOG_VOLTAGE_INPUT_CHANNEL != CHANNEL_UNUSED)
+                battery_voltage._.W1,
+#else
+                (int16_t)0,
+#endif
+#if (ANALOG_CURRENT_INPUT_CHANNEL != CHANNEL_UNUSED)                        
+				battery_current._.W1, battery_mAh_used._.W1);
+#else
+				(int16_t)0, (int16_t)0);                    
+#endif                            
 #if (RECORD_FREE_STACK_SPACE == 1)
 				extern uint16_t maxstack;
 				serial_output("stk%d:", (int16_t)(4096-maxstack));

--- a/Tools/MatrixPilot-SIL/Makefile.unix
+++ b/Tools/MatrixPilot-SIL/Makefile.unix
@@ -1,6 +1,6 @@
 CC       = gcc
 CFLAGS   = -pipe -Wall -W -O0 -DNIX=1
-INCPATH  = -I. -I../../libUDB -I../../libDCM -I../../MatrixPilot
+INCPATH  = -I. -I../../Config -I../../libUDB -I../../libDCM -I../../MatrixPilot
 LFLAGS   = -Wl
 LIBS     = -lm
 RM_FILE  = rm -f
@@ -10,7 +10,7 @@ OBJECTS_DIR = ./
 
 MPSIL_TARGET  = matrixpilot
 
-MP_HEADERS = ../../MatrixPilot/options.h ../../MatrixPilot/waypoints.h ../../MatrixPilot/flightplan-logo.h
+MP_HEADERS = ../../Config/options.h ../../MatrixPilot/waypoints.h ../../MatrixPilot/flightplan-logo.h
 
 MPSIL_OBJECTS = \
 SIL-udb.o \
@@ -23,16 +23,18 @@ SIL-events.o \
  \
 ../../libDCM/deadReckoning.o \
 ../../libDCM/estAltitude.o \
+../../libDCM/estLocation.o \
 ../../libDCM/estWind.o \
 ../../libDCM/estYawDrift.o \
+../../libDCM/gpsData.o \
 ../../libDCM/gpsParseCommon.o \
 ../../libDCM/gpsParseMTEK.o \
 ../../libDCM/gpsParseSTD.o \
 ../../libDCM/gpsParseUBX.o \
+../../libDCM/hilsim.o \
 ../../libDCM/libDCM.o \
 ../../libDCM/mathlibNAV.o \
 ../../libDCM/rmat.o \
- \
 ../../MatrixPilot/airspeedCntrl.o \
 ../../MatrixPilot/altitudeCntrl.o \
 ../../MatrixPilot/altitudeCntrlVariable.o \
@@ -43,10 +45,12 @@ SIL-events.o \
 ../../MatrixPilot/data_services.o \
 ../../MatrixPilot/data_storage.o \
 ../../MatrixPilot/euler_angles.o \
+../../MatrixPilot/flightplan.o \
 ../../MatrixPilot/flightplan-logo.o \
 ../../MatrixPilot/flightplan-waypoints.o \
 ../../MatrixPilot/helicalTurnCntrl.o \
 ../../MatrixPilot/main.o \
+../../MatrixPilot/minIni.o \
 ../../MatrixPilot/MAVLink.o \
 ../../MatrixPilot/MAVParams.o \
 ../../MatrixPilot/MAVMission.o \


### PR DESCRIPTION
Thanks to Giulio Berti for suggesting this improvement in the[ uavdevboard-dev thread.](https://groups.google.com/d/msg/uavdevboard-dev/osH_9e0pd6M/qcj1AhrQAwAJ)

I have regrouped the voltage, amp and amp hours to be in the same part of the telemetry file.

I have dropped support for voltage_milis.BB in SUE. I don't believe anyone has been using that.

Giulio, please can you try this out, and test it in your flights, and confirm that it is working for you before I move this pull request into Master.