### PR TITLE
AUAV3: A Microchip recommended workaround for Silicon Errata #16

### DIFF
--- a/libUDB/serialIO.c
+++ b/libUDB/serialIO.c
@@ -122,6 +122,10 @@ void __attribute__((__interrupt__,__no_auto_psv__)) _U1TXInterrupt(void)
 #endif // HILSIM_USB
 	if (txchar != -1)
 	{
+#if (BOARD_TYPE == AUAV3_BOARD)
+		// a recommended workaround for Silicon Errata #16 in dsPIC33EP512MU810
+		while(U2STAbits.TRMT==0); // wait for the transmit buffer to be empty
+#endif
 		U1TXREG = (uint8_t)txchar;
 	}
 	interrupt_restore_corcon;
@@ -234,6 +238,10 @@ void __attribute__((__interrupt__, __no_auto_psv__)) _U2TXInterrupt(void)
 	}
 	if (txchar != -1)
 	{
+#if (BOARD_TYPE == AUAV3_BOARD)
+		// a recommended workaround for Silicon Errata #16 in dsPIC33EP512MU810
+		while(U2STAbits.TRMT==0); // wait for the transmit buffer to be empty
+#endif
 		U2TXREG = (uint8_t)txchar;
 	}
 	interrupt_restore_corcon;


### PR DESCRIPTION
The errata in the silicon means that the TX interrupt, which is meant to signify that all characters in the FIFO have been sent down the serial stream, may trigger too soon.  This is the recommended fix.
See the following document for further details:
http://ww1.microchip.com/downloads/en/DeviceDoc/80000526F.pdf
The document says:-

**16. Module: UART**
When using UTXISEL = 01 (interrupt when last
character is shifted out of the Transmit Shift
Register), and the final character is being shifted
out through the Transmit Shift Register (TSR), the
TX interrupt may occur before the final bit is shifted
out.
**Work around**
If it is critical that the interrupt processing occurs
only when all transmit operations are complete,
after which the following work around can be
implemented:
Hold off the interrupt routine processing by adding
a loop at the beginning of the routine that polls the
transmit shift register empty bit, as shown in
Example 2.
