### PR TITLE
AUAV3: Stop Null char  at start of telemetry and GPS UART transmit streams.

### DIFF
--- a/libUDB/mcu.c
+++ b/libUDB/mcu.c
@@ -263,16 +263,9 @@ static void configureDigitalIO(void)   // AUAV3 board
 	// port F
 	TRISFbits.TRISF0  = INPUT_PIN;  // CAN_RX
 	TRISFbits.TRISF1  = OUTPUT_PIN; // CAN_TX
-
-	//The following UART specific lines are  commented out as the pins are best setup by the Peripheral Module.
-	// Pins are correctly enabled when the Peripheral Module is enabled, by the Peripheral Module
-	// Setting them here creates a pulse on the Output TX pins
-	// which creates a Null character at the start of the telemetry stream / OpenLog file.
-	//TRISFbits.TRISF2  = INPUT_PIN;  // U3_RX
-	//TRISFbits.TRISF3  = OUTPUT_PIN; // U3_TX
-	//TRISFbits.TRISF4  = INPUT_PIN;  // U2_RX
-	//TRISFbits.TRISF5  = OUTPUT_PIN; // U2_TX
-
+ 
+	// Pins F2, F3, F3, F4 are initialized by the Peripheral Module hardware when it is enabled.
+	
 	TRISFbits.TRISF8  = INPUT_PIN;  // I8
 	TRISFbits.TRISF13 = OUTPUT_PIN; // O7
 	TRISFbits.TRISF12 = OUTPUT_PIN; // O8

--- a/libUDB/mcu.c
+++ b/libUDB/mcu.c
@@ -264,11 +264,14 @@ static void configureDigitalIO(void)   // AUAV3 board
 	TRISFbits.TRISF0  = INPUT_PIN;  // CAN_RX
 	TRISFbits.TRISF1  = OUTPUT_PIN; // CAN_TX
 
-	TRISFbits.TRISF2  = INPUT_PIN;  // U3_RX
-	TRISFbits.TRISF3  = OUTPUT_PIN; // U3_TX
-
-	TRISFbits.TRISF4  = INPUT_PIN;  // U2_RX
-	TRISFbits.TRISF5  = OUTPUT_PIN; // U2_TX
+	//The following UART specific lines are  commented out as the pins are best setup by the Peripheral Module.
+	// Pins are correctly enabled when the Peripheral Module is enabled, by the Peripheral Module
+	// Setting them here creates a pulse on the Output TX pins
+	// which creates a Null character at the start of the telemetry stream / OpenLog file.
+	//TRISFbits.TRISF2  = INPUT_PIN;  // U3_RX
+	//TRISFbits.TRISF3  = OUTPUT_PIN; // U3_TX
+	//TRISFbits.TRISF4  = INPUT_PIN;  // U2_RX
+	//TRISFbits.TRISF5  = OUTPUT_PIN; // U2_TX
 
 	TRISFbits.TRISF8  = INPUT_PIN;  // I8
 	TRISFbits.TRISF13 = OUTPUT_PIN; // O7


### PR DESCRIPTION
This commit ensures that a Null Character is not present at the start of every OpenLog File when using the AUAV3.

The original code for the AUAV3, setup the Input and Output pins of the UART as part of the configuration subroutine, configureDigitalIO(void). However,in the reference manual, and UART chapter for this processor, it explains that the pins will be setup when the UART peripheral module is enabled. That will happen automatically at that time.

So the old code setup the pins twice. Once in configureDigitalIO and once when the UART module was enabled. The result was that a Null Character (ascii value \000) was sent down the TX stream.