### PR TITLE
Reduce spurious warnings on a default compile - SELECTED_VALUE

### DIFF
--- a/libUDB/analog2digital_auav3.c
+++ b/libUDB/analog2digital_auav3.c
@@ -111,12 +111,6 @@ const uint32_t adc_rate = ADC_RATE;
 
 const uint32_t almost_enough = ALMOST_ENOUGH_SAMPLES;
 
-//#define _SELECTED_VALUE(l,v) #l#v
-//#define SELECTED_VALUE(macro) _SELECTED_VALUE(#macro,macro)
-//#pragma message (SELECTED_VALUE(ADCLK_DIV_N_MINUS_1))
-//#pragma message (SELECTED_VALUE(ADC_CLK))
-//#pragma message (SELECTED_VALUE(ADC_RATE))
-//#pragma message (SELECTED_VALUE(ALMOST_ENOUGH_SAMPLES))
 
 void udb_init_ADC(void)
 {

--- a/libUDB/analog2digital_udb4.c
+++ b/libUDB/analog2digital_udb4.c
@@ -93,12 +93,6 @@ const uint32_t adc_rate = ADC_RATE;
 #define ALMOST_ENOUGH_SAMPLES ((ADC_RATE / (NUM_AD_CHAN * HEARTBEAT_HZ)) - 2)
 const uint32_t almost_enough = ALMOST_ENOUGH_SAMPLES;
 
-#define _SELECTED_VALUE(l, v) #l#v
-#define SELECTED_VALUE(macro) _SELECTED_VALUE(#macro, macro)
-#warning (SELECTED_VALUE(ADCLK_DIV_N_MINUS_1))
-#warning (SELECTED_VALUE(ADC_CLK))
-#warning (SELECTED_VALUE(ADC_RATE))
-#warning (SELECTED_VALUE(ALMOST_ENOUGH_SAMPLES))
 #endif // 0/1
 
 int16_t vref_adj;


### PR DESCRIPTION
There have been some #warnings messages in the analog2digital.c files that have not been working for some time. 

I am also moving a a default compile of MatrixPilot and RollPitchYaw that produce no warnings; i.e. a totally clean compile. This makes it much easier to see unusual events in the compile output.

So I have removed the SELECT_VALUE warning messages from analog2digital.c .