### PR TITLE
Fix use of MINIMUM_AIRSPEED in two different contexts.

### DIFF
--- a/MatrixPilot/helicalTurnCntrl.c
+++ b/MatrixPilot/helicalTurnCntrl.c
@@ -79,7 +79,7 @@
 
 #define MAX_INPUT            (1000) // maximum input in pwm units
 
-#define MINIMUM_AIRSPEED     (500) // minimum value of airspeed in cm/sec to be used in tilt computation,
+#define TURN_CALC_MINIMUM_AIRSPEED     (500) // minimum value of airspeed in cm/sec to be used in tilt computation,
                                    // mainly used for ground testing of turning tilt, which would go to zero at zero airspeed
 
 int16_t tiltError[3];
@@ -220,7 +220,7 @@ void helicalTurnCntrl(void)
 	airSpeed = 981; // for testing purposes, an airspeed is needed
 #else
 	airSpeed = air_speed_3DIMU;
-	if (airSpeed < MINIMUM_AIRSPEED) airSpeed = MINIMUM_AIRSPEED;
+	if (airSpeed < TURN_CALC_MINIMUM_AIRSPEED) airSpeed = TURN_CALC_MINIMUM_AIRSPEED;
 #endif
 
 	// determine the desired turn rate as the sum of navigation and fly by wire.


### PR DESCRIPTION
MINIMUM_AIRSPEED was used in airspeed_options.h and in helicalTurnCntrl.c in two different contexts, with two different values. 

The compiler was warning that MINIMUM_AIRSPEED was being re-defined. 

This is a small fix for that.