### PR TITLE
Corrected the climb rate scaling from cm/s to m/s in Mavlink VFR_HUD message

### DIFF
--- a/MatrixPilot/MAVLink.c
+++ b/MatrixPilot/MAVLink.c
@@ -951,7 +951,6 @@ void mavlink_output_40hz(void)
 		    (int16_t)mavlink_heading,
 		    (uint16_t)(((float)((udb_pwOut[THROTTLE_OUTPUT_CHANNEL]) - udb_pwTrim[THROTTLE_INPUT_CHANNEL]) * 100.0) / (float)(pwOut_max - udb_pwTrim[THROTTLE_INPUT_CHANNEL])),
 		    ((float)(IMUlocationz._.W1 + (alt_origin.WW / 100.0))),
-		    (float) -IMUvelocityz._.W1 / 100.0);                                // Current climb rate in meters/second
 		    (float) IMUvelocityz._.W1 / 100.0);                                 // Current climb rate in meters/second
 		//void mavlink_msg_vfr_hud_send(mavlink_channel_t chan, float airspeed, float groundspeed, int16_t heading, uint16_t throttle, float alt, float climb)
 	}

--- a/MatrixPilot/MAVLink.c
+++ b/MatrixPilot/MAVLink.c
@@ -952,6 +952,7 @@ void mavlink_output_40hz(void)
 		    (uint16_t)(((float)((udb_pwOut[THROTTLE_OUTPUT_CHANNEL]) - udb_pwTrim[THROTTLE_INPUT_CHANNEL]) * 100.0) / (float)(pwOut_max - udb_pwTrim[THROTTLE_INPUT_CHANNEL])),
 		    ((float)(IMUlocationz._.W1 + (alt_origin.WW / 100.0))),
 		    (float) -IMUvelocityz._.W1 / 100.0);                                // Current climb rate in meters/second
+		    (float) IMUvelocityz._.W1 / 100.0);                                 // Current climb rate in meters/second
 		//void mavlink_msg_vfr_hud_send(mavlink_channel_t chan, float airspeed, float groundspeed, int16_t heading, uint16_t throttle, float alt, float climb)
 	}
 #endif // (MSG_VFR_HUD_WITH_POSITION == 1)

--- a/MatrixPilot/MAVLink.c
+++ b/MatrixPilot/MAVLink.c
@@ -951,7 +951,7 @@ void mavlink_output_40hz(void)
 		    (int16_t)mavlink_heading,
 		    (uint16_t)(((float)((udb_pwOut[THROTTLE_OUTPUT_CHANNEL]) - udb_pwTrim[THROTTLE_INPUT_CHANNEL]) * 100.0) / (float)(pwOut_max - udb_pwTrim[THROTTLE_INPUT_CHANNEL])),
 		    ((float)(IMUlocationz._.W1 + (alt_origin.WW / 100.0))),
-		    (float) -IMUvelocityz._.W1);
+		    (float) -IMUvelocityz._.W1 / 100.0);                                // Current climb rate in meters/second
 		//void mavlink_msg_vfr_hud_send(mavlink_channel_t chan, float airspeed, float groundspeed, int16_t heading, uint16_t throttle, float alt, float climb)
 	}
 #endif // (MSG_VFR_HUD_WITH_POSITION == 1)


### PR DESCRIPTION
In response to [the issue I opened](https://github.com/MatrixPilot/MatrixPilot/issues/18), I propose a possible solution.

The VFR_HUD message includes the climb rate in m/s as float value, while we are currently sending (-IMUvelocityz._.W1) in cm/s.

I've only compiled this change, I'll test it tomorrow.

Best regards,
Giulio