### PR TITLE
Fixes to improve compilation of FlashOSD tool

### DIFF
--- a/Tools/FlashOSD/main.c
+++ b/Tools/FlashOSD/main.c
@@ -22,6 +22,7 @@
 #include "../../libUDB/libUDB.h"
 #include "../../libUDB/heartbeat.h"
 #include "../../libUDB/osd.h"
+#include "../../libUDB/ADchannel.h"
 #include "font_data.h"
 
 
@@ -136,7 +137,7 @@ void udb_callback_radio_did_turn_off(void) {}
 
 void init_analogs(void) {}
 void init_events(void) {}
-void udb_init_capture(void) {}
+void radioIn_init(void) {}
 void MPU6000_init16(void) {}
 
 int16_t failSafePulses = 0;
@@ -155,7 +156,7 @@ struct ADchannel udb_yrate;
 struct ADchannel udb_zrate;
 
 void start_pwm_outputs(void) {}
-void udb_init_pwm(void) {}
+void servoOut_init(void) {}
 
 void udb_init_GPS(void) {}
 void udb_init_USART(void) {}

--- a/libUDB/ConfigUDB4.h
+++ b/libUDB/ConfigUDB4.h
@@ -33,7 +33,9 @@
 #define yaccelBUFF          6
 #define zaccelBUFF          4
 
+#ifndef NUM_ANALOG_INPUTS
 #define NUM_ANALOG_INPUTS   4
+#endif
 
 // External A/D channels:
 #define analogInput1BUFF    7


### PR DESCRIPTION
This fix does not include the change required to the configuration of the pre-processor options in MLAB or MPLAB-x which is to add an include directory of "../../../Config" (Parent ..s are three levels up).

But with that addition, and these changes the code compiles but has a warning ...
../../../libUDB/heartbeat.c: In function 'heartbeat_pulse':
../../../libUDB/heartbeat.c:121:2: warning: implicit declaration of function 'udb_callback_read_sensors'

Ideally, a developer with working knowledge of the OSD toolkit, and working hardware, would check this out for Ric. who setting up his plane of FPV work.

Best wishes, Pete