### PR TITLE
Fix Logo's processing of  F_ALTITUDE_GOAL

### DIFF
--- a/MatrixPilot/flightplan-logo.c
+++ b/MatrixPilot/flightplan-logo.c
@@ -467,6 +467,7 @@ void flightplan_logo_update(void)
 	{
 		if (abs(IMUheight - navigate_get_goal(NULL)) < ((int16_t)altit.HeightMargin)) // reached altitude goal
 		{
+            desired_behavior._.altitude = 0;
 			process_instructions();
 		}
 	}


### PR DESCRIPTION
This issue came to light with Giulio Berti testing his flying wing with Master. The full discussion can be seen from here [on this thread.](https://groups.google.com/d/msg/uavdevboard/BZe_GGs0b8A/vvn9tCv3AwAJ).

F_ALTITUDE_GOAL is a flag that can set both in waypoints.h and flightplan-logo.h . It is meant to provide a mechanism of moving onto another waypoint as soon as a given altitude is reached. For example, you could takeoff, and give the plane a waypoint a mile away in one direction. And you could request an altitude of 100 meters. As soon as the plane reaches 100 meters, with F_ALTITUDE_GOAL set, the plane will move onto the next waypoint, and ignore the current waypoint (which is probably still nearly a mile away).

In flightplan-logo.c, once the goal is reached, the behaviour flag was not reset. Since this flag creates a form of interrupt (It is checked and if it the altitude has been reached the next logo instruciton is called immediately), the result was that the Logo processor was spinning through a waypoint on every frame rate. 

The fix, as shown is simple. It is has been tested in HILSIM with Guilio's original flight plan that caused the problem.

The fix is not requred for waypoints.c (The non-logo wayhpoints system), because each waypoint contains it's own entire description of the 16 bit flags value. So when the next waypoint is called, the 16 bits of flags, which will probably not include, F_ALTITUDE_GOAL, will effectively ensure that this behavious is switched off. 

However, with Logo, the waypoints do not have their own independent store of the 16 bit flags. That would no make sense. So the F_ALTITUDE_GOAL flag, also known as  desired_behavior._.altitude has to be set to zero. (as shown in the commit.)

Best wishes, Pete
