### PR TITLE
Glide airspeed control fix

### DIFF
--- a/MatrixPilot/altitudeCntrlVariable.c
+++ b/MatrixPilot/altitudeCntrlVariable.c
@@ -110,14 +110,14 @@ void init_altitudeCntrlVariable(void)
 
 void save_altitudeCntrlVariable(void)
 {
-	gains.HeightTargetMax = height_target_max;
-	gains.HeightTargetMin = height_target_min;
+	altit.HeightTargetMax = height_target_max;
+	altit.HeightTargetMin = height_target_min;
 //	height_margin;
-	gains.AltHoldThrottleMin = alt_hold_throttle_min / RMAX;
-	gains.AltHoldThrottleMax = alt_hold_throttle_max / RMAX;
-	gains.AltHoldPitchMin = alt_hold_pitch_min;
-	gains.AltHoldPitchMax = alt_hold_pitch_max;
-	gains.AltHoldPitchHigh = alt_hold_pitch_high;
+	altit.AltHoldThrottleMin = alt_hold_throttle_min / RMAX;
+	altit.AltHoldThrottleMax = alt_hold_throttle_max / RMAX;
+	altit.AltHoldPitchMin = alt_hold_pitch_min;
+	altit.AltHoldPitchMax = alt_hold_pitch_max;
+	altit.AltHoldPitchHigh = alt_hold_pitch_high;
 //	rtl_pitch_down;
 //	desiredSpeed / 10;
 //	speed_control;
@@ -284,7 +284,8 @@ static void normalAltitudeCntrl(void)
 				// In stabilized mode using pitch-only altitude hold, use desiredHeight as
 				// set from the state machine upon entering stabilized mode in ent_stabilizedS()
 			}
-			else if ((settings._.AltitudeholdStabilized == AH_FULL) || (settings._.AltitudeholdStabilized == AH_THROTTLE_ONLY))
+			//else if ((settings._.AltitudeholdStabilized == AH_FULL) ||/// (settings._.AltitudeholdStabilized == AH_THROTTLE_ONLY))
+			else if (settings._.AltitudeholdStabilized == AH_FULL)
 			{
 				// In stabilized mode using full altitude hold, use the throttle stick value to determine desiredHeight,
 				desiredHeight = ((__builtin_mulss(height_throttle_gain, throttleInOffset - ((int16_t)(DEADBAND)))) >> 11)

--- a/MatrixPilot/defines.h
+++ b/MatrixPilot/defines.h
@@ -97,7 +97,7 @@ void save_altitudeCntrlVariable(void);
 #define SERIAL_MAVLINK      9    // The Micro Air Vehicle Link protocol from the PixHawk Project
 
 
-//#include "gain_variables.h"
+#include "gain_variables.h"
 
 // GNU compiler specific macros for specifically marking variables as unused
 // If not using GNU, then these macros make no alteration to the code

--- a/MatrixPilot/helicalTurnCntrl.c
+++ b/MatrixPilot/helicalTurnCntrl.c
@@ -31,7 +31,7 @@
 #include "../libDCM/mathlibNAV.h"
 #include "../libDCM/rmat.h"
 #include <math.h>
-
+#include "airspeed_options.h" 
 //#ifndef RTL_PITCH_DOWN
 //#define RTL_PITCH_DOWN (0.0)
 //#endif // RLT_PITCH_DOWN


### PR DESCRIPTION
if one or more of these setting are used, compilation errors may occur, and/or code will not function;

GAINS_VARIABLE                      1
ALTITUDE_GAINS_VARIABLE             1
GLIDE_AIRSPEED_CONTROL  1

fixing this may help to fix SPEED_CONTROL as well.

Best regards,
Kees