### PR TITLE
Auto Zero Gyros on the UDB4 and remove use of CUSTOM_OFFSETS for Gyros.

### DIFF
--- a/libUDB/ADchannel.c
+++ b/libUDB/ADchannel.c
@@ -36,13 +36,22 @@ void udb_a2d_record_offsets(void)
 		return;
 #endif
 
+#ifdef CUSTOM_OFFSETS
+	// offsets have been measured manually and entered into the options.h file
+	udb_xaccel.offset = XACCEL_OFFSET;
+	udb_yaccel.offset = YACCEL_OFFSET;
+	udb_zaccel.offset = ZACCEL_OFFSET;
+#else
 	// almost ready to turn the control on, save the input offsets
 	UDB_XACCEL.offset = UDB_XACCEL.value;
-	udb_xrate.offset = udb_xrate.value;
 	UDB_YACCEL.offset = UDB_YACCEL.value - (Y_GRAVITY_SIGN ((int16_t)(2*GRAVITY))); // opposite direction
-	udb_yrate.offset = udb_yrate.value;
 	UDB_ZACCEL.offset = UDB_ZACCEL.value;
-	udb_zrate.offset = udb_zrate.value;
+#endif // CUSTOM_OFFSETS
+	
+	udb_xrate.offset  = udb_xrate.value;
+	udb_yrate.offset  = udb_yrate.value;
+	udb_zrate.offset  = udb_zrate.value;	
+	
 #ifdef VREF
 	udb_vref.offset = udb_vref.value;
 #endif
@@ -60,18 +69,17 @@ void udb_a2d_record_offsets(void)
 	udb_xaccel.offset = XACCEL_OFFSET;
 	udb_yaccel.offset = YACCEL_OFFSET;
 	udb_zaccel.offset = ZACCEL_OFFSET;
-	udb_xrate.offset = XRATE_OFFSET;
-	udb_yrate.offset = YRATE_OFFSET;
-	udb_zrate.offset = ZRATE_OFFSET;
 #else
 	// almost ready to turn the control on, save the input offsets
 	UDB_XACCEL.offset = UDB_XACCEL.value;
-	udb_xrate.offset  = udb_xrate.value;
 	UDB_YACCEL.offset = UDB_YACCEL.value;
-	udb_yrate.offset  = udb_yrate.value;
 	UDB_ZACCEL.offset = UDB_ZACCEL.value + (Z_GRAVITY_SIGN ((int16_t)(2*GRAVITY))); // same direction
-	udb_zrate.offset  = udb_zrate.value;
 #endif // CUSTOM_OFFSETS
+	
+	udb_xrate.offset  = udb_xrate.value;
+	udb_yrate.offset  = udb_yrate.value;
+	udb_zrate.offset  = udb_zrate.value;
+	
 #ifdef VREF
 	udb_vref.offset   = udb_vref.value;
 #endif

--- a/libUDB/ADchannel.c
+++ b/libUDB/ADchannel.c
@@ -27,7 +27,8 @@ struct ADchannel udb_xaccel, udb_yaccel, udb_zaccel; // x, y, and z acceleromete
 struct ADchannel udb_xrate,  udb_yrate,  udb_zrate;  // x, y, and z gyro channels
 struct ADchannel udb_vref; // reference voltage (deprecated, here for MAVLink compatibility)
 
-
+#if (BOARD_TYPE == UDB4_BOARD) 
+// CUSTOM_OFFSETS only used for the Accelerometers with the UDB4 Board
 void udb_a2d_record_offsets(void)
 {
 #if (USE_NV_MEMORY == 1)
@@ -53,7 +54,7 @@ void udb_a2d_record_offsets(void)
 	UDB_ZACCEL.offset = UDB_ZACCEL.value + (Z_GRAVITY_SIGN ((int16_t)(2*GRAVITY))); // same direction
 #endif // INITIALIZE_VERTICAL
 #endif // CUSTOM_OFFSETS
-	
+
 	udb_xrate.offset  = udb_xrate.value;
 	udb_yrate.offset  = udb_yrate.value;
 	udb_zrate.offset  = udb_zrate.value;
@@ -63,3 +64,48 @@ void udb_a2d_record_offsets(void)
 #endif
 }
 
+#else
+
+// For Non UDB4 Boards Use CUSTOM_OFFSETS for both Accelerometers and Gyros
+void udb_a2d_record_offsets(void)
+{
+#if (USE_NV_MEMORY == 1)
+	if (udb_skip_flags.skip_imu_cal == 1)
+		return;
+#endif
+
+#ifdef CUSTOM_OFFSETS
+	// offsets have been measured manually and entered into the options.h file
+	udb_xaccel.offset = XACCEL_OFFSET;
+	udb_yaccel.offset = YACCEL_OFFSET;
+	udb_zaccel.offset = ZACCEL_OFFSET;
+	db_xrate.offset   = XRATE_OFFSET;
+	udb_yrate.offset  = YRATE_OFFSET;
+	udb_zrate.offset  = ZRATE_OFFSET;
+	
+#else
+	
+#ifdef INITIALIZE_VERTICAL // for VTOL, vertical initialization
+	// almost ready to turn the control on, save the input offsets
+	UDB_XACCEL.offset = UDB_XACCEL.value;
+	UDB_YACCEL.offset = UDB_YACCEL.value - (Y_GRAVITY_SIGN ((int16_t)(2*GRAVITY))); // opposite direction
+	UDB_ZACCEL.offset = UDB_ZACCEL.value;	
+#else
+	// almost ready to turn the control on, save the input offsets
+	UDB_XACCEL.offset = UDB_XACCEL.value;
+	UDB_YACCEL.offset = UDB_YACCEL.value;
+	UDB_ZACCEL.offset = UDB_ZACCEL.value + (Z_GRAVITY_SIGN ((int16_t)(2*GRAVITY))); // same direction
+#endif // INITIALIZE_VERTICAL
+
+	udb_xrate.offset  = udb_xrate.value;
+	udb_yrate.offset  = udb_yrate.value;
+	udb_zrate.offset  = udb_zrate.value;
+	
+#endif // CUSTOM_OFFSETS
+	
+#ifdef VREF
+	udb_vref.offset   = udb_vref.value;
+#endif 
+}
+
+#endif //(BOARD_TYPE == (UDB4_BOARD)

--- a/libUDB/ADchannel.c
+++ b/libUDB/ADchannel.c
@@ -28,7 +28,6 @@ struct ADchannel udb_xrate,  udb_yrate,  udb_zrate;  // x, y, and z gyro channel
 struct ADchannel udb_vref; // reference voltage (deprecated, here for MAVLink compatibility)
 
 
-#ifdef INITIALIZE_VERTICAL // for VTOL, vertical initialization
 void udb_a2d_record_offsets(void)
 {
 #if (USE_NV_MEMORY == 1)
@@ -42,38 +41,17 @@ void udb_a2d_record_offsets(void)
 	udb_yaccel.offset = YACCEL_OFFSET;
 	udb_zaccel.offset = ZACCEL_OFFSET;
 #else
+#ifdef INITIALIZE_VERTICAL // for VTOL, vertical initialization
 	// almost ready to turn the control on, save the input offsets
 	UDB_XACCEL.offset = UDB_XACCEL.value;
 	UDB_YACCEL.offset = UDB_YACCEL.value - (Y_GRAVITY_SIGN ((int16_t)(2*GRAVITY))); // opposite direction
-	UDB_ZACCEL.offset = UDB_ZACCEL.value;
-#endif // CUSTOM_OFFSETS
-	
-	udb_xrate.offset  = udb_xrate.value;
-	udb_yrate.offset  = udb_yrate.value;
-	udb_zrate.offset  = udb_zrate.value;	
-	
-#ifdef VREF
-	udb_vref.offset = udb_vref.value;
-#endif
-}
-#else  // horizontal initialization
-void udb_a2d_record_offsets(void)
-{
-#if (USE_NV_MEMORY == 1)
-	if (udb_skip_flags.skip_imu_cal == 1)
-		return;
-#endif
-
-#ifdef CUSTOM_OFFSETS
-	// offsets have been measured manually and entered into the options.h file
-	udb_xaccel.offset = XACCEL_OFFSET;
-	udb_yaccel.offset = YACCEL_OFFSET;
-	udb_zaccel.offset = ZACCEL_OFFSET;
+	UDB_ZACCEL.offset = UDB_ZACCEL.value;	
 #else
 	// almost ready to turn the control on, save the input offsets
 	UDB_XACCEL.offset = UDB_XACCEL.value;
 	UDB_YACCEL.offset = UDB_YACCEL.value;
 	UDB_ZACCEL.offset = UDB_ZACCEL.value + (Z_GRAVITY_SIGN ((int16_t)(2*GRAVITY))); // same direction
+#endif // INITIALIZE_VERTICAL
 #endif // CUSTOM_OFFSETS
 	
 	udb_xrate.offset  = udb_xrate.value;
@@ -84,4 +62,4 @@ void udb_a2d_record_offsets(void)
 	udb_vref.offset   = udb_vref.value;
 #endif
 }
-#endif // INITIALIZE_VERTICAL
+

--- a/libUDB/analog2digital_udb4.c
+++ b/libUDB/analog2digital_udb4.c
@@ -111,8 +111,8 @@ uint16_t maxstack = 0;
 
 
 #define GYRO_POWER_UP_TIME		( 300) // No. of Milliseconds to wait for gyros to power up	
-#define AUTO_ZERO_LATCH_TIME		(  10) // No. of executable instructions to wait 4 microseconds
-#define AUTO_ZERO_SETTLE_TIME		(  20) // No. of executable instructions to wait 10 Milliseconds
+#define AUTO_ZERO_LATCH_TIME		(  10) // No. Microseconds to ensure Auto_Zero latch enabled
+#define AUTO_ZERO_SETTLE_TIME		(  20) // No. Milliseconds to ensure Gyros have settled after auto-zero
 
 
 void udb_init_gyros(void)
@@ -122,13 +122,13 @@ void udb_init_gyros(void)
 	_TRISB14 = 0; //  B14 pin made into an output
 	_LATC4 =   0; // Turn off auto-zeroing
 	_LATB14 =  0; // Turn off auto-zeroing
-	delay_ms(GYRO_POWER_UP_TIME);
+	delay_ms(GYRO_POWER_UP_TIME);		// Gyros specs say allow 200 milliseconds for powerup
 	_LATC4 =   1; // Turn on auto-zeroing
 	_LATB14 =  1; // Turn on auto-zeroing
 	delay_us(AUTO_ZERO_LATCH_TIME);         // z gyro spec says wait at least 2 microseconds
 	_LATC4 =   0; // Turn off auto-zeroing
 	_LATB14 =  0; // Turn off auto-zeroing
-	delay_ms(AUTO_ZERO_SETTLE_TIME);        // z gyro spec says wait at least 7 microseconds
+	delay_ms(AUTO_ZERO_SETTLE_TIME);        // z gyro spec says wait at least 7 milliseconds
 }
 
 void udb_init_accelerometer(void)

--- a/libUDB/analog2digital_udb4.c
+++ b/libUDB/analog2digital_udb4.c
@@ -120,8 +120,8 @@ void udb_init_gyros(void)
 	int i = 0;
 	int j = 0;
 	// turn off auto zeroing 
-	_TRISC4  = 0;
-	_TRISB14 = 0;
+	_TRISC4  = 0; //  C4 pin made into an output
+	_TRISB14 = 0; //  B14 pin made into an output
 	_LATC4 =   0; // Turn off auto-zeroing
 	_LATB14 =  0; // Turn off auto-zeroing
 	for (j = 0; j < 1000 * MIPS; j++)
@@ -130,7 +130,6 @@ void udb_init_gyros(void)
 	}
 	_LATC4 =   1; // Turn on auto-zeroing
 	_LATB14 =  1; // Turn on auto-zeroing
-	
 	for (i = 0; i < AUTO_ZERO_LATCH_TIME; i++ ); // z gyro spec says wait at least 2 microseconds
 	_LATC4 =   0; // Turn off auto-zeroing
 	_LATB14 =  0; // Turn off auto-zeroing

--- a/libUDB/analog2digital_udb4.c
+++ b/libUDB/analog2digital_udb4.c
@@ -110,11 +110,31 @@ uint16_t maxstack = 0;
 #endif
 
 
+#define GYRO_POWER_UP_TIME		(  3 *  MIPS)  // No. of Milliseconds to wait for gyros to power up	
+#define AUTO_ZERO_LATCH_TIME		(  4 *  MIPS ) // No. of executable instructions to wait 4 microseconds
+#define AUTO_ZERO_SETTLE_TIME		( 10 *  MIPS ) // No. of executable instructions to wait 10 microseconds
+
+
 void udb_init_gyros(void)
 {
+	int i = 0;
+	int j = 0;
 	// turn off auto zeroing 
-	_TRISC4 = _TRISB14 = 0;
-	_LATC4 = _LATB14 = 0;
+	_TRISC4  = 0;
+	_TRISB14 = 0;
+	_LATC4 =   0; // Turn off auto-zeroing
+	_LATB14 =  0; // Turn off auto-zeroing
+	for (j = 0; j < 1000 * MIPS; j++)
+	{
+		for (i = 0; i < GYRO_POWER_UP_TIME; i++);
+	}
+	_LATC4 =   1; // Turn on auto-zeroing
+	_LATB14 =  1; // Turn on auto-zeroing
+	
+	for (i = 0; i < AUTO_ZERO_LATCH_TIME; i++ ); // z gyro spec says wait at least 2 microseconds
+	_LATC4 =   0; // Turn off auto-zeroing
+	_LATB14 =  0; // Turn off auto-zeroing
+	for (i = 0; i < AUTO_ZERO_SETTLE_TIME; i++ ); // z gyro spec says wait at least 7 microseconds
 }
 
 void udb_init_accelerometer(void)

--- a/libUDB/analog2digital_udb4.c
+++ b/libUDB/analog2digital_udb4.c
@@ -110,30 +110,25 @@ uint16_t maxstack = 0;
 #endif
 
 
-#define GYRO_POWER_UP_TIME		(  3 *  MIPS)  // No. of Milliseconds to wait for gyros to power up	
-#define AUTO_ZERO_LATCH_TIME		(  4 *  MIPS ) // No. of executable instructions to wait 4 microseconds
-#define AUTO_ZERO_SETTLE_TIME		( 10 *  MIPS ) // No. of executable instructions to wait 10 microseconds
+#define GYRO_POWER_UP_TIME		( 300) // No. of Milliseconds to wait for gyros to power up	
+#define AUTO_ZERO_LATCH_TIME		(  10) // No. of executable instructions to wait 4 microseconds
+#define AUTO_ZERO_SETTLE_TIME		(  20) // No. of executable instructions to wait 10 Milliseconds
 
 
 void udb_init_gyros(void)
 {
-	int i = 0;
-	int j = 0;
 	// turn off auto zeroing 
 	_TRISC4  = 0; //  C4 pin made into an output
 	_TRISB14 = 0; //  B14 pin made into an output
 	_LATC4 =   0; // Turn off auto-zeroing
 	_LATB14 =  0; // Turn off auto-zeroing
-	for (j = 0; j < 1000 * MIPS; j++)
-	{
-		for (i = 0; i < GYRO_POWER_UP_TIME; i++);
-	}
+	delay_ms(GYRO_POWER_UP_TIME);
 	_LATC4 =   1; // Turn on auto-zeroing
 	_LATB14 =  1; // Turn on auto-zeroing
-	for (i = 0; i < AUTO_ZERO_LATCH_TIME; i++ ); // z gyro spec says wait at least 2 microseconds
+	delay_us(AUTO_ZERO_LATCH_TIME);         // z gyro spec says wait at least 2 microseconds
 	_LATC4 =   0; // Turn off auto-zeroing
 	_LATB14 =  0; // Turn off auto-zeroing
-	for (i = 0; i < AUTO_ZERO_SETTLE_TIME; i++ ); // z gyro spec says wait at least 7 microseconds
+	delay_ms(AUTO_ZERO_SETTLE_TIME);        // z gyro spec says wait at least 7 microseconds
 }
 
 void udb_init_accelerometer(void)


### PR DESCRIPTION
In some testing of the UDB4 with Master, it became apparent that in normal usage, sometimes the Z Gyro would startup with substantially different UDB unit calibration values for zero degrees / second. If the board was configured with CUSTOM_OFFSETS (recommended now for master / helicalTurns) this change of calibration could cause the DCM to go Dizzy both before flying in a plane, and in the RollPitchYaw Demo.

In this Pull Request I am introducing the use of the Auto-Zero function in the UDB4's gyros. Tests with Ric's gyros showed that sometime his gyros were calibrating at -19000 UDB units. The maximum is of the order of -32000 for a gyro input (0 volts). Using the Auto-Zero function has meant that his gyros are now calibrating in the normal -6000 UDB range. I enclose a spreadsheet with further analysis.

I welcome plenty of discussion on this Pull Request as it is changing code at the heart of the IMU.

Best wishes, Pete
P.S. Sorry, but github does not accept spreadsheets. I enclose a PDF version. Email me if you want the actual spreadsheet.

[UDB4_Gyro_Analysis.pdf](https://github.com/MatrixPilot/MatrixPilot/files/421389/UDB4_Gyro_Analysis.pdf)
