### PR TITLE
Background UDB Gyro Initialisation

### DIFF
--- a/libDCM/libDCM.c
+++ b/libDCM/libDCM.c
@@ -35,10 +35,6 @@
 union dcm_fbts_word dcm_flags;
 int16_t angleOfAttack;
 
-// Calibrate for 10 seconds before moving servos
-#define CALIB_COUNT  400    // 10 seconds at 40 Hz
-#define GPS_COUNT    1000   // 25 seconds at 40 Hz
-
 void send_HILSIM_outputs(void);
 
 void SetAofA(int16_t AofA)
@@ -58,13 +54,13 @@ void dcm_init(void)
 	dcm_init_rmat();
 }
 
-#if (CALIB_COUNT > GPS_COUNT)
+#if (DCM_CALIB_COUNT > DCM_GPS_COUNT)
 #error here
 #endif
 
 void dcm_run_calib_step(uint16_t count)
 {
-	if (count == CALIB_COUNT)
+	if (count == DCM_CALIB_COUNT)
 	{
 		DPRINT("calib_finished\r\n");
 		dcm_flags._.calib_finished = 1;
@@ -74,9 +70,9 @@ void dcm_run_calib_step(uint16_t count)
 
 static boolean gps_run_init_step(uint16_t count)
 {
-	if (count <= GPS_COUNT)
+	if (count <= DCM_GPS_COUNT)
 	{
-		gps_startup_sequence(GPS_COUNT - count); // Counts down from GPS_COUNT to 0
+		gps_startup_sequence(DCM_GPS_COUNT - count); // Counts down from GPS_COUNT to 0
 	}
 	else
 	{

--- a/libDCM/libDCM.h
+++ b/libDCM/libDCM.h
@@ -62,5 +62,8 @@ vect3_32t dcm_rel2abs(vect3_32t rel);
 // Vars
 extern union dcm_fbts_word { struct dcm_flag_bits _; int16_t W; } dcm_flags;
 
+// Calibrate for 10 seconds before moving servos
+#define DCM_CALIB_COUNT  400    // 10 seconds at 40 Hz
+#define DCM_GPS_COUNT    1000   // 25 seconds at 40 Hz
 
 #endif // LIB_DCM_H

--- a/libUDB/ADchannel.c
+++ b/libUDB/ADchannel.c
@@ -27,27 +27,8 @@ struct ADchannel udb_xaccel, udb_yaccel, udb_zaccel; // x, y, and z acceleromete
 struct ADchannel udb_xrate,  udb_yrate,  udb_zrate;  // x, y, and z gyro channels
 struct ADchannel udb_vref; // reference voltage (deprecated, here for MAVLink compatibility)
 
-
-#ifdef INITIALIZE_VERTICAL // for VTOL, vertical initialization
-void udb_a2d_record_offsets(void)
-{
-#if (USE_NV_MEMORY == 1)
-	if (udb_skip_flags.skip_imu_cal == 1)
-		return;
-#endif
-
-	// almost ready to turn the control on, save the input offsets
-	UDB_XACCEL.offset = UDB_XACCEL.value;
-	udb_xrate.offset = udb_xrate.value;
-	UDB_YACCEL.offset = UDB_YACCEL.value - (Y_GRAVITY_SIGN ((int16_t)(2*GRAVITY))); // opposite direction
-	udb_yrate.offset = udb_yrate.value;
-	UDB_ZACCEL.offset = UDB_ZACCEL.value;
-	udb_zrate.offset = udb_zrate.value;
-#ifdef VREF
-	udb_vref.offset = udb_vref.value;
-#endif
-}
-#else  // horizontal initialization
+#if (BOARD_TYPE == UDB4_BOARD) 
+// CUSTOM_OFFSETS only used for the Accelerometers with the UDB4 Board
 void udb_a2d_record_offsets(void)
 {
 #if (USE_NV_MEMORY == 1)
@@ -60,20 +41,71 @@ void udb_a2d_record_offsets(void)
 	udb_xaccel.offset = XACCEL_OFFSET;
 	udb_yaccel.offset = YACCEL_OFFSET;
 	udb_zaccel.offset = ZACCEL_OFFSET;
-	udb_xrate.offset = XRATE_OFFSET;
-	udb_yrate.offset = YRATE_OFFSET;
-	udb_zrate.offset = ZRATE_OFFSET;
+#else
+#ifdef INITIALIZE_VERTICAL // for VTOL, vertical initialization
+	// almost ready to turn the control on, save the input offsets
+	UDB_XACCEL.offset = UDB_XACCEL.value;
+	UDB_YACCEL.offset = UDB_YACCEL.value - (Y_GRAVITY_SIGN ((int16_t)(2*GRAVITY))); // opposite direction
+	UDB_ZACCEL.offset = UDB_ZACCEL.value;	
 #else
 	// almost ready to turn the control on, save the input offsets
 	UDB_XACCEL.offset = UDB_XACCEL.value;
-	udb_xrate.offset  = udb_xrate.value;
 	UDB_YACCEL.offset = UDB_YACCEL.value;
-	udb_yrate.offset  = udb_yrate.value;
 	UDB_ZACCEL.offset = UDB_ZACCEL.value + (Z_GRAVITY_SIGN ((int16_t)(2*GRAVITY))); // same direction
-	udb_zrate.offset  = udb_zrate.value;
+#endif // INITIALIZE_VERTICAL
 #endif // CUSTOM_OFFSETS
+
+	udb_xrate.offset  = udb_xrate.value;
+	udb_yrate.offset  = udb_yrate.value;
+	udb_zrate.offset  = udb_zrate.value;
+	
 #ifdef VREF
 	udb_vref.offset   = udb_vref.value;
 #endif
 }
+
+#else
+
+// For Non UDB4 Boards Use CUSTOM_OFFSETS for both Accelerometers and Gyros
+void udb_a2d_record_offsets(void)
+{
+#if (USE_NV_MEMORY == 1)
+	if (udb_skip_flags.skip_imu_cal == 1)
+		return;
+#endif
+
+#ifdef CUSTOM_OFFSETS
+	// offsets have been measured manually and entered into the options.h file
+	udb_xaccel.offset = XACCEL_OFFSET;
+	udb_yaccel.offset = YACCEL_OFFSET;
+	udb_zaccel.offset = ZACCEL_OFFSET;
+	udb_xrate.offset   = XRATE_OFFSET;
+	udb_yrate.offset  = YRATE_OFFSET;
+	udb_zrate.offset  = ZRATE_OFFSET;
+	
+#else
+	
+#ifdef INITIALIZE_VERTICAL // for VTOL, vertical initialization
+	// almost ready to turn the control on, save the input offsets
+	UDB_XACCEL.offset = UDB_XACCEL.value;
+	UDB_YACCEL.offset = UDB_YACCEL.value - (Y_GRAVITY_SIGN ((int16_t)(2*GRAVITY))); // opposite direction
+	UDB_ZACCEL.offset = UDB_ZACCEL.value;	
+#else
+	// almost ready to turn the control on, save the input offsets
+	UDB_XACCEL.offset = UDB_XACCEL.value;
+	UDB_YACCEL.offset = UDB_YACCEL.value;
+	UDB_ZACCEL.offset = UDB_ZACCEL.value + (Z_GRAVITY_SIGN ((int16_t)(2*GRAVITY))); // same direction
 #endif // INITIALIZE_VERTICAL
+
+	udb_xrate.offset  = udb_xrate.value;
+	udb_yrate.offset  = udb_yrate.value;
+	udb_zrate.offset  = udb_zrate.value;
+	
+#endif // CUSTOM_OFFSETS
+	
+#ifdef VREF
+	udb_vref.offset   = udb_vref.value;
+#endif 
+}
+
+#endif //(BOARD_TYPE == (UDB4_BOARD)

--- a/libUDB/analog2digital_udb4.c
+++ b/libUDB/analog2digital_udb4.c
@@ -108,12 +108,8 @@ uint8_t DmaBuffer = 0;
 #if (RECORD_FREE_STACK_SPACE == 1)
 uint16_t maxstack = 0;
 #endif
-
-
-#define GYRO_POWER_UP_TIME		( 300) // No. of Milliseconds to wait for gyros to power up	
-#define AUTO_ZERO_LATCH_TIME		(  10) // No. of executable instructions to wait 4 microseconds
-#define AUTO_ZERO_SETTLE_TIME		(  20) // No. of executable instructions to wait 10 Milliseconds
-
+	
+#define AUTO_ZERO_LATCH_TIME		( 3 ) // No. of microseconds to wait for auto-zero to latch
 
 void udb_init_gyros(void)
 {
@@ -122,13 +118,18 @@ void udb_init_gyros(void)
 	_TRISB14 = 0; //  B14 pin made into an output
 	_LATC4 =   0; // Turn off auto-zeroing
 	_LATB14 =  0; // Turn off auto-zeroing
-	delay_ms(GYRO_POWER_UP_TIME);
+}
+
+void udb_gyros_auto_zero_latch_up(void)
+{
 	_LATC4 =   1; // Turn on auto-zeroing
 	_LATB14 =  1; // Turn on auto-zeroing
-	delay_us(AUTO_ZERO_LATCH_TIME);         // z gyro spec says wait at least 2 microseconds
+}
+
+void udb_gyros_auto_zero_latch_down(void)
+{
 	_LATC4 =   0; // Turn off auto-zeroing
 	_LATB14 =  0; // Turn off auto-zeroing
-	delay_ms(AUTO_ZERO_SETTLE_TIME);        // z gyro spec says wait at least 7 microseconds
 }
 
 void udb_init_accelerometer(void)

--- a/libUDB/analog2digital_udb4.c
+++ b/libUDB/analog2digital_udb4.c
@@ -110,11 +110,25 @@ uint16_t maxstack = 0;
 #endif
 
 
+#define GYRO_POWER_UP_TIME		( 300) // No. of Milliseconds to wait for gyros to power up	
+#define AUTO_ZERO_LATCH_TIME		(  10) // No. of executable instructions to wait 4 microseconds
+#define AUTO_ZERO_SETTLE_TIME		(  20) // No. of executable instructions to wait 10 Milliseconds
+
+
 void udb_init_gyros(void)
 {
 	// turn off auto zeroing 
-	_TRISC4 = _TRISB14 = 0;
-	_LATC4 = _LATB14 = 0;
+	_TRISC4  = 0; //  C4 pin made into an output
+	_TRISB14 = 0; //  B14 pin made into an output
+	_LATC4 =   0; // Turn off auto-zeroing
+	_LATB14 =  0; // Turn off auto-zeroing
+	delay_ms(GYRO_POWER_UP_TIME);
+	_LATC4 =   1; // Turn on auto-zeroing
+	_LATB14 =  1; // Turn on auto-zeroing
+	delay_us(AUTO_ZERO_LATCH_TIME);         // z gyro spec says wait at least 2 microseconds
+	_LATC4 =   0; // Turn off auto-zeroing
+	_LATB14 =  0; // Turn off auto-zeroing
+	delay_ms(AUTO_ZERO_SETTLE_TIME);        // z gyro spec says wait at least 7 microseconds
 }
 
 void udb_init_accelerometer(void)


### PR DESCRIPTION
Initialise UDB4 Gyros with Auto_Zero feature, just before the DCM offset calibration, about 9 seconds after bootup. There is no use delay functions in this code.

CUSTOM_OFFSETS are not used for the Gyros of the UDB4. Testing had shown that UDB4 gyros could power up with different offset values. Other boards (e.g. UDB5 and AUAV3) continue to use CUSTOM_OFFSETS on their gyros.

This version of the code uses auto-zero timing relative to CALIB_COUNT (now called DCM_CALIB_COUNT) in the dcm routine for recording offsets. 