### PR TITLE
Fix initialisation of SERIAL_UDB_EXTRA  (SUE)

### DIFF
--- a/MatrixPilot/telemetry.c
+++ b/MatrixPilot/telemetry.c
@@ -474,7 +474,7 @@ int16_t udb_serial_callback_get_byte_to_send(void)
 	return -1;
 }
 
-static int16_t telemetry_counter = 12;
+static int16_t telemetry_counter = 11;
 
 void telemetry_restart(void)
 {


### PR DESCRIPTION
A simple fix to ensure the F2: statement in SERIAL_UDB_EXTRA does not initially print 1/2 of it's line at the start of the telemetry file; but waits until all the other initialisation telemetry has completed, before it starts printing whole F2 lines. Ground Tested on the UDB4.