### PR TITLE
Prevent compiler warning that ini_read() and ini_rename() but not used 

### DIFF
--- a/MatrixPilot/config.c
+++ b/MatrixPilot/config.c
@@ -22,6 +22,13 @@
 #include "defines.h"
 #include "config.h"
 //#include "config-defaults.h"
+#if ! (WIN == 1 || NIX == 1 || PX4 == 1 || NOFS == 1)
+/* for floating-point support, define additional types and functions */
+#define INI_REAL float
+#define ini_ftoa(string,value) sprintf((string),"%f",(value))
+#define ini_atof(string) (INI_REAL)strtod((string),NULL)
+#endif
+
 #include "minIni.h"
 #include "navigate.h"
 #include "airspeedCntrl.h"

--- a/MatrixPilot/minIni.c
+++ b/MatrixPilot/minIni.c
@@ -33,6 +33,11 @@
 //#define NDEBUG
 
 #define MININI_IMPLEMENTATION
+#if (WIN == 1 || NIX == 1 || PX4 == 1 || NOFS == 1)
+#include "minGlue.h"
+#else
+#include "minGlue-mdd.h"
+#endif
 #include "minIni.h"
 #if defined NDEBUG
   #define assert(e)

--- a/MatrixPilot/minIni.h
+++ b/MatrixPilot/minIni.h
@@ -19,12 +19,6 @@
 #ifndef MININI_H
 #define MININI_H
 
-#if (WIN == 1 || NIX == 1 || PX4 == 1 || NOFS == 1)
-#include "minGlue.h"
-#else
-#include "minGlue-mdd.h"
-#endif
-
 #if (defined _UNICODE || defined __UNICODE__ || defined UNICODE) && !defined MININI_ANSI
   #include <tchar.h>
   #define mTCHAR TCHAR


### PR DESCRIPTION
2nd Try:-

This change is being made to remove a compiler warning in the project that ini_read() and ini_rename are being defined but not used.

Here is what was happening:-
minIni.c  includes miniIni.h which, in turn, includes minGlue-mdd.h. 
minGlue_mdd.h has two statically defined functions called ini_read() and ini_rename.
This all works fine for minIni.c which uses ini_read() and ini_rename().
However, config.c, also includes minIni.h, but will never directly use ini_read() and ini_rename(). Because these functions are are statically defined, they are separately instantiated inside of config.c (in a separate name space), and so are created inside of config.c and never used.

This commit, ensures that the statically defined functions [ini_read(), ini_rename()] are not defined in config.c  and minGlue-mdd.h is no longer included within miniIni.h. The issue behind the compiler warning is prevented with this commit.

Robert, if you are reading this, I would be grateful if you could test this fix for non microchip platforms (if you have been running this on them.). e.g. Unix and Windows.

Best wishes, Pete