### PR TITLE
Change default of USE_MCU_IDLE from 1 to 0 .

### DIFF
--- a/libUDB/interrupt.h
+++ b/libUDB/interrupt.h
@@ -21,7 +21,7 @@
 
 ////////////////////////////////////////////////////////////////////////////////
 // Optionally enable the new power saving idle mode of the MCU during mainloop
-#define USE_MCU_IDLE    1
+#define USE_MCU_IDLE    0
 
 
 #define INT_PRI_T1      6   // background.c : high priority HEARTBEAT of libUDB


### PR DESCRIPTION
As[ discussed recently in uavdevboard](https://groups.google.com/d/msg/uavdevboard/Ja-NeeXkC50/vHyuhmoLAwAJ) I am moving to have USE_MCU_IDLE be switched off i.e. move from being 1 to 0.