### PR TITLE
Include battery Voltage and Current in the Mavlink SYS_STATUS mesage

### DIFF
--- a/MatrixPilot/MAVLink.c
+++ b/MatrixPilot/MAVLink.c
@@ -975,7 +975,7 @@ void mavlink_output_40hz(void)
             #else
 				(int16_t)0,                    
             #endif
-		    0,                              // Percentage battery remaining 100 percent is 1000
+		    100,                               // Remaining battery energy: (0%: 0, 100%: 100), -1: autopilot estimate the remaining battery
 		    r_mavlink_status.packet_rx_drop_count,
 		    0,              // errors_comm
 		    0,              // errors_count1

--- a/MatrixPilot/MAVLink.c
+++ b/MatrixPilot/MAVLink.c
@@ -965,9 +965,17 @@ void mavlink_output_40hz(void)
 		    0,              // Sensors enabled
 		    0,              // Sensor health
 		    udb_cpu_load() * 10,
-		    0,              // Battery voltage in mV
-		    0,              // Current
-		    0,              // Percentage battery remaining 100 percent is 1000
+            #if (ANALOG_VOLTAGE_INPUT_CHANNEL != CHANNEL_UNUSED)
+                battery_voltage._.W1 * 100,     // Battery voltage, in millivolts (1 = 1 millivolt)
+            #else
+                (int16_t)0,
+            #endif
+		    #if (ANALOG_CURRENT_INPUT_CHANNEL != CHANNEL_UNUSED)                        
+                battery_current._.W1 * 10,      // Battery current, in 10*milliamperes (1 = 10 milliampere), -1: autopilot does not measure the current
+            #else
+				(int16_t)0,                    
+            #endif
+		    0,                              // Percentage battery remaining 100 percent is 1000
 		    r_mavlink_status.packet_rx_drop_count,
 		    0,              // errors_comm
 		    0,              // errors_count1


### PR DESCRIPTION
As I started to use the Minim Osd, flashed with MinimOsdExtra firmware, I noticed that voltage and current data were not displayed, even though I had already configured the voltage and current sensor in options.h

I wanted to fix this also to learn the GitHub workflow, explained by Pete in [one of his videos](https://vimeo.com/163824531).

For the time being, I've only compiled this fix, I'll fly test it tomorrow.

Personally, I find that the use of #if () #else #endif disrupts the readability of the code, but I understand the memory efficiency needs.

Best regards,
Giulio