### PR TITLE
Navigation light support

### DIFF
--- a/Config/options.h
+++ b/Config/options.h
@@ -760,6 +760,8 @@
 // Define USE_DEBUG_IO to enable DPRINT macro to call printf(..)
 //#define USE_DEBUG_IO
 
+// Enable support for external wing led, currently supported only by UDB4 and UDB5
+#define USE_WING_LED 1
 
 ////////////////////////////////////////////////////////////////////////////////
 // AUAV3 only options

--- a/MatrixPilot/states.c
+++ b/MatrixPilot/states.c
@@ -179,6 +179,7 @@ static void ent_calibrateS(void)
 	stateS = &calibrateS;
 	calib_timer = CALIB_PAUSE;
 	led_on(LED_RED); // turn on mode led
+    led_wing_set_mode(LED_ALL_WING, LED_MODE_ON, 0);
 }
 
 // Acquire state is used to wait for the GPS to achieve lock.
@@ -209,6 +210,7 @@ static void ent_acquiringS(void)
 	stateS = &acquiringS;
 	standby_timer = STANDBY_PAUSE;
 	led_off(LED_RED);
+    led_wing_set_mode(LED_LEFT_WING, LED_MODE_ON, 0);
 }
 
 //	Manual state is used for direct pass-through control from radio to servos.
@@ -223,6 +225,7 @@ static void ent_manualS(void)
 	state_flags._.disable_throttle = 0;
 	waggle = 0;
 	led_off(LED_RED);
+    led_wing_set_mode(LED_ALL_WING, LED_MODE_ON, 0);
 	stateS = &manualS;
 }
 
@@ -244,6 +247,7 @@ static void ent_stabilizedS(void)
 	state_flags._.altitude_hold_pitch = (settings._.AltitudeholdStabilized == AH_FULL || settings._.AltitudeholdStabilized == AH_PITCH_ONLY);
 	waggle = 0;
 	led_on(LED_RED);
+    led_wing_set_mode(LED_ALL_WING, LED_MODE_PATTERN_INV, 0);
 	stateS = &stabilizedS;
 }
 
@@ -298,6 +302,7 @@ static void ent_waypointS(void)
 
 	waggle = 0;
 	led_on(LED_RED);
+    led_wing_set_mode(LED_ALL_WING, LED_MODE_PATTERN, 0);
 	stateS = &waypointS;
 }
 
@@ -324,6 +329,7 @@ static void ent_returnS(void)
 
 	waggle = 0;
 	led_on(LED_RED);
+    led_wing_set_mode(LED_ALL_WING, LED_MODE_BLINK, 4);
 	stateS = &returnS;
 }
 
@@ -345,6 +351,7 @@ static void calibrateS(void)
 #endif
 	{
 		udb_led_toggle(LED_RED);
+        led_wing_set_mode(LED_ALL_WING, LED_MODE_BLINK, 1);     // Calling this one time would have been sufficient
 		calib_timer--;
 		DPRINT("calib_timer %u  \r", calib_timer);
 		if (calib_timer <= 0)
@@ -363,7 +370,7 @@ static void acquiringS(void)
 	ent_manualS();
 	return;
 #endif
-
+    
 	if (dcm_flags._.nav_capable && ((MAG_YAW_DRIFT == 0) || (magMessage == 7)))
 	{
 #if (NORADIO == 1)
@@ -378,7 +385,7 @@ static void acquiringS(void)
 				waggle = - waggle;
 			else
 				waggle = 0;
-
+            
 			standby_timer--;
 			DPRINT("standby_timer %u  \r", standby_timer);
 			if (standby_timer == 6)
@@ -484,7 +491,7 @@ static void stabilizedS(void)
 		if (launch_enabled() & flight_mode_switch_waypoints() & dcm_flags._.nav_capable)
 			ent_cat_armedS();
 		else
-#endif
+#endif           
 		if (flight_mode_switch_waypoints() & dcm_flags._.nav_capable)
 			ent_waypointS();
 		else if (flight_mode_switch_manual())
@@ -503,7 +510,7 @@ static void stabilizedS(void)
 static void waypointS(void)
 {
 	udb_led_toggle(LED_RED);
-
+    
 	if (udb_flags._.radio_on)
 	{
 		if (flight_mode_switch_manual())
@@ -521,7 +528,7 @@ static void waypointS(void)
 static void returnS(void)
 {
 	if (udb_flags._.radio_on)
-	{
+	{         
 		if (flight_mode_switch_manual())
 			ent_manualS();
 		else if (flight_mode_switch_stabilize())

--- a/libUDB/ConfigUDB4.h
+++ b/libUDB/ConfigUDB4.h
@@ -61,6 +61,8 @@
 #define LED_ORANGE          _LATE3
 #define LED_GREEN           _LATE2
 #define LED_RED             _LATE1
+#define LED_GREEN_EXT       _LATA5
+#define LED_RED_EXT         _LATA14
 
 // SPI SS pin definitions
 #define SPI1_SS             _LATB2

--- a/libUDB/ConfigUDB5.h
+++ b/libUDB/ConfigUDB5.h
@@ -75,6 +75,8 @@
 #define LED_ORANGE          _LATE3
 #define LED_GREEN           _LATE2
 #define LED_RED             _LATE1
+#define LED_GREEN_EXT       _LATA5
+#define LED_RED_EXT         _LATA14
 
 // SPI SS pin definitions
 #define SPI1_SS             _LATB2

--- a/libUDB/heartbeat.c
+++ b/libUDB/heartbeat.c
@@ -139,4 +139,10 @@ static void heartbeat_pulse(void)
 		flexiFunctionServiceTrigger();
 #endif
 	}
+#if (USE_WING_LED == 1)    
+    if (udb_heartbeat_counter % (HEARTBEAT_HZ/20) == 0)
+	{
+        led_wing_heartbeat_callback();
+    }
+#endif
 }

--- a/libUDB/led_wing.c
+++ b/libUDB/led_wing.c
@@ -1,0 +1,135 @@
+// This file is part of MatrixPilot.
+//
+//    http://code.google.com/p/gentlenav/
+//
+// Copyright 2009-2011 MatrixPilot Team
+// See the AUTHORS.TXT file for a list of authors of MatrixPilot.
+//
+// MatrixPilot is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// MatrixPilot is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with MatrixPilot.  If not, see <http://www.gnu.org/licenses/>.
+
+#include "../MatrixPilot/defines.h"
+
+#define LED_COUNTER_MAX 20
+#define NUM_LED_WING 2      // Max 255 leds
+
+uint16_t led_counter = 0;
+uint8_t  led_pattern[LED_COUNTER_MAX] = {1,0,1,0,1,0,1,0,0,0,0,0,0,0,0,0,0,0,0,0};
+struct Led led_wing[NUM_LED_WING];
+
+void led_wing_heartbeat_callback()
+{
+#if (USE_WING_LED == 1)    
+    led_wing[LED_RIGHT_WING].index = (led_counter + led_wing[LED_RIGHT_WING].offset) % LED_COUNTER_MAX;
+    switch(led_wing[LED_RIGHT_WING].mode)
+    {
+        case LED_MODE_OFF:
+            led_off_wing(LED_GREEN_EXT);                
+            break;
+
+        case LED_MODE_ON:
+            led_on_wing(LED_GREEN_EXT);                
+            break;
+
+        case LED_MODE_BLINK:    // Offset variable used as blink frequency in Hz
+            if (led_counter % (10/led_wing[LED_RIGHT_WING].offset) == 0)  // toggle twice the frequency (20/(led_wing[].offset *2))
+                udb_led_toggle(LED_GREEN_EXT);               
+            break;  
+
+        case LED_MODE_PATTERN:
+            LED_GREEN_EXT = led_pattern[led_wing[LED_RIGHT_WING].index];             
+            break;
+
+        case LED_MODE_PATTERN_INV:
+            LED_GREEN_EXT = !led_pattern[led_wing[LED_RIGHT_WING].index];                
+            break;       
+    }        
+
+    led_wing[LED_LEFT_WING].index = (led_counter + led_wing[LED_LEFT_WING].offset) % LED_COUNTER_MAX;
+    switch(led_wing[LED_LEFT_WING].mode)
+    {
+        case LED_MODE_OFF:
+            led_off_wing(LED_RED_EXT);                
+            break;
+
+        case LED_MODE_ON:
+            led_on_wing(LED_RED_EXT);                
+            break;
+
+        case LED_MODE_BLINK:    // Offset variable used as blink frequency in Hz
+            if (led_counter % (10/led_wing[LED_LEFT_WING].offset) == 0)  // toggle twice the frequency (20/(led_wing[].offset *2))
+                udb_led_toggle(LED_RED_EXT);               
+            break;  
+
+        case LED_MODE_PATTERN:
+            LED_RED_EXT = led_pattern[led_wing[LED_LEFT_WING].index];             
+            break;
+
+        case LED_MODE_PATTERN_INV:
+            LED_RED_EXT = !led_pattern[led_wing[LED_LEFT_WING].index];                
+            break;       
+    }
+    
+	led_counter = (led_counter+1) % LED_COUNTER_MAX;
+#endif    
+}
+
+void led_wing_set_mode(uint8_t led_num, uint8_t mode, uint8_t offset)
+{   
+    uint8_t startFor = 0;
+    uint8_t endFor = 0;
+    uint8_t i = 0;
+    
+    if(led_num == LED_ALL_WING){
+        startFor = 0;
+        endFor = NUM_LED_WING-1;
+    }
+    else{
+        startFor = led_num;
+        endFor = led_num;
+    }  
+        
+    for(i=startFor; i<=endFor; i++)
+    {
+        switch(mode)
+        {
+            case LED_MODE_OFF:
+                led_wing[i].mode     = LED_MODE_OFF;                
+                break;
+
+            case LED_MODE_ON:
+                led_wing[i].mode     = LED_MODE_ON;               
+                break;
+
+            case LED_MODE_BLINK:    // Offset variable used as blink frequency
+                led_wing[i].mode     = LED_MODE_BLINK;
+                if(offset == 0)
+                    led_wing[i].offset   = 1;      
+                else if (offset > 10)   // led_wing_heatbeat_callback() is called at 20Hz, thus 10Hz max blinking frequency
+                    led_wing[i].offset   = 10;      
+                else
+                    led_wing[i].offset   = offset;                          
+                break;  
+
+            case LED_MODE_PATTERN:
+                led_wing[i].mode     = LED_MODE_PATTERN;
+                led_wing[i].offset   = offset;                
+                break;
+
+            case LED_MODE_PATTERN_INV:
+                led_wing[i].mode     = LED_MODE_PATTERN_INV;
+                led_wing[i].offset   = offset;                
+                break;       
+        }
+    }
+}

--- a/libUDB/led_wing.h
+++ b/libUDB/led_wing.h
@@ -1,0 +1,53 @@
+// This file is part of MatrixPilot.
+//
+//    http://code.google.com/p/gentlenav/
+//
+// Copyright 2009-2011 MatrixPilot Team
+// See the AUTHORS.TXT file for a list of authors of MatrixPilot.
+//
+// MatrixPilot is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// MatrixPilot is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with MatrixPilot.  If not, see <http://www.gnu.org/licenses/>.
+
+#ifndef LED_WING_H
+#define	LED_WING_H
+
+#ifdef	__cplusplus
+extern "C" {
+#endif
+    
+#define LED_MODE_OFF            0    
+#define LED_MODE_ON             1    
+#define LED_MODE_BLINK          2
+#define LED_MODE_PATTERN        3    
+#define LED_MODE_PATTERN_INV    4    
+
+#define LED_ALL_WING            255    
+#define LED_RIGHT_WING          0
+#define LED_LEFT_WING           1
+    
+    
+struct Led {
+    uint8_t mode;
+    uint8_t offset;
+    uint8_t index;
+};    
+void led_wing_heartbeat_callback();
+void led_wing_set_mode(uint8_t led_num, uint8_t mode, uint8_t offset);
+
+
+#ifdef	__cplusplus
+}
+#endif
+
+#endif	/* LED_WING_H */
+

--- a/libUDB/libUDB.h
+++ b/libUDB/libUDB.h
@@ -254,6 +254,8 @@ void led_off(uint8_t x);
 //#define led_off(x)                      ((x) = 1)
 #define led_on(x)                       ((x) = LED_ON)
 #define led_off(x)                      ((x) = LED_OFF)
+#define led_on_wing(x)                   ((x) = LED_ON_WING)
+#define led_off_wing(x)                  ((x) = LED_OFF_WING)
 #endif
 
 

--- a/libUDB/libUDB_defines.h
+++ b/libUDB/libUDB_defines.h
@@ -140,7 +140,9 @@ struct udb_flag_bits {
 // LED states
 #define LED_ON                  0
 #define LED_OFF                 1
-
+#define LED_ON_WING             1
+#define LED_OFF_WING            0
+#include "led_wing.h"
 
 // Channel numbers on the board, mapped to positions in the pulse width arrays.
 #define CHANNEL_UNUSED          0   // udb_pwIn[0], udb_pwOut[0], etc. are not used, but allow lazy code everywhere else  :)

--- a/libUDB/mcu.c
+++ b/libUDB/mcu.c
@@ -311,9 +311,11 @@ static void init_leds(void)
 	_LATB2 = LED_OFF; _LATB3 = LED_OFF; _LATB4 = LED_OFF; _LATB5 = LED_OFF; 
 	_TRISB2 = 0; _TRISB3 = 0; _TRISB4 = 0; _TRISB5 = 0;
 #elif (BOARD_TYPE == UDB4_BOARD || BOARD_TYPE == UDB5_BOARD)
-	_LATE1 = LED_OFF; _LATE2 = LED_OFF; _LATE3 = LED_OFF; _LATE4 = LED_OFF;
-	_TRISE1 = 0; _TRISE2 = 0; _TRISE3 = 0; _TRISE4 = 0;
-#else
+	_LATE1  = LED_OFF;      _LATE2   = LED_OFF;  _LATE3  = LED_OFF;  _LATE4  = LED_OFF;
+	_TRISE1 = 0;            _TRISE2  = 0;        _TRISE3 = 0;        _TRISE4 = 0;
+    _LATA5  = LED_OFF_WING;  _LATA14  = LED_OFF_WING;
+    _TRISA5 = 0;            _TRISA14 = 0;
+#else   
 #error Invalid BOARD_TYPE
 #endif // BOARD_TYPE
 }


### PR DESCRIPTION
Hi everyone,

in this branch I added an initial support for led navigation lights in MatrixPilot.
I made a [video introducing the functionalities](https://youtu.be/p2I5vmy2RJ0) (please excuse the language mistakes, I was nervous while speaking english)
Essentially I generalized how leds are switched on and off. 
instead of directly switch on, off, or toggle an led using functions like udb_led_toggle(LED_RED), each led can be dynamically configured by calling the led_wing_set_mode(led,mode,param) function, and it is switched accordingly to its selected mode inside the function led_wing_heartbeat_callback(), called at 20Hz from the low priority heartbeat.

**led_wing_set_mode(led,mode,param)**

- **led**: first associate the led number with name in [led_wing.h](https://github.com/giukio/MatrixPilot/blob/led_wing/libUDB/led_wing.h#L34).
Optionally you can speify LED_ALL_WING to apply the mode to all defined leds (I find this useful).

- **param**: parameter needed by certain led modes

- **mode**
The led modes I defined are:
LED_MODE_OFF: the selected led will be switched off
LED_MODE_ON: the selected led will be switched on
LED_MODE_BLINK: the selected led will blink at frequency specified in param (range clipped at 1-10Hz)
LED_MODE_PATTERN: led normally off, 4 rapid flashes every second. the param fiels is used as offset:as example by setting it to 8 you can make the right wing to flash right after the left one. If you live it at 0 all led in this mode will be synchonized, even if their mode is set at different times.
LED_MODE_PATTERN_INV: same as above, but led normally on, 4 rapid flashes every second

Personally I don't consider led_wing_heartbeat_callback() as finished: I would like to serve in a for loop all the defined leds, but I don't know how to implement a pointer array of output pins.

These modes are then used in states.c

- After the battery is plugged in, before the radio is switched on, all leds are on (to check whether they are working)

- During calibration they blink at 1Hz. when calibration is done, the left wing (red led) will stay on (visual feedback)

- after the 4 aileron waggles, also the right wing (green led) will stay on

- In manual mode both led are on solid

- stabilize uses the inverted pattern: is still a semi-manual mode, thus the led are normally on (like manual), but they rapidly flash 4 times each second

- LOGO or waypoint mode use the normal pattern: led normally off, 4 rapid flashes each second.

- Finally if the plane looses the radio link, all leds will blink at 4Hz. The idea was to give a sort of visual "alarm".

Note that this led mode is [enabled in options.h](https://github.com/giukio/MatrixPilot/blob/led_wing/Config/options.h#L764), and the led_wing_set_mode can be called without #if( USE_WING_LED == 1)

I am open to comments and suggestions, both for the implementation and the choice of the names.
Do you think this could be useful to anyone?

Best regards,
Giulio