### PR TITLE
Limit main routine in flight_controller() to running at 40Hz.

### DIFF
--- a/MatrixPilot/servoPrepare.c
+++ b/MatrixPilot/servoPrepare.c
@@ -84,24 +84,25 @@ static void flight_controller(void)
 	if (udb_heartbeat_counter % (HEARTBEAT_HZ/40) == 0)
 	{
 		flight_mode_switch_2pos_poll(); // we always want this called at 40Hz
-	}
+	
 #if (DEADRECKONING == 1)
-	navigate_process_flightplan();
+        navigate_process_flightplan();
 #endif
 #if (ALTITUDE_GAINS_VARIABLE == 1)
-	airspeedCntrl();
+        airspeedCntrl();
 #endif // ALTITUDE_GAINS_VARIABLE
-	updateBehavior();
-	wind_gain = wind_gain_adjustment();
-	helicalTurnCntrl();
-	rollCntrl();
-	yawCntrl();
-	altitudeCntrl();
-	pitchCntrl();
-	servoMix();
-	cameraCntrl();
-	cameraServoMix();
-	updateTriggerAction();
+        updateBehavior();
+        wind_gain = wind_gain_adjustment();
+        helicalTurnCntrl();
+        rollCntrl();
+        yawCntrl();
+        altitudeCntrl();
+        pitchCntrl();
+        servoMix();
+        cameraCntrl();
+        cameraServoMix();
+        updateTriggerAction();
+    }
 }
 
 static void manualPassthrough(void)


### PR DESCRIPTION
After some [discussion on CPU load](https://groups.google.com/d/msg/uavdevboard/xWHRCKIFewQ/M4FHbYnJBAAJ), and the fact that for the UDB5 and AUAV4 HEARTBEAT is driven at 200Hz by the invensense gyro, and so the flight_controller() routines should be limited to running at 40Hz. In the past, they were not, and so were running at 200Hz and chewing up CPU.

This Pull request compiles, and CPU has returned from 26% before the commit,  to 20% (In line with the original wjp_helicalTurns branch).  (That is a start up figure).

The Pull request needs flight testing. Volunteers ?

Best wishes, Pete
