### PR TITLE
Improve initialisation of UDB4 Gyros 

### DIFF
--- a/libUDB/ADchannel.c
+++ b/libUDB/ADchannel.c
@@ -27,53 +27,47 @@ struct ADchannel udb_xaccel, udb_yaccel, udb_zaccel; // x, y, and z acceleromete
 struct ADchannel udb_xrate,  udb_yrate,  udb_zrate;  // x, y, and z gyro channels
 struct ADchannel udb_vref; // reference voltage (deprecated, here for MAVLink compatibility)
 
+#ifdef UDB4
+void udb_init_gyros(void);
+#endif
 
-#ifdef INITIALIZE_VERTICAL // for VTOL, vertical initialization
+
 void udb_a2d_record_offsets(void)
 {
+#ifdef UDB4
+	udb_init_gyros();
+#endif
 #if (USE_NV_MEMORY == 1)
 	if (udb_skip_flags.skip_imu_cal == 1)
 		return;
 #endif
-
-	// almost ready to turn the control on, save the input offsets
-	UDB_XACCEL.offset = UDB_XACCEL.value;
-	udb_xrate.offset = udb_xrate.value;
-	UDB_YACCEL.offset = UDB_YACCEL.value - (Y_GRAVITY_SIGN ((int16_t)(2*GRAVITY))); // opposite direction
-	udb_yrate.offset = udb_yrate.value;
-	UDB_ZACCEL.offset = UDB_ZACCEL.value;
-	udb_zrate.offset = udb_zrate.value;
-#ifdef VREF
-	udb_vref.offset = udb_vref.value;
-#endif
-}
-#else  // horizontal initialization
-void udb_a2d_record_offsets(void)
-{
-#if (USE_NV_MEMORY == 1)
-	if (udb_skip_flags.skip_imu_cal == 1)
-		return;
-#endif
-
 #ifdef CUSTOM_OFFSETS
-	// offsets have been measured manually and entered into the options.h file
+	// offsets have been measured manually and entered into the options.h file	
 	udb_xaccel.offset = XACCEL_OFFSET;
 	udb_yaccel.offset = YACCEL_OFFSET;
 	udb_zaccel.offset = ZACCEL_OFFSET;
-	udb_xrate.offset = XRATE_OFFSET;
-	udb_yrate.offset = YRATE_OFFSET;
-	udb_zrate.offset = ZRATE_OFFSET;
-#else
+	
+#else   // Measure offsets from sensor values now
+#ifdef INITIALIZE_VERTICAL // for VTOL, vertical initialization
 	// almost ready to turn the control on, save the input offsets
 	UDB_XACCEL.offset = UDB_XACCEL.value;
-	udb_xrate.offset  = udb_xrate.value;
+	UDB_YACCEL.offset = UDB_YACCEL.value - (Y_GRAVITY_SIGN ((int16_t)(2*GRAVITY))); // opposite direction
+	UDB_ZACCEL.offset = UDB_ZACCEL.value;
+#else	// horizontal initialization
+	// almost ready to turn the control on, save the input offsets
+	UDB_XACCEL.offset = UDB_XACCEL.value;
 	UDB_YACCEL.offset = UDB_YACCEL.value;
-	udb_yrate.offset  = udb_yrate.value;
 	UDB_ZACCEL.offset = UDB_ZACCEL.value + (Z_GRAVITY_SIGN ((int16_t)(2*GRAVITY))); // same direction
-	udb_zrate.offset  = udb_zrate.value;
+#endif // INITIALIZE_VERTICAL	
+	
 #endif // CUSTOM_OFFSETS
+	
+	udb_xrate.offset  = udb_xrate.value;
+	udb_yrate.offset  = udb_yrate.value;
+	udb_zrate.offset  = udb_zrate.value;
+	
 #ifdef VREF
 	udb_vref.offset   = udb_vref.value;
 #endif
 }
-#endif // INITIALIZE_VERTICAL
+

--- a/libUDB/analog2digital_udb4.c
+++ b/libUDB/analog2digital_udb4.c
@@ -167,7 +167,7 @@ void udb_init_ADC(void)
 	AD1PCFGH= 0xFFFF;
 	AD2PCFGL= 0xFFFF;
 
-// include the 500 degree/second scale, gyro
+// include the 110 degree/second scale, gyro
 /*
 	AD1CSSLbits.CSS0 = 1;
 	AD1CSSLbits.CSS3 = 1;
@@ -178,7 +178,7 @@ void udb_init_ADC(void)
 	AD1PCFGLbits.PCFG5 = 0;
  */
 
-// include the 110 degree/second scale, gyro
+// include the 500 degree/second scale, gyro
 	AD1CSSLbits.CSS1 = 1;
 	AD1CSSLbits.CSS4 = 1;
 	AD1CSSLbits.CSS6 = 1;

--- a/libUDB/analog2digital_udb4.c
+++ b/libUDB/analog2digital_udb4.c
@@ -93,12 +93,6 @@ const uint32_t adc_rate = ADC_RATE;
 #define ALMOST_ENOUGH_SAMPLES ((ADC_RATE / (NUM_AD_CHAN * HEARTBEAT_HZ)) - 2)
 const uint32_t almost_enough = ALMOST_ENOUGH_SAMPLES;
 
-#define _SELECTED_VALUE(l, v) #l#v
-#define SELECTED_VALUE(macro) _SELECTED_VALUE(#macro, macro)
-#warning (SELECTED_VALUE(ADCLK_DIV_N_MINUS_1))
-#warning (SELECTED_VALUE(ADC_CLK))
-#warning (SELECTED_VALUE(ADC_RATE))
-#warning (SELECTED_VALUE(ALMOST_ENOUGH_SAMPLES))
 #endif // 0/1
 
 int16_t vref_adj;
@@ -110,11 +104,24 @@ uint16_t maxstack = 0;
 #endif
 
 
+#define GYRO_POWER_UP_TIME	( 210 ) // No. of Milliseconds to wait for gyros to power up	
+#define AUTO_ZERO_LATCH_TIME	(   5 ) // No. of Microseconds to wait for Auto-Zero pin to Latch
+#define AUTO_ZERO_SETTLE_TIME	(  15 ) // No. of Microseconds for Auto-Zero to configure gyros
+
+
 void udb_init_gyros(void)
 {
-	// turn off auto zeroing 
-	_TRISC4 = _TRISB14 = 0;
-	_LATC4 = _LATB14 = 0;
+	_TRISC4  = 0;
+	_TRISB14 = 0;
+	_LATC4 =   0; // Turn off auto-zeroing
+	_LATB14 =  0; // Turn off auto-zeroing
+	delay_ms(GYRO_POWER_UP_TIME); //Gyros max spec of 200 milliseconds to start up
+	_LATC4 =   1; // Turn on auto-zeroing
+	_LATB14 =  1; // Turn on auto-zeroing
+	delay_us(AUTO_ZERO_LATCH_TIME); // z gyro spec says wait at least 2 microseconds
+	_LATC4 =   0; // Turn off auto-zeroing
+	_LATB14 =  0; // Turn off auto-zeroing
+	delay_us(AUTO_ZERO_SETTLE_TIME); // z gyro spec says wait at least 7 microseconds
 }
 
 void udb_init_accelerometer(void)
@@ -160,7 +167,7 @@ void udb_init_ADC(void)
 	AD1PCFGH= 0xFFFF;
 	AD2PCFGL= 0xFFFF;
 
-// include the 110 degree/second scale, gyro
+// include the 500 degree/second scale, gyro
 /*
 	AD1CSSLbits.CSS0 = 1;
 	AD1CSSLbits.CSS3 = 1;
@@ -171,7 +178,7 @@ void udb_init_ADC(void)
 	AD1PCFGLbits.PCFG5 = 0;
  */
 
-// include the 500 degree/second scale, gyro
+// include the 110 degree/second scale, gyro
 	AD1CSSLbits.CSS1 = 1;
 	AD1CSSLbits.CSS4 = 1;
 	AD1CSSLbits.CSS6 = 1;


### PR DESCRIPTION
UDB4 Z Gyros have been observed having different zero values between reboots which invalidated the use of CUSTOM_OFFSETS for gyros.  

Remove use of CUSTOM_OFFSETS for gyros.
Introduce use of Auto-Zero function for the UDB4 gyros.
Call Auto-Zero once always at least 200 milliseconds after startup.
Recall Auto-Zero just before calibration of MatrixPilot offsets (just before first waggles of ailerons).
Remove compile messages regarding DMA internals (SELECTED_VALUE).