### PR TITLE
Reduce warnings from a default compile

### DIFF
--- a/libUDB/heartbeat.c
+++ b/libUDB/heartbeat.c
@@ -26,6 +26,7 @@
 #include "servoOut.h"
 #include "analogs.h"
 #include "radioIn.h"
+#include "../libDCM/rmat.h"
 #if (USE_I2C1_DRIVER == 1)
 #include "I2C.h"
 #endif

--- a/libUDB/mcu.c
+++ b/libUDB/mcu.c
@@ -322,7 +322,7 @@ static void init_pll(void)
 {
 #if (BOARD_TYPE == UDB4_BOARD || BOARD_TYPE == UDB5_BOARD)
 #if (MIPS == 16)
-//#warning 16 MIPS selected
+//No warning given for default MIPS speed
 	CLKDIVbits.PLLPRE = 0;  // PLL prescaler: N1 = 2 (default)
 	CLKDIVbits.PLLPOST = 1; // PLL postscaler: N2 = 4 (default)
 	PLLFBDbits.PLLDIV = 30; // FOSC = 32 MHz (XTAL=8MHz, N1=2, N2=4, M = 32)
@@ -359,7 +359,7 @@ static void init_pll(void)
 #warning 32 MIPS selected
 	PLLFBD = 30;                // M  = 32
 #elif (MIPS == 16)
-#warning 16 MIPS selected
+// No warning given for default MIPS speed
 	PLLFBD = 14;                // M  = 16
 #else
 #error Invalid MIPS Configuration

--- a/libUDB/mcu.c
+++ b/libUDB/mcu.c
@@ -322,7 +322,7 @@ static void init_pll(void)
 {
 #if (BOARD_TYPE == UDB4_BOARD || BOARD_TYPE == UDB5_BOARD)
 #if (MIPS == 16)
-#warning 16 MIPS selected
+//#warning 16 MIPS selected
 	CLKDIVbits.PLLPRE = 0;  // PLL prescaler: N1 = 2 (default)
 	CLKDIVbits.PLLPOST = 1; // PLL postscaler: N2 = 4 (default)
 	PLLFBDbits.PLLDIV = 30; // FOSC = 32 MHz (XTAL=8MHz, N1=2, N2=4, M = 32)


### PR DESCRIPTION
I would like to remove all warnings from a default compile of the code.

Out of the box, a download of master, should compile without warnings in my view.

