### PR TITLE
Improve configuration of projects in MPLAB-X ...

### DIFF
--- a/MatrixPilot/MatrixPilot-auav3.X/nbproject/configurations.xml
+++ b/MatrixPilot/MatrixPilot-auav3.X/nbproject/configurations.xml
@@ -1,24 +1,25 @@
-<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="UTF-8"?>
 <configurationDescriptor version="62">
-  <logicalFolder name="root" displayName="root"
-  projectFiles="true">
-    <logicalFolder name="HeaderFiles" displayName="Header Files"
-    projectFiles="true">      <logicalFolder name="Config" displayName="Config" projectFiles="true">
+  <logicalFolder name="root" displayName="root" projectFiles="true">
+    <logicalFolder name="HeaderFiles"
+                   displayName="Header Files"
+                   projectFiles="true">
+      <logicalFolder name="Config" displayName="Config" projectFiles="true">
+        <logicalFolder name="Cessna" displayName="Cessna" projectFiles="true">
+          <itemPath>../../Config/Cessna/airspeed_options.h</itemPath>
+          <itemPath>../../Config/Cessna/FSconfig.h</itemPath>
+          <itemPath>../../Config/Cessna/magnetometerOptions.h</itemPath>
+          <itemPath>../../Config/Cessna/mavlink_options.h</itemPath>
+          <itemPath>../../Config/Cessna/nv_memory_options.h</itemPath>
+          <itemPath>../../Config/Cessna/options.h</itemPath>
+          <itemPath>../../Config/Cessna/options_auav3.h</itemPath>
+          <itemPath>../../Config/Cessna/osd_config.h</itemPath>
+          <itemPath>../../Config/Cessna/ports_config.h</itemPath>
+        </logicalFolder>
+        <logicalFolder name="CloudsFly" displayName="CloudsFly" projectFiles="true">
+          <itemPath>../../Config/CloudsFly/options.h</itemPath>
+        </logicalFolder>
         <itemPath>../../Config/airspeed_options.h</itemPath>
-      <logicalFolder name="Cessna" displayName="Cessna" projectFiles="true">
-        <itemPath>../../Config/Cessna/airspeed_options.h</itemPath>
-        <itemPath>../../Config/Cessna/FSconfig.h</itemPath>
-        <itemPath>../../Config/Cessna/magnetometerOptions.h</itemPath>
-        <itemPath>../../Config/Cessna/mavlink_options.h</itemPath>
-        <itemPath>../../Config/Cessna/nv_memory_options.h</itemPath>
-        <itemPath>../../Config/Cessna/options.h</itemPath>
-        <itemPath>../../Config/Cessna/options_auav3.h</itemPath>
-        <itemPath>../../Config/Cessna/osd_config.h</itemPath>
-        <itemPath>../../Config/Cessna/ports_config.h</itemPath>
-      </logicalFolder>
-      <logicalFolder name="CloudsFly" displayName="CloudsFly" projectFiles="true">
-        <itemPath>../../Config/CloudsFly/options.h</itemPath>
-      </logicalFolder>
         <itemPath>../../Config/FSconfig.h</itemPath>
         <itemPath>../../Config/magnetometerOptions.h</itemPath>
         <itemPath>../../Config/mavlink_options.h</itemPath>
@@ -28,7 +29,81 @@
         <itemPath>../../Config/osd_config.h</itemPath>
         <itemPath>../../Config/ports_config.h</itemPath>
       </logicalFolder>
+      <logicalFolder name="libDCM" displayName="libDCM" projectFiles="true">
+        <itemPath>../../libDCM/dcmTypes.h</itemPath>
+        <itemPath>../../libDCM/deadReckoning.h</itemPath>
+        <itemPath>../../libDCM/estAltitude.h</itemPath>
+        <itemPath>../../libDCM/estLocation.h</itemPath>
+        <itemPath>../../libDCM/estWind.h</itemPath>
+        <itemPath>../../libDCM/estYawDrift.h</itemPath>
+        <itemPath>../../libDCM/gpsData.h</itemPath>
+        <itemPath>../../libDCM/gpsParseCommon.h</itemPath>
+        <itemPath>../../libDCM/libDCM.h</itemPath>
+        <itemPath>../../libDCM/libDCM_defines.h</itemPath>
+        <itemPath>../../libDCM/libDCM_internal.h</itemPath>
+        <itemPath>../../libDCM/mag_drift.h</itemPath>
+        <itemPath>../../libDCM/mathlib.h</itemPath>
+        <itemPath>../../libDCM/mathlibNAV.h</itemPath>
+        <itemPath>../../libDCM/rmat.h</itemPath>
+      </logicalFolder>
+      <logicalFolder name="libFlashFS" displayName="libFlashFS" projectFiles="true">
+        <itemPath>../../libFlashFS/AT45D.h</itemPath>
+        <itemPath>../../libFlashFS/EEPROM.h</itemPath>
+        <itemPath>../../libFlashFS/filesys.h</itemPath>
+        <itemPath>../../libFlashFS/MDD_AT45D.h</itemPath>
+        <itemPath>../../libFlashFS/MDD_EEPROM.h</itemPath>
+      </logicalFolder>
+      <logicalFolder name="libUDB" displayName="libUDB" projectFiles="true">
+        <itemPath>../../libUDB/ADchannel.h</itemPath>
+        <itemPath>../../libUDB/analogs.h</itemPath>
+        <itemPath>../../libUDB/barometer.h</itemPath>
+        <itemPath>../../libUDB/boardRotation_defines.h</itemPath>
+        <itemPath>../../libUDB/builtins.h</itemPath>
+        <itemPath>../../libUDB/ConfigAUAV3.h</itemPath>
+        <itemPath>../../libUDB/ConfigHILSIM.h</itemPath>
+        <itemPath>../../libUDB/ConfigPX4.h</itemPath>
+        <itemPath>../../libUDB/ConfigUDB4.h</itemPath>
+        <itemPath>../../libUDB/ConfigUDB5.h</itemPath>
+        <itemPath>../../libUDB/eeprom_udb4.h</itemPath>
+        <itemPath>../../libUDB/events.h</itemPath>
+        <itemPath>../../libUDB/fixDeps.h</itemPath>
+        <itemPath>../../libUDB/heartbeat.h</itemPath>
+        <itemPath>../../libUDB/I2C.h</itemPath>
+        <itemPath>../../libUDB/interrupt.h</itemPath>
+        <itemPath>../../libUDB/libUDB.h</itemPath>
+        <itemPath>../../libUDB/libUDB_defines.h</itemPath>
+        <itemPath>../../libUDB/libUDB_internal.h</itemPath>
+        <itemPath>../../libUDB/magnetometer.h</itemPath>
+        <itemPath>../../libUDB/mcu.h</itemPath>
+        <itemPath>../../libUDB/mpu6000.h</itemPath>
+        <itemPath>../../libUDB/mpu_spi.h</itemPath>
+        <itemPath>../../libUDB/NV_memory.h</itemPath>
+        <itemPath>../../libUDB/oscillator.h</itemPath>
+        <itemPath>../../libUDB/osd.h</itemPath>
+        <itemPath>../../libUDB/radioIn.h</itemPath>
+        <itemPath>../../libUDB/serialIO.h</itemPath>
+        <itemPath>../../libUDB/servoOut.h</itemPath>
+        <itemPath>../../libUDB/sonarIn.h</itemPath>
+        <itemPath>../../libUDB/uart.h</itemPath>
+        <itemPath>../../libUDB/udbTypes.h</itemPath>
+      </logicalFolder>
+      <logicalFolder name="libVectorMatrix"
+                     displayName="libVectorMatrix"
+                     projectFiles="true">
+        <itemPath>../../libVectorMatrix/dspcommon.inc</itemPath>
+      </logicalFolder>
       <logicalFolder name="MatrixPilot" displayName="MatrixPilot" projectFiles="true">
+        <logicalFolder name="example-options-files"
+                       displayName="example-options-files"
+                       projectFiles="true">
+          <itemPath>../../MatrixPilot/example-options-files/options.AcroMaster-ben.h</itemPath>
+          <itemPath>../../MatrixPilot/example-options-files/options.Delta-Phil.h</itemPath>
+          <itemPath>../../MatrixPilot/example-options-files/options.EasyStar-Bill.h</itemPath>
+          <itemPath>../../MatrixPilot/example-options-files/options.GentleLady-Bill.h</itemPath>
+          <itemPath>../../MatrixPilot/example-options-files/options.HILSIM-B747-Bill.h</itemPath>
+          <itemPath>../../MatrixPilot/example-options-files/options.HILSIM-Cessna-ben.h</itemPath>
+          <itemPath>../../MatrixPilot/example-options-files/options.MiniMag-ben.h</itemPath>
+        </logicalFolder>
         <itemPath>../../MatrixPilot/airspeedCntrl.h</itemPath>
         <itemPath>../../MatrixPilot/altitudeCntrl.h</itemPath>
         <itemPath>../../MatrixPilot/behaviour.h</itemPath>
@@ -39,15 +114,6 @@
         <itemPath>../../MatrixPilot/data_storage.h</itemPath>
         <itemPath>../../MatrixPilot/defines.h</itemPath>
         <itemPath>../../MatrixPilot/euler_angles.h</itemPath>
-      <logicalFolder name="example-options-files" displayName="example-options-files" projectFiles="true">
-        <itemPath>../../MatrixPilot/example-options-files/options.AcroMaster-ben.h</itemPath>
-        <itemPath>../../MatrixPilot/example-options-files/options.Delta-Phil.h</itemPath>
-        <itemPath>../../MatrixPilot/example-options-files/options.EasyStar-Bill.h</itemPath>
-        <itemPath>../../MatrixPilot/example-options-files/options.GentleLady-Bill.h</itemPath>
-        <itemPath>../../MatrixPilot/example-options-files/options.HILSIM-B747-Bill.h</itemPath>
-        <itemPath>../../MatrixPilot/example-options-files/options.HILSIM-Cessna-ben.h</itemPath>
-        <itemPath>../../MatrixPilot/example-options-files/options.MiniMag-ben.h</itemPath>
-      </logicalFolder>
         <itemPath>../../MatrixPilot/flightplan-logo.h</itemPath>
         <itemPath>../../MatrixPilot/flightplan-waypoints.h</itemPath>
         <itemPath>../../MatrixPilot/flightplan.h</itemPath>
@@ -84,277 +150,311 @@
         <itemPath>../../MatrixPilot/waypoints.h</itemPath>
       </logicalFolder>
       <logicalFolder name="MAVLink" displayName="MAVLink" projectFiles="true">
-      <logicalFolder name="include" displayName="include" projectFiles="true">
-        <itemPath>../../MAVLink/include/checksum.h</itemPath>
-      <logicalFolder name="common" displayName="common" projectFiles="true">
-        <itemPath>../../MAVLink/include/common/common.h</itemPath>
-        <itemPath>../../MAVLink/include/common/mavlink.h</itemPath>
-        <itemPath>../../MAVLink/include/common/mavlink_msg_attitude.h</itemPath>
-        <itemPath>../../MAVLink/include/common/mavlink_msg_attitude_quaternion.h</itemPath>
-        <itemPath>../../MAVLink/include/common/mavlink_msg_attitude_quaternion_cov.h</itemPath>
-        <itemPath>../../MAVLink/include/common/mavlink_msg_attitude_setpoint_external.h</itemPath>
-        <itemPath>../../MAVLink/include/common/mavlink_msg_attitude_target.h</itemPath>
-        <itemPath>../../MAVLink/include/common/mavlink_msg_auth_key.h</itemPath>
-        <itemPath>../../MAVLink/include/common/mavlink_msg_autopilot_version.h</itemPath>
-        <itemPath>../../MAVLink/include/common/mavlink_msg_battery_status.h</itemPath>
-        <itemPath>../../MAVLink/include/common/mavlink_msg_change_operator_control.h</itemPath>
-        <itemPath>../../MAVLink/include/common/mavlink_msg_change_operator_control_ack.h</itemPath>
-        <itemPath>../../MAVLink/include/common/mavlink_msg_command_ack.h</itemPath>
-        <itemPath>../../MAVLink/include/common/mavlink_msg_command_int.h</itemPath>
-        <itemPath>../../MAVLink/include/common/mavlink_msg_command_long.h</itemPath>
-        <itemPath>../../MAVLink/include/common/mavlink_msg_data_stream.h</itemPath>
-        <itemPath>../../MAVLink/include/common/mavlink_msg_data_transmission_handshake.h</itemPath>
-        <itemPath>../../MAVLink/include/common/mavlink_msg_debug.h</itemPath>
-        <itemPath>../../MAVLink/include/common/mavlink_msg_debug_vect.h</itemPath>
-        <itemPath>../../MAVLink/include/common/mavlink_msg_distance_sensor.h</itemPath>
-        <itemPath>../../MAVLink/include/common/mavlink_msg_encapsulated_data.h</itemPath>
-        <itemPath>../../MAVLink/include/common/mavlink_msg_file_transfer_dir_list.h</itemPath>
-        <itemPath>../../MAVLink/include/common/mavlink_msg_file_transfer_protocol.h</itemPath>
-        <itemPath>../../MAVLink/include/common/mavlink_msg_file_transfer_res.h</itemPath>
-        <itemPath>../../MAVLink/include/common/mavlink_msg_file_transfer_start.h</itemPath>
-        <itemPath>../../MAVLink/include/common/mavlink_msg_global_position_int.h</itemPath>
-        <itemPath>../../MAVLink/include/common/mavlink_msg_global_position_int_cov.h</itemPath>
-        <itemPath>../../MAVLink/include/common/mavlink_msg_global_position_setpoint_external_int.h</itemPath>
-        <itemPath>../../MAVLink/include/common/mavlink_msg_global_position_setpoint_int.h</itemPath>
-        <itemPath>../../MAVLink/include/common/mavlink_msg_global_vision_position_estimate.h</itemPath>
-        <itemPath>../../MAVLink/include/common/mavlink_msg_gps2_raw.h</itemPath>
-        <itemPath>../../MAVLink/include/common/mavlink_msg_gps2_rtk.h</itemPath>
-        <itemPath>../../MAVLink/include/common/mavlink_msg_gps_global_origin.h</itemPath>
-        <itemPath>../../MAVLink/include/common/mavlink_msg_gps_inject_data.h</itemPath>
-        <itemPath>../../MAVLink/include/common/mavlink_msg_gps_raw_int.h</itemPath>
-        <itemPath>../../MAVLink/include/common/mavlink_msg_gps_rtk.h</itemPath>
-        <itemPath>../../MAVLink/include/common/mavlink_msg_gps_status.h</itemPath>
-        <itemPath>../../MAVLink/include/common/mavlink_msg_heartbeat.h</itemPath>
-        <itemPath>../../MAVLink/include/common/mavlink_msg_highres_imu.h</itemPath>
-        <itemPath>../../MAVLink/include/common/mavlink_msg_hil_controls.h</itemPath>
-        <itemPath>../../MAVLink/include/common/mavlink_msg_hil_gps.h</itemPath>
-        <itemPath>../../MAVLink/include/common/mavlink_msg_hil_optical_flow.h</itemPath>
-        <itemPath>../../MAVLink/include/common/mavlink_msg_hil_rc_inputs_raw.h</itemPath>
-        <itemPath>../../MAVLink/include/common/mavlink_msg_hil_sensor.h</itemPath>
-        <itemPath>../../MAVLink/include/common/mavlink_msg_hil_state.h</itemPath>
-        <itemPath>../../MAVLink/include/common/mavlink_msg_hil_state_quaternion.h</itemPath>
-        <itemPath>../../MAVLink/include/common/mavlink_msg_local_ned_position_setpoint_external.h</itemPath>
-        <itemPath>../../MAVLink/include/common/mavlink_msg_local_position_ned.h</itemPath>
-        <itemPath>../../MAVLink/include/common/mavlink_msg_local_position_ned_cov.h</itemPath>
-        <itemPath>../../MAVLink/include/common/mavlink_msg_local_position_ned_system_global_offset.h</itemPath>
-        <itemPath>../../MAVLink/include/common/mavlink_msg_local_position_setpoint.h</itemPath>
-        <itemPath>../../MAVLink/include/common/mavlink_msg_log_data.h</itemPath>
-        <itemPath>../../MAVLink/include/common/mavlink_msg_log_entry.h</itemPath>
-        <itemPath>../../MAVLink/include/common/mavlink_msg_log_erase.h</itemPath>
-        <itemPath>../../MAVLink/include/common/mavlink_msg_log_request_data.h</itemPath>
-        <itemPath>../../MAVLink/include/common/mavlink_msg_log_request_end.h</itemPath>
-        <itemPath>../../MAVLink/include/common/mavlink_msg_log_request_list.h</itemPath>
-        <itemPath>../../MAVLink/include/common/mavlink_msg_manual_control.h</itemPath>
-        <itemPath>../../MAVLink/include/common/mavlink_msg_manual_setpoint.h</itemPath>
-        <itemPath>../../MAVLink/include/common/mavlink_msg_memory_vect.h</itemPath>
-        <itemPath>../../MAVLink/include/common/mavlink_msg_mission_ack.h</itemPath>
-        <itemPath>../../MAVLink/include/common/mavlink_msg_mission_clear_all.h</itemPath>
-        <itemPath>../../MAVLink/include/common/mavlink_msg_mission_count.h</itemPath>
-        <itemPath>../../MAVLink/include/common/mavlink_msg_mission_current.h</itemPath>
-        <itemPath>../../MAVLink/include/common/mavlink_msg_mission_item.h</itemPath>
-        <itemPath>../../MAVLink/include/common/mavlink_msg_mission_item_int.h</itemPath>
-        <itemPath>../../MAVLink/include/common/mavlink_msg_mission_item_reached.h</itemPath>
-        <itemPath>../../MAVLink/include/common/mavlink_msg_mission_request.h</itemPath>
-        <itemPath>../../MAVLink/include/common/mavlink_msg_mission_request_list.h</itemPath>
-        <itemPath>../../MAVLink/include/common/mavlink_msg_mission_request_partial_list.h</itemPath>
-        <itemPath>../../MAVLink/include/common/mavlink_msg_mission_set_current.h</itemPath>
-        <itemPath>../../MAVLink/include/common/mavlink_msg_mission_write_partial_list.h</itemPath>
-        <itemPath>../../MAVLink/include/common/mavlink_msg_named_value_float.h</itemPath>
-        <itemPath>../../MAVLink/include/common/mavlink_msg_named_value_int.h</itemPath>
-        <itemPath>../../MAVLink/include/common/mavlink_msg_nav_controller_output.h</itemPath>
-        <itemPath>../../MAVLink/include/common/mavlink_msg_omnidirectional_flow.h</itemPath>
-        <itemPath>../../MAVLink/include/common/mavlink_msg_optical_flow.h</itemPath>
-        <itemPath>../../MAVLink/include/common/mavlink_msg_optical_flow_rad.h</itemPath>
-        <itemPath>../../MAVLink/include/common/mavlink_msg_param_request_list.h</itemPath>
-        <itemPath>../../MAVLink/include/common/mavlink_msg_param_request_read.h</itemPath>
-        <itemPath>../../MAVLink/include/common/mavlink_msg_param_set.h</itemPath>
-        <itemPath>../../MAVLink/include/common/mavlink_msg_param_value.h</itemPath>
-        <itemPath>../../MAVLink/include/common/mavlink_msg_ping.h</itemPath>
-        <itemPath>../../MAVLink/include/common/mavlink_msg_position_target_global_int.h</itemPath>
-        <itemPath>../../MAVLink/include/common/mavlink_msg_position_target_local_ned.h</itemPath>
-        <itemPath>../../MAVLink/include/common/mavlink_msg_power_status.h</itemPath>
-        <itemPath>../../MAVLink/include/common/mavlink_msg_radio_status.h</itemPath>
-        <itemPath>../../MAVLink/include/common/mavlink_msg_raw_imu.h</itemPath>
-        <itemPath>../../MAVLink/include/common/mavlink_msg_raw_pressure.h</itemPath>
-        <itemPath>../../MAVLink/include/common/mavlink_msg_rc_channels.h</itemPath>
-        <itemPath>../../MAVLink/include/common/mavlink_msg_rc_channels_override.h</itemPath>
-        <itemPath>../../MAVLink/include/common/mavlink_msg_rc_channels_raw.h</itemPath>
-        <itemPath>../../MAVLink/include/common/mavlink_msg_rc_channels_scaled.h</itemPath>
-        <itemPath>../../MAVLink/include/common/mavlink_msg_request_data_stream.h</itemPath>
-        <itemPath>../../MAVLink/include/common/mavlink_msg_roll_pitch_yaw_rates_thrust_setpoint.h</itemPath>
-        <itemPath>../../MAVLink/include/common/mavlink_msg_roll_pitch_yaw_speed_thrust_setpoint.h</itemPath>
-        <itemPath>../../MAVLink/include/common/mavlink_msg_roll_pitch_yaw_thrust_setpoint.h</itemPath>
-        <itemPath>../../MAVLink/include/common/mavlink_msg_safety_allowed_area.h</itemPath>
-        <itemPath>../../MAVLink/include/common/mavlink_msg_safety_set_allowed_area.h</itemPath>
-        <itemPath>../../MAVLink/include/common/mavlink_msg_scaled_imu.h</itemPath>
-        <itemPath>../../MAVLink/include/common/mavlink_msg_scaled_imu2.h</itemPath>
-        <itemPath>../../MAVLink/include/common/mavlink_msg_scaled_pressure.h</itemPath>
-        <itemPath>../../MAVLink/include/common/mavlink_msg_serial_control.h</itemPath>
-        <itemPath>../../MAVLink/include/common/mavlink_msg_servo_output_raw.h</itemPath>
-        <itemPath>../../MAVLink/include/common/mavlink_msg_setpoint_6dof.h</itemPath>
-        <itemPath>../../MAVLink/include/common/mavlink_msg_setpoint_8dof.h</itemPath>
-        <itemPath>../../MAVLink/include/common/mavlink_msg_set_attitude_target.h</itemPath>
-        <itemPath>../../MAVLink/include/common/mavlink_msg_set_global_position_setpoint_int.h</itemPath>
-        <itemPath>../../MAVLink/include/common/mavlink_msg_set_gps_global_origin.h</itemPath>
-        <itemPath>../../MAVLink/include/common/mavlink_msg_set_local_position_setpoint.h</itemPath>
-        <itemPath>../../MAVLink/include/common/mavlink_msg_set_mode.h</itemPath>
-        <itemPath>../../MAVLink/include/common/mavlink_msg_set_position_target_global_int.h</itemPath>
-        <itemPath>../../MAVLink/include/common/mavlink_msg_set_position_target_local_ned.h</itemPath>
-        <itemPath>../../MAVLink/include/common/mavlink_msg_set_quad_motors_setpoint.h</itemPath>
-        <itemPath>../../MAVLink/include/common/mavlink_msg_set_quad_swarm_led_roll_pitch_yaw_thrust.h</itemPath>
-        <itemPath>../../MAVLink/include/common/mavlink_msg_set_quad_swarm_roll_pitch_yaw_thrust.h</itemPath>
-        <itemPath>../../MAVLink/include/common/mavlink_msg_set_roll_pitch_yaw_speed_thrust.h</itemPath>
-        <itemPath>../../MAVLink/include/common/mavlink_msg_set_roll_pitch_yaw_thrust.h</itemPath>
-        <itemPath>../../MAVLink/include/common/mavlink_msg_sim_state.h</itemPath>
-        <itemPath>../../MAVLink/include/common/mavlink_msg_state_correction.h</itemPath>
-        <itemPath>../../MAVLink/include/common/mavlink_msg_statustext.h</itemPath>
-        <itemPath>../../MAVLink/include/common/mavlink_msg_system_time.h</itemPath>
-        <itemPath>../../MAVLink/include/common/mavlink_msg_sys_status.h</itemPath>
-        <itemPath>../../MAVLink/include/common/mavlink_msg_terrain_check.h</itemPath>
-        <itemPath>../../MAVLink/include/common/mavlink_msg_terrain_data.h</itemPath>
-        <itemPath>../../MAVLink/include/common/mavlink_msg_terrain_report.h</itemPath>
-        <itemPath>../../MAVLink/include/common/mavlink_msg_terrain_request.h</itemPath>
-        <itemPath>../../MAVLink/include/common/mavlink_msg_timesync.h</itemPath>
-        <itemPath>../../MAVLink/include/common/mavlink_msg_v2_extension.h</itemPath>
-        <itemPath>../../MAVLink/include/common/mavlink_msg_vfr_hud.h</itemPath>
-        <itemPath>../../MAVLink/include/common/mavlink_msg_vicon_position_estimate.h</itemPath>
-        <itemPath>../../MAVLink/include/common/mavlink_msg_vision_position_estimate.h</itemPath>
-        <itemPath>../../MAVLink/include/common/mavlink_msg_vision_speed_estimate.h</itemPath>
-        <itemPath>../../MAVLink/include/common/testsuite.h</itemPath>
-        <itemPath>../../MAVLink/include/common/version.h</itemPath>
-      </logicalFolder>
-        <itemPath>../../MAVLink/include/inttypes.h</itemPath>
-      <logicalFolder name="matrixpilot" displayName="matrixpilot" projectFiles="true">
-        <itemPath>../../MAVLink/include/matrixpilot/matrixpilot.h</itemPath>
-        <itemPath>../../MAVLink/include/matrixpilot/mavlink.h</itemPath>
-        <itemPath>../../MAVLink/include/matrixpilot/mavlink_msg_airspeeds.h</itemPath>
-        <itemPath>../../MAVLink/include/matrixpilot/mavlink_msg_altitudes.h</itemPath>
-        <itemPath>../../MAVLink/include/matrixpilot/mavlink_msg_flexifunction_buffer_function.h</itemPath>
-        <itemPath>../../MAVLink/include/matrixpilot/mavlink_msg_flexifunction_buffer_function_ack.h</itemPath>
-        <itemPath>../../MAVLink/include/matrixpilot/mavlink_msg_flexifunction_command.h</itemPath>
-        <itemPath>../../MAVLink/include/matrixpilot/mavlink_msg_flexifunction_command_ack.h</itemPath>
-        <itemPath>../../MAVLink/include/matrixpilot/mavlink_msg_flexifunction_directory.h</itemPath>
-        <itemPath>../../MAVLink/include/matrixpilot/mavlink_msg_flexifunction_directory_ack.h</itemPath>
-        <itemPath>../../MAVLink/include/matrixpilot/mavlink_msg_flexifunction_read_req.h</itemPath>
-        <itemPath>../../MAVLink/include/matrixpilot/mavlink_msg_flexifunction_set.h</itemPath>
-        <itemPath>../../MAVLink/include/matrixpilot/mavlink_msg_force.h</itemPath>
-        <itemPath>../../MAVLink/include/matrixpilot/mavlink_msg_serial_udb_extra_f13.h</itemPath>
-        <itemPath>../../MAVLink/include/matrixpilot/mavlink_msg_serial_udb_extra_f14.h</itemPath>
-        <itemPath>../../MAVLink/include/matrixpilot/mavlink_msg_serial_udb_extra_f15.h</itemPath>
-        <itemPath>../../MAVLink/include/matrixpilot/mavlink_msg_serial_udb_extra_f16.h</itemPath>
-        <itemPath>../../MAVLink/include/matrixpilot/mavlink_msg_serial_udb_extra_f2_a.h</itemPath>
-        <itemPath>../../MAVLink/include/matrixpilot/mavlink_msg_serial_udb_extra_f2_b.h</itemPath>
-        <itemPath>../../MAVLink/include/matrixpilot/mavlink_msg_serial_udb_extra_f4.h</itemPath>
-        <itemPath>../../MAVLink/include/matrixpilot/mavlink_msg_serial_udb_extra_f5.h</itemPath>
-        <itemPath>../../MAVLink/include/matrixpilot/mavlink_msg_serial_udb_extra_f6.h</itemPath>
-        <itemPath>../../MAVLink/include/matrixpilot/mavlink_msg_serial_udb_extra_f7.h</itemPath>
-        <itemPath>../../MAVLink/include/matrixpilot/mavlink_msg_serial_udb_extra_f8.h</itemPath>
-        <itemPath>../../MAVLink/include/matrixpilot/testsuite.h</itemPath>
-        <itemPath>../../MAVLink/include/matrixpilot/version.h</itemPath>
-      </logicalFolder>
-        <itemPath>../../MAVLink/include/matrixpilot_mavlink_bridge_header.h</itemPath>
-        <itemPath>../../MAVLink/include/mavlink_conversions.h</itemPath>
-        <itemPath>../../MAVLink/include/mavlink_helpers.h</itemPath>
-        <itemPath>../../MAVLink/include/mavlink_types.h</itemPath>
-        <itemPath>../../MAVLink/include/protocol.h</itemPath>
-      </logicalFolder>
+        <logicalFolder name="include" displayName="include" projectFiles="true">
+          <logicalFolder name="common" displayName="common" projectFiles="true">
+            <itemPath>../../MAVLink/include/common/common.h</itemPath>
+            <itemPath>../../MAVLink/include/common/mavlink.h</itemPath>
+            <itemPath>../../MAVLink/include/common/mavlink_msg_attitude.h</itemPath>
+            <itemPath>../../MAVLink/include/common/mavlink_msg_attitude_quaternion.h</itemPath>
+            <itemPath>../../MAVLink/include/common/mavlink_msg_attitude_quaternion_cov.h</itemPath>
+            <itemPath>../../MAVLink/include/common/mavlink_msg_attitude_setpoint_external.h</itemPath>
+            <itemPath>../../MAVLink/include/common/mavlink_msg_attitude_target.h</itemPath>
+            <itemPath>../../MAVLink/include/common/mavlink_msg_auth_key.h</itemPath>
+            <itemPath>../../MAVLink/include/common/mavlink_msg_autopilot_version.h</itemPath>
+            <itemPath>../../MAVLink/include/common/mavlink_msg_battery_status.h</itemPath>
+            <itemPath>../../MAVLink/include/common/mavlink_msg_change_operator_control.h</itemPath>
+            <itemPath>../../MAVLink/include/common/mavlink_msg_change_operator_control_ack.h</itemPath>
+            <itemPath>../../MAVLink/include/common/mavlink_msg_command_ack.h</itemPath>
+            <itemPath>../../MAVLink/include/common/mavlink_msg_command_int.h</itemPath>
+            <itemPath>../../MAVLink/include/common/mavlink_msg_command_long.h</itemPath>
+            <itemPath>../../MAVLink/include/common/mavlink_msg_data_stream.h</itemPath>
+            <itemPath>../../MAVLink/include/common/mavlink_msg_data_transmission_handshake.h</itemPath>
+            <itemPath>../../MAVLink/include/common/mavlink_msg_debug.h</itemPath>
+            <itemPath>../../MAVLink/include/common/mavlink_msg_debug_vect.h</itemPath>
+            <itemPath>../../MAVLink/include/common/mavlink_msg_distance_sensor.h</itemPath>
+            <itemPath>../../MAVLink/include/common/mavlink_msg_encapsulated_data.h</itemPath>
+            <itemPath>../../MAVLink/include/common/mavlink_msg_file_transfer_dir_list.h</itemPath>
+            <itemPath>../../MAVLink/include/common/mavlink_msg_file_transfer_protocol.h</itemPath>
+            <itemPath>../../MAVLink/include/common/mavlink_msg_file_transfer_res.h</itemPath>
+            <itemPath>../../MAVLink/include/common/mavlink_msg_file_transfer_start.h</itemPath>
+            <itemPath>../../MAVLink/include/common/mavlink_msg_global_position_int.h</itemPath>
+            <itemPath>../../MAVLink/include/common/mavlink_msg_global_position_int_cov.h</itemPath>
+            <itemPath>../../MAVLink/include/common/mavlink_msg_global_position_setpoint_external_int.h</itemPath>
+            <itemPath>../../MAVLink/include/common/mavlink_msg_global_position_setpoint_int.h</itemPath>
+            <itemPath>../../MAVLink/include/common/mavlink_msg_global_vision_position_estimate.h</itemPath>
+            <itemPath>../../MAVLink/include/common/mavlink_msg_gps2_raw.h</itemPath>
+            <itemPath>../../MAVLink/include/common/mavlink_msg_gps2_rtk.h</itemPath>
+            <itemPath>../../MAVLink/include/common/mavlink_msg_gps_global_origin.h</itemPath>
+            <itemPath>../../MAVLink/include/common/mavlink_msg_gps_inject_data.h</itemPath>
+            <itemPath>../../MAVLink/include/common/mavlink_msg_gps_raw_int.h</itemPath>
+            <itemPath>../../MAVLink/include/common/mavlink_msg_gps_rtk.h</itemPath>
+            <itemPath>../../MAVLink/include/common/mavlink_msg_gps_status.h</itemPath>
+            <itemPath>../../MAVLink/include/common/mavlink_msg_heartbeat.h</itemPath>
+            <itemPath>../../MAVLink/include/common/mavlink_msg_highres_imu.h</itemPath>
+            <itemPath>../../MAVLink/include/common/mavlink_msg_hil_controls.h</itemPath>
+            <itemPath>../../MAVLink/include/common/mavlink_msg_hil_gps.h</itemPath>
+            <itemPath>../../MAVLink/include/common/mavlink_msg_hil_optical_flow.h</itemPath>
+            <itemPath>../../MAVLink/include/common/mavlink_msg_hil_rc_inputs_raw.h</itemPath>
+            <itemPath>../../MAVLink/include/common/mavlink_msg_hil_sensor.h</itemPath>
+            <itemPath>../../MAVLink/include/common/mavlink_msg_hil_state.h</itemPath>
+            <itemPath>../../MAVLink/include/common/mavlink_msg_hil_state_quaternion.h</itemPath>
+            <itemPath>../../MAVLink/include/common/mavlink_msg_local_ned_position_setpoint_external.h</itemPath>
+            <itemPath>../../MAVLink/include/common/mavlink_msg_local_position_ned.h</itemPath>
+            <itemPath>../../MAVLink/include/common/mavlink_msg_local_position_ned_cov.h</itemPath>
+            <itemPath>../../MAVLink/include/common/mavlink_msg_local_position_ned_system_global_offset.h</itemPath>
+            <itemPath>../../MAVLink/include/common/mavlink_msg_local_position_setpoint.h</itemPath>
+            <itemPath>../../MAVLink/include/common/mavlink_msg_log_data.h</itemPath>
+            <itemPath>../../MAVLink/include/common/mavlink_msg_log_entry.h</itemPath>
+            <itemPath>../../MAVLink/include/common/mavlink_msg_log_erase.h</itemPath>
+            <itemPath>../../MAVLink/include/common/mavlink_msg_log_request_data.h</itemPath>
+            <itemPath>../../MAVLink/include/common/mavlink_msg_log_request_end.h</itemPath>
+            <itemPath>../../MAVLink/include/common/mavlink_msg_log_request_list.h</itemPath>
+            <itemPath>../../MAVLink/include/common/mavlink_msg_manual_control.h</itemPath>
+            <itemPath>../../MAVLink/include/common/mavlink_msg_manual_setpoint.h</itemPath>
+            <itemPath>../../MAVLink/include/common/mavlink_msg_memory_vect.h</itemPath>
+            <itemPath>../../MAVLink/include/common/mavlink_msg_mission_ack.h</itemPath>
+            <itemPath>../../MAVLink/include/common/mavlink_msg_mission_clear_all.h</itemPath>
+            <itemPath>../../MAVLink/include/common/mavlink_msg_mission_count.h</itemPath>
+            <itemPath>../../MAVLink/include/common/mavlink_msg_mission_current.h</itemPath>
+            <itemPath>../../MAVLink/include/common/mavlink_msg_mission_item.h</itemPath>
+            <itemPath>../../MAVLink/include/common/mavlink_msg_mission_item_int.h</itemPath>
+            <itemPath>../../MAVLink/include/common/mavlink_msg_mission_item_reached.h</itemPath>
+            <itemPath>../../MAVLink/include/common/mavlink_msg_mission_request.h</itemPath>
+            <itemPath>../../MAVLink/include/common/mavlink_msg_mission_request_list.h</itemPath>
+            <itemPath>../../MAVLink/include/common/mavlink_msg_mission_request_partial_list.h</itemPath>
+            <itemPath>../../MAVLink/include/common/mavlink_msg_mission_set_current.h</itemPath>
+            <itemPath>../../MAVLink/include/common/mavlink_msg_mission_write_partial_list.h</itemPath>
+            <itemPath>../../MAVLink/include/common/mavlink_msg_named_value_float.h</itemPath>
+            <itemPath>../../MAVLink/include/common/mavlink_msg_named_value_int.h</itemPath>
+            <itemPath>../../MAVLink/include/common/mavlink_msg_nav_controller_output.h</itemPath>
+            <itemPath>../../MAVLink/include/common/mavlink_msg_omnidirectional_flow.h</itemPath>
+            <itemPath>../../MAVLink/include/common/mavlink_msg_optical_flow.h</itemPath>
+            <itemPath>../../MAVLink/include/common/mavlink_msg_optical_flow_rad.h</itemPath>
+            <itemPath>../../MAVLink/include/common/mavlink_msg_param_request_list.h</itemPath>
+            <itemPath>../../MAVLink/include/common/mavlink_msg_param_request_read.h</itemPath>
+            <itemPath>../../MAVLink/include/common/mavlink_msg_param_set.h</itemPath>
+            <itemPath>../../MAVLink/include/common/mavlink_msg_param_value.h</itemPath>
+            <itemPath>../../MAVLink/include/common/mavlink_msg_ping.h</itemPath>
+            <itemPath>../../MAVLink/include/common/mavlink_msg_position_target_global_int.h</itemPath>
+            <itemPath>../../MAVLink/include/common/mavlink_msg_position_target_local_ned.h</itemPath>
+            <itemPath>../../MAVLink/include/common/mavlink_msg_power_status.h</itemPath>
+            <itemPath>../../MAVLink/include/common/mavlink_msg_radio_status.h</itemPath>
+            <itemPath>../../MAVLink/include/common/mavlink_msg_raw_imu.h</itemPath>
+            <itemPath>../../MAVLink/include/common/mavlink_msg_raw_pressure.h</itemPath>
+            <itemPath>../../MAVLink/include/common/mavlink_msg_rc_channels.h</itemPath>
+            <itemPath>../../MAVLink/include/common/mavlink_msg_rc_channels_override.h</itemPath>
+            <itemPath>../../MAVLink/include/common/mavlink_msg_rc_channels_raw.h</itemPath>
+            <itemPath>../../MAVLink/include/common/mavlink_msg_rc_channels_scaled.h</itemPath>
+            <itemPath>../../MAVLink/include/common/mavlink_msg_request_data_stream.h</itemPath>
+            <itemPath>../../MAVLink/include/common/mavlink_msg_roll_pitch_yaw_rates_thrust_setpoint.h</itemPath>
+            <itemPath>../../MAVLink/include/common/mavlink_msg_roll_pitch_yaw_speed_thrust_setpoint.h</itemPath>
+            <itemPath>../../MAVLink/include/common/mavlink_msg_roll_pitch_yaw_thrust_setpoint.h</itemPath>
+            <itemPath>../../MAVLink/include/common/mavlink_msg_safety_allowed_area.h</itemPath>
+            <itemPath>../../MAVLink/include/common/mavlink_msg_safety_set_allowed_area.h</itemPath>
+            <itemPath>../../MAVLink/include/common/mavlink_msg_scaled_imu.h</itemPath>
+            <itemPath>../../MAVLink/include/common/mavlink_msg_scaled_imu2.h</itemPath>
+            <itemPath>../../MAVLink/include/common/mavlink_msg_scaled_pressure.h</itemPath>
+            <itemPath>../../MAVLink/include/common/mavlink_msg_serial_control.h</itemPath>
+            <itemPath>../../MAVLink/include/common/mavlink_msg_servo_output_raw.h</itemPath>
+            <itemPath>../../MAVLink/include/common/mavlink_msg_setpoint_6dof.h</itemPath>
+            <itemPath>../../MAVLink/include/common/mavlink_msg_setpoint_8dof.h</itemPath>
+            <itemPath>../../MAVLink/include/common/mavlink_msg_set_attitude_target.h</itemPath>
+            <itemPath>../../MAVLink/include/common/mavlink_msg_set_global_position_setpoint_int.h</itemPath>
+            <itemPath>../../MAVLink/include/common/mavlink_msg_set_gps_global_origin.h</itemPath>
+            <itemPath>../../MAVLink/include/common/mavlink_msg_set_local_position_setpoint.h</itemPath>
+            <itemPath>../../MAVLink/include/common/mavlink_msg_set_mode.h</itemPath>
+            <itemPath>../../MAVLink/include/common/mavlink_msg_set_position_target_global_int.h</itemPath>
+            <itemPath>../../MAVLink/include/common/mavlink_msg_set_position_target_local_ned.h</itemPath>
+            <itemPath>../../MAVLink/include/common/mavlink_msg_set_quad_motors_setpoint.h</itemPath>
+            <itemPath>../../MAVLink/include/common/mavlink_msg_set_quad_swarm_led_roll_pitch_yaw_thrust.h</itemPath>
+            <itemPath>../../MAVLink/include/common/mavlink_msg_set_quad_swarm_roll_pitch_yaw_thrust.h</itemPath>
+            <itemPath>../../MAVLink/include/common/mavlink_msg_set_roll_pitch_yaw_speed_thrust.h</itemPath>
+            <itemPath>../../MAVLink/include/common/mavlink_msg_set_roll_pitch_yaw_thrust.h</itemPath>
+            <itemPath>../../MAVLink/include/common/mavlink_msg_sim_state.h</itemPath>
+            <itemPath>../../MAVLink/include/common/mavlink_msg_state_correction.h</itemPath>
+            <itemPath>../../MAVLink/include/common/mavlink_msg_statustext.h</itemPath>
+            <itemPath>../../MAVLink/include/common/mavlink_msg_system_time.h</itemPath>
+            <itemPath>../../MAVLink/include/common/mavlink_msg_sys_status.h</itemPath>
+            <itemPath>../../MAVLink/include/common/mavlink_msg_terrain_check.h</itemPath>
+            <itemPath>../../MAVLink/include/common/mavlink_msg_terrain_data.h</itemPath>
+            <itemPath>../../MAVLink/include/common/mavlink_msg_terrain_report.h</itemPath>
+            <itemPath>../../MAVLink/include/common/mavlink_msg_terrain_request.h</itemPath>
+            <itemPath>../../MAVLink/include/common/mavlink_msg_timesync.h</itemPath>
+            <itemPath>../../MAVLink/include/common/mavlink_msg_v2_extension.h</itemPath>
+            <itemPath>../../MAVLink/include/common/mavlink_msg_vfr_hud.h</itemPath>
+            <itemPath>../../MAVLink/include/common/mavlink_msg_vicon_position_estimate.h</itemPath>
+            <itemPath>../../MAVLink/include/common/mavlink_msg_vision_position_estimate.h</itemPath>
+            <itemPath>../../MAVLink/include/common/mavlink_msg_vision_speed_estimate.h</itemPath>
+            <itemPath>../../MAVLink/include/common/testsuite.h</itemPath>
+            <itemPath>../../MAVLink/include/common/version.h</itemPath>
+          </logicalFolder>
+          <logicalFolder name="matrixpilot" displayName="matrixpilot" projectFiles="true">
+            <itemPath>../../MAVLink/include/matrixpilot/matrixpilot.h</itemPath>
+            <itemPath>../../MAVLink/include/matrixpilot/mavlink.h</itemPath>
+            <itemPath>../../MAVLink/include/matrixpilot/mavlink_msg_airspeeds.h</itemPath>
+            <itemPath>../../MAVLink/include/matrixpilot/mavlink_msg_altitudes.h</itemPath>
+            <itemPath>../../MAVLink/include/matrixpilot/mavlink_msg_flexifunction_buffer_function.h</itemPath>
+            <itemPath>../../MAVLink/include/matrixpilot/mavlink_msg_flexifunction_buffer_function_ack.h</itemPath>
+            <itemPath>../../MAVLink/include/matrixpilot/mavlink_msg_flexifunction_command.h</itemPath>
+            <itemPath>../../MAVLink/include/matrixpilot/mavlink_msg_flexifunction_command_ack.h</itemPath>
+            <itemPath>../../MAVLink/include/matrixpilot/mavlink_msg_flexifunction_directory.h</itemPath>
+            <itemPath>../../MAVLink/include/matrixpilot/mavlink_msg_flexifunction_directory_ack.h</itemPath>
+            <itemPath>../../MAVLink/include/matrixpilot/mavlink_msg_flexifunction_read_req.h</itemPath>
+            <itemPath>../../MAVLink/include/matrixpilot/mavlink_msg_flexifunction_set.h</itemPath>
+            <itemPath>../../MAVLink/include/matrixpilot/mavlink_msg_force.h</itemPath>
+            <itemPath>../../MAVLink/include/matrixpilot/mavlink_msg_serial_udb_extra_f13.h</itemPath>
+            <itemPath>../../MAVLink/include/matrixpilot/mavlink_msg_serial_udb_extra_f14.h</itemPath>
+            <itemPath>../../MAVLink/include/matrixpilot/mavlink_msg_serial_udb_extra_f15.h</itemPath>
+            <itemPath>../../MAVLink/include/matrixpilot/mavlink_msg_serial_udb_extra_f16.h</itemPath>
+            <itemPath>../../MAVLink/include/matrixpilot/mavlink_msg_serial_udb_extra_f2_a.h</itemPath>
+            <itemPath>../../MAVLink/include/matrixpilot/mavlink_msg_serial_udb_extra_f2_b.h</itemPath>
+            <itemPath>../../MAVLink/include/matrixpilot/mavlink_msg_serial_udb_extra_f4.h</itemPath>
+            <itemPath>../../MAVLink/include/matrixpilot/mavlink_msg_serial_udb_extra_f5.h</itemPath>
+            <itemPath>../../MAVLink/include/matrixpilot/mavlink_msg_serial_udb_extra_f6.h</itemPath>
+            <itemPath>../../MAVLink/include/matrixpilot/mavlink_msg_serial_udb_extra_f7.h</itemPath>
+            <itemPath>../../MAVLink/include/matrixpilot/mavlink_msg_serial_udb_extra_f8.h</itemPath>
+            <itemPath>../../MAVLink/include/matrixpilot/testsuite.h</itemPath>
+            <itemPath>../../MAVLink/include/matrixpilot/version.h</itemPath>
+          </logicalFolder>
+          <itemPath>../../MAVLink/include/checksum.h</itemPath>
+          <itemPath>../../MAVLink/include/inttypes.h</itemPath>
+          <itemPath>../../MAVLink/include/matrixpilot_mavlink_bridge_header.h</itemPath>
+          <itemPath>../../MAVLink/include/mavlink_conversions.h</itemPath>
+          <itemPath>../../MAVLink/include/mavlink_helpers.h</itemPath>
+          <itemPath>../../MAVLink/include/mavlink_types.h</itemPath>
+          <itemPath>../../MAVLink/include/protocol.h</itemPath>
+        </logicalFolder>
         <itemPath>../../MAVLink/MAVFTP.h</itemPath>
       </logicalFolder>
-      <logicalFolder name="libDCM" displayName="libDCM" projectFiles="true">
-        <itemPath>../../libDCM/dcmTypes.h</itemPath>
-        <itemPath>../../libDCM/deadReckoning.h</itemPath>
-        <itemPath>../../libDCM/estAltitude.h</itemPath>
-        <itemPath>../../libDCM/estLocation.h</itemPath>
-        <itemPath>../../libDCM/estWind.h</itemPath>
-        <itemPath>../../libDCM/estYawDrift.h</itemPath>
-        <itemPath>../../libDCM/gpsData.h</itemPath>
-        <itemPath>../../libDCM/gpsParseCommon.h</itemPath>
-        <itemPath>../../libDCM/libDCM.h</itemPath>
-        <itemPath>../../libDCM/libDCM_defines.h</itemPath>
-        <itemPath>../../libDCM/libDCM_internal.h</itemPath>
-        <itemPath>../../libDCM/mag_drift.h</itemPath>
-        <itemPath>../../libDCM/mathlib.h</itemPath>
-        <itemPath>../../libDCM/mathlibNAV.h</itemPath>
-        <itemPath>../../libDCM/rmat.h</itemPath>
-      </logicalFolder>
-      <logicalFolder name="libUDB" displayName="libUDB" projectFiles="true">
-        <itemPath>../../libUDB/ADchannel.h</itemPath>
-        <itemPath>../../libUDB/analogs.h</itemPath>
-        <itemPath>../../libUDB/barometer.h</itemPath>
-        <itemPath>../../libUDB/boardRotation_defines.h</itemPath>
-        <itemPath>../../libUDB/builtins.h</itemPath>
-        <itemPath>../../libUDB/ConfigAUAV3.h</itemPath>
-        <itemPath>../../libUDB/ConfigHILSIM.h</itemPath>
-        <itemPath>../../libUDB/ConfigPX4.h</itemPath>
-        <itemPath>../../libUDB/ConfigUDB4.h</itemPath>
-        <itemPath>../../libUDB/ConfigUDB5.h</itemPath>
-        <itemPath>../../libUDB/eeprom_udb4.h</itemPath>
-        <itemPath>../../libUDB/events.h</itemPath>
-        <itemPath>../../libUDB/fixDeps.h</itemPath>
-        <itemPath>../../libUDB/heartbeat.h</itemPath>
-        <itemPath>../../libUDB/I2C.h</itemPath>
-        <itemPath>../../libUDB/interrupt.h</itemPath>
-        <itemPath>../../libUDB/libUDB.h</itemPath>
-        <itemPath>../../libUDB/libUDB_defines.h</itemPath>
-        <itemPath>../../libUDB/libUDB_internal.h</itemPath>
-        <itemPath>../../libUDB/magnetometer.h</itemPath>
-        <itemPath>../../libUDB/mcu.h</itemPath>
-        <itemPath>../../libUDB/mpu6000.h</itemPath>
-        <itemPath>../../libUDB/mpu_spi.h</itemPath>
-        <itemPath>../../libUDB/NV_memory.h</itemPath>
-        <itemPath>../../libUDB/oscillator.h</itemPath>
-        <itemPath>../../libUDB/osd.h</itemPath>
-        <itemPath>../../libUDB/radioIn.h</itemPath>
-        <itemPath>../../libUDB/serialIO.h</itemPath>
-        <itemPath>../../libUDB/servoOut.h</itemPath>
-        <itemPath>../../libUDB/sonarIn.h</itemPath>
-        <itemPath>../../libUDB/uart.h</itemPath>
-        <itemPath>../../libUDB/udbTypes.h</itemPath>
-      </logicalFolder>
-      <logicalFolder name="libVectorMatrix" displayName="libVectorMatrix" projectFiles="true">
-        <itemPath>../../libVectorMatrix/dspcommon.inc</itemPath>
-      </logicalFolder>
-      <logicalFolder name="libFlashFS" displayName="libFlashFS" projectFiles="true">
-        <itemPath>../../libFlashFS/AT45D.h</itemPath>
-        <itemPath>../../libFlashFS/EEPROM.h</itemPath>
-        <itemPath>../../libFlashFS/filesys.h</itemPath>
-        <itemPath>../../libFlashFS/MDD_AT45D.h</itemPath>
-        <itemPath>../../libFlashFS/MDD_EEPROM.h</itemPath>
-      </logicalFolder>
       <logicalFolder name="Microchip" displayName="Microchip" projectFiles="true">
+        <logicalFolder name="Include" displayName="Include" projectFiles="true">
+          <logicalFolder name="MDD-File-System"
+                         displayName="MDD-File-System"
+                         projectFiles="true">
+            <itemPath>../../Microchip/Include/MDD-File-System/FSDefs.h</itemPath>
+            <itemPath>../../Microchip/Include/MDD-File-System/FSIO.h</itemPath>
+            <itemPath>../../Microchip/Include/MDD-File-System/SD-SPI.h</itemPath>
+          </logicalFolder>
+          <logicalFolder name="USB" displayName="USB" projectFiles="true">
+            <itemPath>../../Microchip/Include/USB/usb.h</itemPath>
+            <itemPath>../../Microchip/Include/USB/usb_ch9.h</itemPath>
+            <itemPath>../../Microchip/Include/USB/usb_common.h</itemPath>
+            <itemPath>../../Microchip/Include/USB/usb_device.h</itemPath>
+            <itemPath>../../Microchip/Include/USB/usb_function_cdc.h</itemPath>
+            <itemPath>../../Microchip/Include/USB/usb_function_msd.h</itemPath>
+            <itemPath>../../Microchip/Include/USB/usb_hal.h</itemPath>
+            <itemPath>../../Microchip/Include/USB/usb_hal_dspic33E.h</itemPath>
+          </logicalFolder>
+          <itemPath>../../Microchip/Include/Compiler.h</itemPath>
+          <itemPath>../../Microchip/Include/GenericTypeDefs.h</itemPath>
+        </logicalFolder>
+        <logicalFolder name="USB" displayName="USB" projectFiles="true">
+          <itemPath>../../Microchip/USB/usb_device_local.h</itemPath>
+        </logicalFolder>
         <itemPath>../../Microchip/HardwareProfile.h</itemPath>
-      <logicalFolder name="Include" displayName="Include" projectFiles="true">
-        <itemPath>../../Microchip/Include/Compiler.h</itemPath>
-        <itemPath>../../Microchip/Include/GenericTypeDefs.h</itemPath>
-      <logicalFolder name="MDD-File-System" displayName="MDD-File-System" projectFiles="true">
-        <itemPath>../../Microchip/Include/MDD-File-System/FSDefs.h</itemPath>
-        <itemPath>../../Microchip/Include/MDD-File-System/FSIO.h</itemPath>
-        <itemPath>../../Microchip/Include/MDD-File-System/SD-SPI.h</itemPath>
-      </logicalFolder>
-      <logicalFolder name="USB" displayName="USB" projectFiles="true">
-        <itemPath>../../Microchip/Include/USB/usb.h</itemPath>
-        <itemPath>../../Microchip/Include/USB/usb_ch9.h</itemPath>
-        <itemPath>../../Microchip/Include/USB/usb_common.h</itemPath>
-        <itemPath>../../Microchip/Include/USB/usb_device.h</itemPath>
-        <itemPath>../../Microchip/Include/USB/usb_function_cdc.h</itemPath>
-        <itemPath>../../Microchip/Include/USB/usb_function_msd.h</itemPath>
-        <itemPath>../../Microchip/Include/USB/usb_hal.h</itemPath>
-        <itemPath>../../Microchip/Include/USB/usb_hal_dspic33E.h</itemPath>
-      </logicalFolder>
-      </logicalFolder>
         <itemPath>../../Microchip/NetConfig.h</itemPath>
         <itemPath>../../Microchip/Sockets.h</itemPath>
-      <logicalFolder name="USB" displayName="USB" projectFiles="true">
-        <itemPath>../../Microchip/USB/usb_device_local.h</itemPath>
-      </logicalFolder>
         <itemPath>../../Microchip/usb_cdc.h</itemPath>
         <itemPath>../../Microchip/usb_config.h</itemPath>
       </logicalFolder>
-</logicalFolder>
-    <logicalFolder name="LinkerScript" displayName="Linker Files"
-    projectFiles="true"></logicalFolder>
-    <logicalFolder name="SourceFiles" displayName="Source Files"
-    projectFiles="true">      <logicalFolder name="MatrixPilot" displayName="MatrixPilot" projectFiles="true">
+    </logicalFolder>
+    <logicalFolder name="LinkerScript"
+                   displayName="Linker Files"
+                   projectFiles="true">
+    </logicalFolder>
+    <logicalFolder name="SourceFiles"
+                   displayName="Source Files"
+                   projectFiles="true">
+      <logicalFolder name="libDCM" displayName="libDCM" projectFiles="true">
+        <itemPath>../../libDCM/deadReckoning.c</itemPath>
+        <itemPath>../../libDCM/estAirspeed.c</itemPath>
+        <itemPath>../../libDCM/estAltitude.c</itemPath>
+        <itemPath>../../libDCM/estLocation.c</itemPath>
+        <itemPath>../../libDCM/estWind.c</itemPath>
+        <itemPath>../../libDCM/estYawDrift.c</itemPath>
+        <itemPath>../../libDCM/gpsData.c</itemPath>
+        <itemPath>../../libDCM/gpsParseCommon.c</itemPath>
+        <itemPath>../../libDCM/gpsParseMTEK.c</itemPath>
+        <itemPath>../../libDCM/gpsParseNMEA.c</itemPath>
+        <itemPath>../../libDCM/gpsParseSTD.c</itemPath>
+        <itemPath>../../libDCM/gpsParseUBX.c</itemPath>
+        <itemPath>../../libDCM/hilsim.c</itemPath>
+        <itemPath>../../libDCM/libDCM.c</itemPath>
+        <itemPath>../../libDCM/mag_drift.c</itemPath>
+        <itemPath>../../libDCM/mathlib.c</itemPath>
+        <itemPath>../../libDCM/mathlibNAV.c</itemPath>
+        <itemPath>../../libDCM/rmat.c</itemPath>
+      </logicalFolder>
+      <logicalFolder name="libFlashFS" displayName="libFlashFS" projectFiles="true">
+        <itemPath>../../libFlashFS/AT45D.c</itemPath>
+        <itemPath>../../libFlashFS/AT45D_DMA.c</itemPath>
+        <itemPath>../../libFlashFS/AT45D_FS.c</itemPath>
+        <itemPath>../../libFlashFS/EEPROM.c</itemPath>
+        <itemPath>../../libFlashFS/EEPROM_FS.c</itemPath>
+        <itemPath>../../libFlashFS/filesys.c</itemPath>
+        <itemPath>../../libFlashFS/MDD_AT45D.c</itemPath>
+        <itemPath>../../libFlashFS/MDD_EEPROM.c</itemPath>
+        <itemPath>../../libFlashFS/usb.c</itemPath>
+        <itemPath>../../libFlashFS/usb_cdc.c</itemPath>
+        <itemPath>../../libFlashFS/usb_descriptors.c</itemPath>
+        <itemPath>../../libFlashFS/usb_msd.c</itemPath>
+      </logicalFolder>
+      <logicalFolder name="libUDB" displayName="libUDB" projectFiles="true">
+        <itemPath>../../libUDB/24LC256.c</itemPath>
+        <itemPath>../../libUDB/ADchannel.c</itemPath>
+        <itemPath>../../libUDB/analog2digital_auav3.c</itemPath>
+        <itemPath>../../libUDB/analog2digital_udb4.c</itemPath>
+        <itemPath>../../libUDB/analog2digital_udb5.c</itemPath>
+        <itemPath>../../libUDB/analogs.c</itemPath>
+        <itemPath>../../libUDB/background.c</itemPath>
+        <itemPath>../../libUDB/barometer.c</itemPath>
+        <itemPath>../../libUDB/eeprom_udb4.c</itemPath>
+        <itemPath>../../libUDB/events.c</itemPath>
+        <itemPath>../../libUDB/fbcl.s</itemPath>
+        <itemPath>../../libUDB/heartbeat.c</itemPath>
+        <itemPath>../../libUDB/I2C1.c</itemPath>
+        <itemPath>../../libUDB/I2C2.c</itemPath>
+        <itemPath>../../libUDB/libUDB.c</itemPath>
+        <itemPath>../../libUDB/magnetometer.c</itemPath>
+        <itemPath>../../libUDB/mcu.c</itemPath>
+        <itemPath>../../libUDB/mpu6000.c</itemPath>
+        <itemPath>../../libUDB/mpu_spi.c</itemPath>
+        <itemPath>../../libUDB/osd.c</itemPath>
+        <itemPath>../../libUDB/osd_bit.c</itemPath>
+        <itemPath>../../libUDB/osd_spi.c</itemPath>
+        <itemPath>../../libUDB/radioIn.c</itemPath>
+        <itemPath>../../libUDB/read.c</itemPath>
+        <itemPath>../../libUDB/serialIO.c</itemPath>
+        <itemPath>../../libUDB/servoOut.c</itemPath>
+        <itemPath>../../libUDB/sonarIn.c</itemPath>
+        <itemPath>../../libUDB/traps.c</itemPath>
+        <itemPath>../../libUDB/traps_asm.s</itemPath>
+        <itemPath>../../libUDB/uart.c</itemPath>
+        <itemPath>../../libUDB/write.c</itemPath>
+      </logicalFolder>
+      <logicalFolder name="libVectorMatrix"
+                     displayName="libVectorMatrix"
+                     projectFiles="true">
+        <itemPath>../../libVectorMatrix/madd.s</itemPath>
+        <itemPath>../../libVectorMatrix/mmul.s</itemPath>
+        <itemPath>../../libVectorMatrix/mscl.s</itemPath>
+        <itemPath>../../libVectorMatrix/msub.s</itemPath>
+        <itemPath>../../libVectorMatrix/mtrp.s</itemPath>
+        <itemPath>../../libVectorMatrix/vadd.s</itemPath>
+        <itemPath>../../libVectorMatrix/vcon.s</itemPath>
+        <itemPath>../../libVectorMatrix/vcopy.s</itemPath>
+        <itemPath>../../libVectorMatrix/vcor.s</itemPath>
+        <itemPath>../../libVectorMatrix/vdot.s</itemPath>
+        <itemPath>../../libVectorMatrix/vmax.s</itemPath>
+        <itemPath>../../libVectorMatrix/vmin.s</itemPath>
+        <itemPath>../../libVectorMatrix/vmul.s</itemPath>
+        <itemPath>../../libVectorMatrix/vneg.s</itemPath>
+        <itemPath>../../libVectorMatrix/vpow.s</itemPath>
+        <itemPath>../../libVectorMatrix/vscl.s</itemPath>
+        <itemPath>../../libVectorMatrix/vsub.s</itemPath>
+        <itemPath>../../libVectorMatrix/vzpad.s</itemPath>
+      </logicalFolder>
+      <logicalFolder name="MatrixPilot" displayName="MatrixPilot" projectFiles="true">
         <itemPath>../../MatrixPilot/airspeedCntrl.c</itemPath>
         <itemPath>../../MatrixPilot/altitudeCntrl.c</itemPath>
         <itemPath>../../MatrixPilot/altitudeCntrlVariable.c</itemPath>
@@ -403,117 +503,37 @@
         <itemPath>../../MatrixPilot/yawCntrl.c</itemPath>
       </logicalFolder>
       <logicalFolder name="MAVLink" displayName="MAVLink" projectFiles="true">
-      <logicalFolder name="include" displayName="include" projectFiles="true">
-        <itemPath>../../MAVLink/include/bittest.c</itemPath>
-      </logicalFolder>
+        <logicalFolder name="include" displayName="include" projectFiles="true">
+          <itemPath>../../MAVLink/include/bittest.c</itemPath>
+        </logicalFolder>
         <itemPath>../../MAVLink/MAVFTP.c</itemPath>
       </logicalFolder>
-      <logicalFolder name="libDCM" displayName="libDCM" projectFiles="true">
-        <itemPath>../../libDCM/deadReckoning.c</itemPath>
-        <itemPath>../../libDCM/estAirspeed.c</itemPath>
-        <itemPath>../../libDCM/estAltitude.c</itemPath>
-        <itemPath>../../libDCM/estLocation.c</itemPath>
-        <itemPath>../../libDCM/estWind.c</itemPath>
-        <itemPath>../../libDCM/estYawDrift.c</itemPath>
-        <itemPath>../../libDCM/gpsData.c</itemPath>
-        <itemPath>../../libDCM/gpsParseCommon.c</itemPath>
-        <itemPath>../../libDCM/gpsParseMTEK.c</itemPath>
-        <itemPath>../../libDCM/gpsParseNMEA.c</itemPath>
-        <itemPath>../../libDCM/gpsParseSTD.c</itemPath>
-        <itemPath>../../libDCM/gpsParseUBX.c</itemPath>
-        <itemPath>../../libDCM/hilsim.c</itemPath>
-        <itemPath>../../libDCM/libDCM.c</itemPath>
-        <itemPath>../../libDCM/mag_drift.c</itemPath>
-        <itemPath>../../libDCM/mathlib.c</itemPath>
-        <itemPath>../../libDCM/mathlibNAV.c</itemPath>
-        <itemPath>../../libDCM/rmat.c</itemPath>
-      </logicalFolder>
-      <logicalFolder name="libUDB" displayName="libUDB" projectFiles="true">
-        <itemPath>../../libUDB/24LC256.c</itemPath>
-        <itemPath>../../libUDB/ADchannel.c</itemPath>
-        <itemPath>../../libUDB/analog2digital_auav3.c</itemPath>
-        <itemPath>../../libUDB/analog2digital_udb4.c</itemPath>
-        <itemPath>../../libUDB/analog2digital_udb5.c</itemPath>
-        <itemPath>../../libUDB/analogs.c</itemPath>
-        <itemPath>../../libUDB/background.c</itemPath>
-        <itemPath>../../libUDB/barometer.c</itemPath>
-        <itemPath>../../libUDB/eeprom_udb4.c</itemPath>
-        <itemPath>../../libUDB/events.c</itemPath>
-        <itemPath>../../libUDB/fbcl.s</itemPath>
-        <itemPath>../../libUDB/heartbeat.c</itemPath>
-        <itemPath>../../libUDB/I2C1.c</itemPath>
-        <itemPath>../../libUDB/I2C2.c</itemPath>
-        <itemPath>../../libUDB/libUDB.c</itemPath>
-        <itemPath>../../libUDB/magnetometer.c</itemPath>
-        <itemPath>../../libUDB/mcu.c</itemPath>
-        <itemPath>../../libUDB/mpu6000.c</itemPath>
-        <itemPath>../../libUDB/mpu_spi.c</itemPath>
-        <itemPath>../../libUDB/osd.c</itemPath>
-        <itemPath>../../libUDB/osd_bit.c</itemPath>
-        <itemPath>../../libUDB/osd_spi.c</itemPath>
-        <itemPath>../../libUDB/radioIn.c</itemPath>
-        <itemPath>../../libUDB/read.c</itemPath>
-        <itemPath>../../libUDB/serialIO.c</itemPath>
-        <itemPath>../../libUDB/servoOut.c</itemPath>
-        <itemPath>../../libUDB/sonarIn.c</itemPath>
-        <itemPath>../../libUDB/traps.c</itemPath>
-        <itemPath>../../libUDB/traps_asm.s</itemPath>
-        <itemPath>../../libUDB/uart.c</itemPath>
-        <itemPath>../../libUDB/write.c</itemPath>
-      </logicalFolder>
-      <logicalFolder name="libVectorMatrix" displayName="libVectorMatrix" projectFiles="true">
-        <itemPath>../../libVectorMatrix/madd.s</itemPath>
-        <itemPath>../../libVectorMatrix/mmul.s</itemPath>
-        <itemPath>../../libVectorMatrix/mscl.s</itemPath>
-        <itemPath>../../libVectorMatrix/msub.s</itemPath>
-        <itemPath>../../libVectorMatrix/mtrp.s</itemPath>
-        <itemPath>../../libVectorMatrix/vadd.s</itemPath>
-        <itemPath>../../libVectorMatrix/vcon.s</itemPath>
-        <itemPath>../../libVectorMatrix/vcopy.s</itemPath>
-        <itemPath>../../libVectorMatrix/vcor.s</itemPath>
-        <itemPath>../../libVectorMatrix/vdot.s</itemPath>
-        <itemPath>../../libVectorMatrix/vmax.s</itemPath>
-        <itemPath>../../libVectorMatrix/vmin.s</itemPath>
-        <itemPath>../../libVectorMatrix/vmul.s</itemPath>
-        <itemPath>../../libVectorMatrix/vneg.s</itemPath>
-        <itemPath>../../libVectorMatrix/vpow.s</itemPath>
-        <itemPath>../../libVectorMatrix/vscl.s</itemPath>
-        <itemPath>../../libVectorMatrix/vsub.s</itemPath>
-        <itemPath>../../libVectorMatrix/vzpad.s</itemPath>
-      </logicalFolder>
-      <logicalFolder name="libFlashFS" displayName="libFlashFS" projectFiles="true">
-        <itemPath>../../libFlashFS/AT45D.c</itemPath>
-        <itemPath>../../libFlashFS/AT45D_DMA.c</itemPath>
-        <itemPath>../../libFlashFS/AT45D_FS.c</itemPath>
-        <itemPath>../../libFlashFS/EEPROM.c</itemPath>
-        <itemPath>../../libFlashFS/EEPROM_FS.c</itemPath>
-        <itemPath>../../libFlashFS/filesys.c</itemPath>
-        <itemPath>../../libFlashFS/MDD_AT45D.c</itemPath>
-        <itemPath>../../libFlashFS/MDD_EEPROM.c</itemPath>
-        <itemPath>../../libFlashFS/usb.c</itemPath>
-        <itemPath>../../libFlashFS/usb_cdc.c</itemPath>
-        <itemPath>../../libFlashFS/usb_descriptors.c</itemPath>
-        <itemPath>../../libFlashFS/usb_msd.c</itemPath>
-      </logicalFolder>
       <logicalFolder name="Microchip" displayName="Microchip" projectFiles="true">
-      <logicalFolder name="MDD-File-System" displayName="MDD-File-System" projectFiles="true">
-        <itemPath>../../Microchip/MDD-File-System/FSIO.c</itemPath>
-        <itemPath>../../Microchip/MDD-File-System/SD-SPI.c</itemPath>
+        <logicalFolder name="MDD-File-System"
+                       displayName="MDD-File-System"
+                       projectFiles="true">
+          <itemPath>../../Microchip/MDD-File-System/FSIO.c</itemPath>
+          <itemPath>../../Microchip/MDD-File-System/SD-SPI.c</itemPath>
+        </logicalFolder>
+        <logicalFolder name="USB" displayName="USB" projectFiles="true">
+          <logicalFolder name="CDC-Device-Driver"
+                         displayName="CDC-Device-Driver"
+                         projectFiles="true">
+            <itemPath>../../Microchip/USB/CDC-Device-Driver/usb_function_cdc.c</itemPath>
+          </logicalFolder>
+          <logicalFolder name="MSD-Device-Driver"
+                         displayName="MSD-Device-Driver"
+                         projectFiles="true">
+            <itemPath>../../Microchip/USB/MSD-Device-Driver/usb_function_msd.c</itemPath>
+          </logicalFolder>
+          <itemPath>../../Microchip/USB/usb_device.c</itemPath>
+          <itemPath>../../Microchip/USB/usb_hal_dspic33e.c</itemPath>
+        </logicalFolder>
       </logicalFolder>
-      <logicalFolder name="USB" displayName="USB" projectFiles="true">
-      <logicalFolder name="CDC-Device-Driver" displayName="CDC-Device-Driver" projectFiles="true">
-        <itemPath>../../Microchip/USB/CDC-Device-Driver/usb_function_cdc.c</itemPath>
-      </logicalFolder>
-      <logicalFolder name="MSD-Device-Driver" displayName="MSD-Device-Driver" projectFiles="true">
-        <itemPath>../../Microchip/USB/MSD-Device-Driver/usb_function_msd.c</itemPath>
-      </logicalFolder>
-        <itemPath>../../Microchip/USB/usb_device.c</itemPath>
-        <itemPath>../../Microchip/USB/usb_hal_dspic33e.c</itemPath>
-      </logicalFolder>
-      </logicalFolder>
-</logicalFolder>
+    </logicalFolder>
     <logicalFolder name="ExternalFiles"
-    displayName="Important Files" projectFiles="false">
+                   displayName="Important Files"
+                   projectFiles="false">
       <itemPath>Makefile</itemPath>
     </logicalFolder>
   </logicalFolder>
@@ -534,149 +554,255 @@
         <targetPluginBoard></targetPluginBoard>
         <platformTool>PICkit3PlatformTool</platformTool>
         <languageToolchain>XC16</languageToolchain>
-        <languageToolchainVersion>1.10</languageToolchainVersion>
-        <platform>3</platform>
+        <languageToolchainVersion>1.26</languageToolchainVersion>
+        <platform>4</platform>
       </toolsSet>
       <compileType>
         <linkerTool>
-          <linkerLibItems></linkerLibItems>
+          <linkerLibItems>
+          </linkerLibItems>
         </linkerTool>
+        <archiverTool>
+        </archiverTool>
         <loading>
-          <useAlternateLoadableFile>
-          false</useAlternateLoadableFile>
+          <useAlternateLoadableFile>false</useAlternateLoadableFile>
+          <parseOnProdLoad>false</parseOnProdLoad>
           <alternateLoadableFile></alternateLoadableFile>
         </loading>
       </compileType>
       <makeCustomizationType>
-        <makeCustomizationPreStepEnabled>
-        false</makeCustomizationPreStepEnabled>
+        <makeCustomizationPreStepEnabled>false</makeCustomizationPreStepEnabled>
         <makeCustomizationPreStep></makeCustomizationPreStep>
-        <makeCustomizationPostStepEnabled>
-        false</makeCustomizationPostStepEnabled>
+        <makeCustomizationPostStepEnabled>false</makeCustomizationPostStepEnabled>
         <makeCustomizationPostStep></makeCustomizationPostStep>
-        <makeCustomizationPutChecksumInUserID>
-        false</makeCustomizationPutChecksumInUserID>
-        <makeCustomizationEnableLongLines>
-        false</makeCustomizationEnableLongLines>
-        <makeCustomizationNormalizeHexFile>
-        false</makeCustomizationNormalizeHexFile>
+        <makeCustomizationPutChecksumInUserID>false</makeCustomizationPutChecksumInUserID>
+        <makeCustomizationEnableLongLines>false</makeCustomizationEnableLongLines>
+        <makeCustomizationNormalizeHexFile>false</makeCustomizationNormalizeHexFile>
       </makeCustomizationType>
       <C30>
-        <property key="code-model" value="large-code" />
-        <property key="const-model" value="default" />
-        <property key="data-model" value="large-data" />
-        <property key="enable-all-warnings" value="true" />
-        <property key="enable-ansi-std" value="false" />
-        <property key="enable-ansi-warnings" value="false" />
-        <property key="enable-fatal-warnings" value="false" />
-        <property key="enable-large-arrays" value="false" />
-        <property key="enable-omit-frame-pointer" value="false" />
-        <property key="enable-procedural-abstraction"
-        value="false" />
-        <property key="enable-short-double" value="false" />
-        <property key="enable-symbols" value="true" />
-        <property key="enable-unroll-loops" value="false" />
+        <property key="code-model" value="large-code"/>
+        <property key="const-model" value="default"/>
+        <property key="data-model" value="large-data"/>
+        <property key="disable-instruction-scheduling" value="false"/>
+        <property key="enable-all-warnings" value="true"/>
+        <property key="enable-ansi-std" value="false"/>
+        <property key="enable-ansi-warnings" value="false"/>
+        <property key="enable-fatal-warnings" value="false"/>
+        <property key="enable-large-arrays" value="false"/>
+        <property key="enable-omit-frame-pointer" value="false"/>
+        <property key="enable-procedural-abstraction" value="false"/>
+        <property key="enable-short-double" value="false"/>
+        <property key="enable-symbols" value="true"/>
+        <property key="enable-unroll-loops" value="false"/>
         <property key="extra-include-directories"
-        value="../../Config;../../MAVLink/include;../../Microchip;../../Microchip/Include;../../libVectorMatrix" />
-        <property key="isolate-each-function" value="false" />
-        <property key="keep-inline" value="false" />
-        <property key="oXC16gcc-align-arr" value="false" />
-        <property key="oXC16gcc-cnsts-mauxflash" value="false" />
-        <property key="oXC16gcc-data-sects" value="false" />
-        <property key="oXC16gcc-errata" value="" />
-        <property key="oXC16gcc-fillupper" value="" />
-        <property key="oXC16gcc-large-aggregate" value="false" />
-        <property key="oXC16gcc-mauxflash" value="false" />
-        <property key="oXC16gcc-mpa-lvl" value="" />
-        <property key="oXC16gcc-name-text-sec" value="" />
-        <property key="oXC16gcc-near-chars" value="false" />
-        <property key="oXC16gcc-no-isr-warn" value="false" />
-        <property key="oXC16gcc-sfr-warn" value="false" />
-        <property key="oXC16gcc-smar-io-lvl" value="1" />
-        <property key="oXC16gcc-smart-io-fmt" value="" />
-        <property key="optimization-level" value="0" />
-        <property key="post-instruction-scheduling"
-        value="default" />
-        <property key="pre-instruction-scheduling"
-        value="default" />
-        <property key="preprocessor-macros"
-        value="AUAV3=1;" />
-        <property key="scalar-model" value="default" />
-        <property key="use-cci" value="false" />
+                  value="../../Config;../../MAVLink/include;../../Microchip;../../Microchip/Include;../../libVectorMatrix"/>
+        <property key="isolate-each-function" value="false"/>
+        <property key="keep-inline" value="false"/>
+        <property key="oXC16gcc-align-arr" value="false"/>
+        <property key="oXC16gcc-cnsts-mauxflash" value="false"/>
+        <property key="oXC16gcc-data-sects" value="false"/>
+        <property key="oXC16gcc-errata" value=""/>
+        <property key="oXC16gcc-fillupper" value=""/>
+        <property key="oXC16gcc-large-aggregate" value="false"/>
+        <property key="oXC16gcc-mauxflash" value="false"/>
+        <property key="oXC16gcc-mpa-lvl" value=""/>
+        <property key="oXC16gcc-name-text-sec" value=""/>
+        <property key="oXC16gcc-near-chars" value="false"/>
+        <property key="oXC16gcc-no-isr-warn" value="false"/>
+        <property key="oXC16gcc-sfr-warn" value="false"/>
+        <property key="oXC16gcc-smar-io-lvl" value="1"/>
+        <property key="oXC16gcc-smart-io-fmt" value=""/>
+        <property key="optimization-level" value="0"/>
+        <property key="post-instruction-scheduling" value="default"/>
+        <property key="pre-instruction-scheduling" value="default"/>
+        <property key="preprocessor-macros" value="AUAV3=1"/>
+        <property key="scalar-model" value="default"/>
+        <property key="use-cci" value="false"/>
+        <property key="use-iar" value="false"/>
       </C30>
+      <C30-AR>
+        <property key="additional-options-chop-files" value="false"/>
+      </C30-AR>
       <C30-AS>
-        <property key="assembler-symbols" value="PSV_ERRATA=1" />
-        <property key="expand-macros" value="false" />
+        <property key="assembler-symbols" value="PSV_ERRATA=1"/>
+        <property key="expand-macros" value="false"/>
         <property key="extra-include-directories-for-assembler"
-        value="..;../../libVectorMatrix" />
-        <property key="extra-include-directories-for-preprocessor"
-        value="" />
-        <property key="false-conditionals" value="false" />
-        <property key="keep-locals" value="false" />
-        <property key="list-assembly" value="false" />
-        <property key="list-section-info" value="false" />
-        <property key="list-source" value="false" />
-        <property key="list-symbols" value="false" />
-        <property key="oXC16asm-extra-opts" value="" />
-        <property key="oXC16asm-list-to-file" value="false" />
-        <property key="omit-debug-dirs" value="false" />
-        <property key="omit-forms" value="false" />
-        <property key="preprocessor-macros" value="" />
-        <property key="relax" value="false" />
-        <property key="warning-level" value="emit-warnings" />
-        <appendMe value="-g" />
+                  value="..;../../libVectorMatrix"/>
+        <property key="extra-include-directories-for-preprocessor" value=""/>
+        <property key="false-conditionals" value="false"/>
+        <property key="keep-locals" value="false"/>
+        <property key="list-assembly" value="false"/>
+        <property key="list-section-info" value="false"/>
+        <property key="list-source" value="false"/>
+        <property key="list-symbols" value="false"/>
+        <property key="oXC16asm-extra-opts" value=""/>
+        <property key="oXC16asm-list-to-file" value="false"/>
+        <property key="omit-debug-dirs" value="false"/>
+        <property key="omit-forms" value="false"/>
+        <property key="preprocessor-macros" value=""/>
+        <property key="relax" value="false"/>
+        <property key="warning-level" value="emit-warnings"/>
+        <appendMe value="-g"/>
       </C30-AS>
       <C30-LD>
-        <property key="additional-options-use-response-files"
-        value="false" />
-        <property key="boot-eeprom" value="no_eeprom" />
-        <property key="boot-flash" value="no_flash" />
-        <property key="boot-ram" value="no_ram" />
-        <property key="boot-write-protect"
-        value="no_write_protect" />
-        <property key="enable-check-sections" value="false" />
-        <property key="enable-data-init" value="true" />
-        <property key="enable-default-isr" value="true" />
-        <property key="enable-handles" value="true" />
-        <property key="enable-pack-data" value="true" />
-        <property key="extra-lib-directories" value="" />
-        <property key="general-code-protect"
-        value="no_code_protect" />
-        <property key="general-write-protect"
-        value="no_write_protect" />
-        <property key="generate-cross-reference-file"
-        value="false" />
-        <property key="heap-size" value="256" />
-        <property key="input-libraries" value="" />
-        <property key="linker-symbols" value="" />
+        <property key="additional-options-use-response-files" value="false"/>
+        <property key="boot-eeprom" value="no_eeprom"/>
+        <property key="boot-flash" value="no_flash"/>
+        <property key="boot-ram" value="no_ram"/>
+        <property key="boot-write-protect" value="no_write_protect"/>
+        <property key="enable-check-sections" value="false"/>
+        <property key="enable-data-init" value="true"/>
+        <property key="enable-default-isr" value="true"/>
+        <property key="enable-handles" value="true"/>
+        <property key="enable-pack-data" value="true"/>
+        <property key="extra-lib-directories" value=""/>
+        <property key="fill-flash-options-addr" value=""/>
+        <property key="fill-flash-options-const" value=""/>
+        <property key="fill-flash-options-how" value="0"/>
+        <property key="fill-flash-options-inc-const" value="1"/>
+        <property key="fill-flash-options-increment" value=""/>
+        <property key="fill-flash-options-seq" value=""/>
+        <property key="fill-flash-options-what" value="0"/>
+        <property key="general-code-protect" value="no_code_protect"/>
+        <property key="general-write-protect" value="no_write_protect"/>
+        <property key="generate-cross-reference-file" value="false"/>
+        <property key="heap-size" value="256"/>
+        <property key="input-libraries" value=""/>
+        <property key="linker-stack" value="true"/>
+        <property key="linker-symbols" value=""/>
         <property key="map-file"
-        value="&quot;${DISTDIR}/MatrixPilot-AUAV3.X.${IMAGE_TYPE}.map&quot;" />
-        <property key="oXC16ld-extra-opts" value="" />
-        <property key="oXC16ld-fill-upper" value="0" />
-        <property key="oXC16ld-force-link" value="false" />
-        <property key="oXC16ld-no-smart-io" value="false" />
-        <property key="oXC16ld-nostdlib" value="false" />
-        <property key="oXC16ld-stackguard" value="16" />
-        <property key="preprocessor-macros" value="" />
-        <property key="remove-unused-sections" value="false" />
-        <property key="report-memory-usage" value="false" />
-        <property key="secure-eeprom" value="no_eeprom" />
-        <property key="secure-flash" value="no_flash" />
-        <property key="secure-ram" value="no_ram" />
-        <property key="secure-write-protect"
-        value="no_write_protect" />
-        <property key="stack-size" value="16" />
-        <property key="symbol-stripping" value="" />
-        <property key="trace-symbols" value="" />
-        <property key="warn-section-align" value="false" />
+                  value="&quot;${DISTDIR}/MatrixPilot-AUAV3.X.${IMAGE_TYPE}.map&quot;"/>
+        <property key="oXC16ld-extra-opts" value=""/>
+        <property key="oXC16ld-fill-upper" value="0"/>
+        <property key="oXC16ld-force-link" value="false"/>
+        <property key="oXC16ld-no-smart-io" value="false"/>
+        <property key="oXC16ld-nostdlib" value="false"/>
+        <property key="oXC16ld-stackguard" value="16"/>
+        <property key="preprocessor-macros" value=""/>
+        <property key="remove-unused-sections" value="false"/>
+        <property key="report-memory-usage" value="false"/>
+        <property key="secure-eeprom" value="no_eeprom"/>
+        <property key="secure-flash" value="no_flash"/>
+        <property key="secure-ram" value="no_ram"/>
+        <property key="secure-write-protect" value="no_write_protect"/>
+        <property key="stack-size" value="16"/>
+        <property key="symbol-stripping" value=""/>
+        <property key="trace-symbols" value=""/>
+        <property key="warn-section-align" value="false"/>
       </C30-LD>
       <C30Global>
-        <property key="fast-math" value="false" />
-        <property key="generic-16-bit" value="false" />
-        <property key="legacy-libc" value="true" />
-        <property key="oXC16glb-macros" value="" />
-        <property key="output-file-format" value="elf" />
+        <property key="common-include-directories" value=""/>
+        <property key="dual-boot-partition" value="0"/>
+        <property key="fast-math" value="false"/>
+        <property key="generic-16-bit" value="false"/>
+        <property key="legacy-libc" value="true"/>
+        <property key="oXC16glb-macros" value=""/>
+        <property key="output-file-format" value="elf"/>
+        <property key="relaxed-math" value="false"/>
+        <property key="save-temps" value="false"/>
       </C30Global>
+      <PICkit3PlatformTool>
+        <property key="ADC 1" value="true"/>
+        <property key="ADC 2" value="true"/>
+        <property key="AutoSelectMemRanges" value="auto"/>
+        <property key="COMPARATOR" value="true"/>
+        <property key="CRC" value="true"/>
+        <property key="DCI" value="true"/>
+        <property key="Freeze All Other Peripherals" value="true"/>
+        <property key="I2C1" value="true"/>
+        <property key="I2C2" value="true"/>
+        <property key="INPUT CAPTURE 1" value="true"/>
+        <property key="INPUT CAPTURE 10" value="true"/>
+        <property key="INPUT CAPTURE 11" value="true"/>
+        <property key="INPUT CAPTURE 12" value="true"/>
+        <property key="INPUT CAPTURE 13" value="true"/>
+        <property key="INPUT CAPTURE 14" value="true"/>
+        <property key="INPUT CAPTURE 15" value="true"/>
+        <property key="INPUT CAPTURE 16" value="true"/>
+        <property key="INPUT CAPTURE 2" value="true"/>
+        <property key="INPUT CAPTURE 3" value="true"/>
+        <property key="INPUT CAPTURE 4" value="true"/>
+        <property key="INPUT CAPTURE 5" value="true"/>
+        <property key="INPUT CAPTURE 6" value="true"/>
+        <property key="INPUT CAPTURE 7" value="true"/>
+        <property key="INPUT CAPTURE 8" value="true"/>
+        <property key="INPUT CAPTURE 9" value="true"/>
+        <property key="OUTPUT COMPARE 1" value="true"/>
+        <property key="OUTPUT COMPARE 10" value="true"/>
+        <property key="OUTPUT COMPARE 11" value="true"/>
+        <property key="OUTPUT COMPARE 12" value="true"/>
+        <property key="OUTPUT COMPARE 13" value="true"/>
+        <property key="OUTPUT COMPARE 14" value="true"/>
+        <property key="OUTPUT COMPARE 15" value="true"/>
+        <property key="OUTPUT COMPARE 16" value="true"/>
+        <property key="OUTPUT COMPARE 2" value="true"/>
+        <property key="OUTPUT COMPARE 3" value="true"/>
+        <property key="OUTPUT COMPARE 4" value="true"/>
+        <property key="OUTPUT COMPARE 5" value="true"/>
+        <property key="OUTPUT COMPARE 6" value="true"/>
+        <property key="OUTPUT COMPARE 7" value="true"/>
+        <property key="OUTPUT COMPARE 8" value="true"/>
+        <property key="OUTPUT COMPARE 9" value="true"/>
+        <property key="PARALLEL MASTER/SLAVE PORT" value="true"/>
+        <property key="PWM" value="true"/>
+        <property key="REAL TIME CLOCK AND CALENDAR" value="true"/>
+        <property key="SPI 1" value="true"/>
+        <property key="SPI 2" value="true"/>
+        <property key="SPI 3" value="true"/>
+        <property key="SPI 4" value="true"/>
+        <property key="SecureSegment.SegmentProgramming" value="FullChipProgramming"/>
+        <property key="TIMER1" value="true"/>
+        <property key="TIMER2" value="true"/>
+        <property key="TIMER3" value="true"/>
+        <property key="TIMER4" value="true"/>
+        <property key="TIMER5" value="true"/>
+        <property key="TIMER6" value="true"/>
+        <property key="TIMER7" value="true"/>
+        <property key="TIMER8" value="true"/>
+        <property key="TIMER9" value="true"/>
+        <property key="ToolFirmwareFilePath"
+                  value="Press to browse for a specific firmware version"/>
+        <property key="ToolFirmwareOption.UseLatestFirmware" value="true"/>
+        <property key="UART 1" value="true"/>
+        <property key="UART 2" value="true"/>
+        <property key="UART 3" value="true"/>
+        <property key="UART 4" value="true"/>
+        <property key="USB" value="true"/>
+        <property key="hwtoolclock.frcindebug" value="false"/>
+        <property key="memories.aux" value="false"/>
+        <property key="memories.bootflash" value="true"/>
+        <property key="memories.configurationmemory" value="true"/>
+        <property key="memories.configurationmemory2" value="true"/>
+        <property key="memories.dataflash" value="true"/>
+        <property key="memories.eeprom" value="true"/>
+        <property key="memories.flashdata" value="true"/>
+        <property key="memories.id" value="true"/>
+        <property key="memories.programmemory" value="true"/>
+        <property key="memories.programmemory.end" value="0x557ff"/>
+        <property key="memories.programmemory.partition2" value="true"/>
+        <property key="memories.programmemory.partition2.end"
+                  value="${memories.programmemory.partition2.end.value}"/>
+        <property key="memories.programmemory.partition2.start"
+                  value="${memories.programmemory.partition2.start.value}"/>
+        <property key="memories.programmemory.start" value="0x0"/>
+        <property key="poweroptions.powerenable" value="false"/>
+        <property key="programmertogo.imagename" value=""/>
+        <property key="programoptions.donoteraseauxmem" value="false"/>
+        <property key="programoptions.eraseb4program" value="true"/>
+        <property key="programoptions.pgmspeed" value="2"/>
+        <property key="programoptions.preservedataflash" value="false"/>
+        <property key="programoptions.preserveeeprom" value="false"/>
+        <property key="programoptions.preserveprogramrange" value="false"/>
+        <property key="programoptions.preserveprogramrange.end" value="0x557ff"/>
+        <property key="programoptions.preserveprogramrange.start" value="0x0"/>
+        <property key="programoptions.preserveuserid" value="false"/>
+        <property key="programoptions.programcalmem" value="false"/>
+        <property key="programoptions.programuserotp" value="false"/>
+        <property key="programoptions.testmodeentrymethod" value="VDDFirst"/>
+        <property key="programoptions.usehighvoltageonmclr" value="false"/>
+        <property key="programoptions.uselvpprogramming" value="false"/>
+        <property key="voltagevalue" value="3.25"/>
+      </PICkit3PlatformTool>
     </conf>
   </confs>
 </configurationDescriptor>

--- a/MatrixPilot/MatrixPilot-udb4.X/nbproject/configurations.xml
+++ b/MatrixPilot/MatrixPilot-udb4.X/nbproject/configurations.xml
@@ -1,24 +1,25 @@
-<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="UTF-8"?>
 <configurationDescriptor version="62">
-  <logicalFolder name="root" displayName="root"
-  projectFiles="true">
-    <logicalFolder name="HeaderFiles" displayName="Header Files"
-    projectFiles="true">      <logicalFolder name="Config" displayName="Config" projectFiles="true">
+  <logicalFolder name="root" displayName="root" projectFiles="true">
+    <logicalFolder name="HeaderFiles"
+                   displayName="Header Files"
+                   projectFiles="true">
+      <logicalFolder name="Config" displayName="Config" projectFiles="true">
+        <logicalFolder name="Cessna" displayName="Cessna" projectFiles="true">
+          <itemPath>../../Config/Cessna/airspeed_options.h</itemPath>
+          <itemPath>../../Config/Cessna/FSconfig.h</itemPath>
+          <itemPath>../../Config/Cessna/magnetometerOptions.h</itemPath>
+          <itemPath>../../Config/Cessna/mavlink_options.h</itemPath>
+          <itemPath>../../Config/Cessna/nv_memory_options.h</itemPath>
+          <itemPath>../../Config/Cessna/options.h</itemPath>
+          <itemPath>../../Config/Cessna/options_auav3.h</itemPath>
+          <itemPath>../../Config/Cessna/osd_config.h</itemPath>
+          <itemPath>../../Config/Cessna/ports_config.h</itemPath>
+        </logicalFolder>
+        <logicalFolder name="CloudsFly" displayName="CloudsFly" projectFiles="true">
+          <itemPath>../../Config/CloudsFly/options.h</itemPath>
+        </logicalFolder>
         <itemPath>../../Config/airspeed_options.h</itemPath>
-      <logicalFolder name="Cessna" displayName="Cessna" projectFiles="true">
-        <itemPath>../../Config/Cessna/airspeed_options.h</itemPath>
-        <itemPath>../../Config/Cessna/FSconfig.h</itemPath>
-        <itemPath>../../Config/Cessna/magnetometerOptions.h</itemPath>
-        <itemPath>../../Config/Cessna/mavlink_options.h</itemPath>
-        <itemPath>../../Config/Cessna/nv_memory_options.h</itemPath>
-        <itemPath>../../Config/Cessna/options.h</itemPath>
-        <itemPath>../../Config/Cessna/options_auav3.h</itemPath>
-        <itemPath>../../Config/Cessna/osd_config.h</itemPath>
-        <itemPath>../../Config/Cessna/ports_config.h</itemPath>
-      </logicalFolder>
-      <logicalFolder name="CloudsFly" displayName="CloudsFly" projectFiles="true">
-        <itemPath>../../Config/CloudsFly/options.h</itemPath>
-      </logicalFolder>
         <itemPath>../../Config/FSconfig.h</itemPath>
         <itemPath>../../Config/magnetometerOptions.h</itemPath>
         <itemPath>../../Config/mavlink_options.h</itemPath>
@@ -28,7 +29,81 @@
         <itemPath>../../Config/osd_config.h</itemPath>
         <itemPath>../../Config/ports_config.h</itemPath>
       </logicalFolder>
+      <logicalFolder name="libDCM" displayName="libDCM" projectFiles="true">
+        <itemPath>../../libDCM/dcmTypes.h</itemPath>
+        <itemPath>../../libDCM/deadReckoning.h</itemPath>
+        <itemPath>../../libDCM/estAltitude.h</itemPath>
+        <itemPath>../../libDCM/estLocation.h</itemPath>
+        <itemPath>../../libDCM/estWind.h</itemPath>
+        <itemPath>../../libDCM/estYawDrift.h</itemPath>
+        <itemPath>../../libDCM/gpsData.h</itemPath>
+        <itemPath>../../libDCM/gpsParseCommon.h</itemPath>
+        <itemPath>../../libDCM/libDCM.h</itemPath>
+        <itemPath>../../libDCM/libDCM_defines.h</itemPath>
+        <itemPath>../../libDCM/libDCM_internal.h</itemPath>
+        <itemPath>../../libDCM/mag_drift.h</itemPath>
+        <itemPath>../../libDCM/mathlib.h</itemPath>
+        <itemPath>../../libDCM/mathlibNAV.h</itemPath>
+        <itemPath>../../libDCM/rmat.h</itemPath>
+      </logicalFolder>
+      <logicalFolder name="libFlashFS" displayName="libFlashFS" projectFiles="true">
+        <itemPath>../../libFlashFS/AT45D.h</itemPath>
+        <itemPath>../../libFlashFS/EEPROM.h</itemPath>
+        <itemPath>../../libFlashFS/filesys.h</itemPath>
+        <itemPath>../../libFlashFS/MDD_AT45D.h</itemPath>
+        <itemPath>../../libFlashFS/MDD_EEPROM.h</itemPath>
+      </logicalFolder>
+      <logicalFolder name="libUDB" displayName="libUDB" projectFiles="true">
+        <itemPath>../../libUDB/ADchannel.h</itemPath>
+        <itemPath>../../libUDB/analogs.h</itemPath>
+        <itemPath>../../libUDB/barometer.h</itemPath>
+        <itemPath>../../libUDB/boardRotation_defines.h</itemPath>
+        <itemPath>../../libUDB/builtins.h</itemPath>
+        <itemPath>../../libUDB/ConfigAUAV3.h</itemPath>
+        <itemPath>../../libUDB/ConfigHILSIM.h</itemPath>
+        <itemPath>../../libUDB/ConfigPX4.h</itemPath>
+        <itemPath>../../libUDB/ConfigUDB4.h</itemPath>
+        <itemPath>../../libUDB/ConfigUDB5.h</itemPath>
+        <itemPath>../../libUDB/eeprom_udb4.h</itemPath>
+        <itemPath>../../libUDB/events.h</itemPath>
+        <itemPath>../../libUDB/fixDeps.h</itemPath>
+        <itemPath>../../libUDB/heartbeat.h</itemPath>
+        <itemPath>../../libUDB/I2C.h</itemPath>
+        <itemPath>../../libUDB/interrupt.h</itemPath>
+        <itemPath>../../libUDB/libUDB.h</itemPath>
+        <itemPath>../../libUDB/libUDB_defines.h</itemPath>
+        <itemPath>../../libUDB/libUDB_internal.h</itemPath>
+        <itemPath>../../libUDB/magnetometer.h</itemPath>
+        <itemPath>../../libUDB/mcu.h</itemPath>
+        <itemPath>../../libUDB/mpu6000.h</itemPath>
+        <itemPath>../../libUDB/mpu_spi.h</itemPath>
+        <itemPath>../../libUDB/NV_memory.h</itemPath>
+        <itemPath>../../libUDB/oscillator.h</itemPath>
+        <itemPath>../../libUDB/osd.h</itemPath>
+        <itemPath>../../libUDB/radioIn.h</itemPath>
+        <itemPath>../../libUDB/serialIO.h</itemPath>
+        <itemPath>../../libUDB/servoOut.h</itemPath>
+        <itemPath>../../libUDB/sonarIn.h</itemPath>
+        <itemPath>../../libUDB/uart.h</itemPath>
+        <itemPath>../../libUDB/udbTypes.h</itemPath>
+      </logicalFolder>
+      <logicalFolder name="libVectorMatrix"
+                     displayName="libVectorMatrix"
+                     projectFiles="true">
+        <itemPath>../../libVectorMatrix/dspcommon.inc</itemPath>
+      </logicalFolder>
       <logicalFolder name="MatrixPilot" displayName="MatrixPilot" projectFiles="true">
+        <logicalFolder name="example-options-files"
+                       displayName="example-options-files"
+                       projectFiles="true">
+          <itemPath>../../MatrixPilot/example-options-files/options.AcroMaster-ben.h</itemPath>
+          <itemPath>../../MatrixPilot/example-options-files/options.Delta-Phil.h</itemPath>
+          <itemPath>../../MatrixPilot/example-options-files/options.EasyStar-Bill.h</itemPath>
+          <itemPath>../../MatrixPilot/example-options-files/options.GentleLady-Bill.h</itemPath>
+          <itemPath>../../MatrixPilot/example-options-files/options.HILSIM-B747-Bill.h</itemPath>
+          <itemPath>../../MatrixPilot/example-options-files/options.HILSIM-Cessna-ben.h</itemPath>
+          <itemPath>../../MatrixPilot/example-options-files/options.MiniMag-ben.h</itemPath>
+        </logicalFolder>
         <itemPath>../../MatrixPilot/airspeedCntrl.h</itemPath>
         <itemPath>../../MatrixPilot/altitudeCntrl.h</itemPath>
         <itemPath>../../MatrixPilot/behaviour.h</itemPath>
@@ -39,15 +114,6 @@
         <itemPath>../../MatrixPilot/data_storage.h</itemPath>
         <itemPath>../../MatrixPilot/defines.h</itemPath>
         <itemPath>../../MatrixPilot/euler_angles.h</itemPath>
-      <logicalFolder name="example-options-files" displayName="example-options-files" projectFiles="true">
-        <itemPath>../../MatrixPilot/example-options-files/options.AcroMaster-ben.h</itemPath>
-        <itemPath>../../MatrixPilot/example-options-files/options.Delta-Phil.h</itemPath>
-        <itemPath>../../MatrixPilot/example-options-files/options.EasyStar-Bill.h</itemPath>
-        <itemPath>../../MatrixPilot/example-options-files/options.GentleLady-Bill.h</itemPath>
-        <itemPath>../../MatrixPilot/example-options-files/options.HILSIM-B747-Bill.h</itemPath>
-        <itemPath>../../MatrixPilot/example-options-files/options.HILSIM-Cessna-ben.h</itemPath>
-        <itemPath>../../MatrixPilot/example-options-files/options.MiniMag-ben.h</itemPath>
-      </logicalFolder>
         <itemPath>../../MatrixPilot/flightplan-logo.h</itemPath>
         <itemPath>../../MatrixPilot/flightplan-waypoints.h</itemPath>
         <itemPath>../../MatrixPilot/flightplan.h</itemPath>
@@ -84,277 +150,311 @@
         <itemPath>../../MatrixPilot/waypoints.h</itemPath>
       </logicalFolder>
       <logicalFolder name="MAVLink" displayName="MAVLink" projectFiles="true">
-      <logicalFolder name="include" displayName="include" projectFiles="true">
-        <itemPath>../../MAVLink/include/checksum.h</itemPath>
-      <logicalFolder name="common" displayName="common" projectFiles="true">
-        <itemPath>../../MAVLink/include/common/common.h</itemPath>
-        <itemPath>../../MAVLink/include/common/mavlink.h</itemPath>
-        <itemPath>../../MAVLink/include/common/mavlink_msg_attitude.h</itemPath>
-        <itemPath>../../MAVLink/include/common/mavlink_msg_attitude_quaternion.h</itemPath>
-        <itemPath>../../MAVLink/include/common/mavlink_msg_attitude_quaternion_cov.h</itemPath>
-        <itemPath>../../MAVLink/include/common/mavlink_msg_attitude_setpoint_external.h</itemPath>
-        <itemPath>../../MAVLink/include/common/mavlink_msg_attitude_target.h</itemPath>
-        <itemPath>../../MAVLink/include/common/mavlink_msg_auth_key.h</itemPath>
-        <itemPath>../../MAVLink/include/common/mavlink_msg_autopilot_version.h</itemPath>
-        <itemPath>../../MAVLink/include/common/mavlink_msg_battery_status.h</itemPath>
-        <itemPath>../../MAVLink/include/common/mavlink_msg_change_operator_control.h</itemPath>
-        <itemPath>../../MAVLink/include/common/mavlink_msg_change_operator_control_ack.h</itemPath>
-        <itemPath>../../MAVLink/include/common/mavlink_msg_command_ack.h</itemPath>
-        <itemPath>../../MAVLink/include/common/mavlink_msg_command_int.h</itemPath>
-        <itemPath>../../MAVLink/include/common/mavlink_msg_command_long.h</itemPath>
-        <itemPath>../../MAVLink/include/common/mavlink_msg_data_stream.h</itemPath>
-        <itemPath>../../MAVLink/include/common/mavlink_msg_data_transmission_handshake.h</itemPath>
-        <itemPath>../../MAVLink/include/common/mavlink_msg_debug.h</itemPath>
-        <itemPath>../../MAVLink/include/common/mavlink_msg_debug_vect.h</itemPath>
-        <itemPath>../../MAVLink/include/common/mavlink_msg_distance_sensor.h</itemPath>
-        <itemPath>../../MAVLink/include/common/mavlink_msg_encapsulated_data.h</itemPath>
-        <itemPath>../../MAVLink/include/common/mavlink_msg_file_transfer_dir_list.h</itemPath>
-        <itemPath>../../MAVLink/include/common/mavlink_msg_file_transfer_protocol.h</itemPath>
-        <itemPath>../../MAVLink/include/common/mavlink_msg_file_transfer_res.h</itemPath>
-        <itemPath>../../MAVLink/include/common/mavlink_msg_file_transfer_start.h</itemPath>
-        <itemPath>../../MAVLink/include/common/mavlink_msg_global_position_int.h</itemPath>
-        <itemPath>../../MAVLink/include/common/mavlink_msg_global_position_int_cov.h</itemPath>
-        <itemPath>../../MAVLink/include/common/mavlink_msg_global_position_setpoint_external_int.h</itemPath>
-        <itemPath>../../MAVLink/include/common/mavlink_msg_global_position_setpoint_int.h</itemPath>
-        <itemPath>../../MAVLink/include/common/mavlink_msg_global_vision_position_estimate.h</itemPath>
-        <itemPath>../../MAVLink/include/common/mavlink_msg_gps2_raw.h</itemPath>
-        <itemPath>../../MAVLink/include/common/mavlink_msg_gps2_rtk.h</itemPath>
-        <itemPath>../../MAVLink/include/common/mavlink_msg_gps_global_origin.h</itemPath>
-        <itemPath>../../MAVLink/include/common/mavlink_msg_gps_inject_data.h</itemPath>
-        <itemPath>../../MAVLink/include/common/mavlink_msg_gps_raw_int.h</itemPath>
-        <itemPath>../../MAVLink/include/common/mavlink_msg_gps_rtk.h</itemPath>
-        <itemPath>../../MAVLink/include/common/mavlink_msg_gps_status.h</itemPath>
-        <itemPath>../../MAVLink/include/common/mavlink_msg_heartbeat.h</itemPath>
-        <itemPath>../../MAVLink/include/common/mavlink_msg_highres_imu.h</itemPath>
-        <itemPath>../../MAVLink/include/common/mavlink_msg_hil_controls.h</itemPath>
-        <itemPath>../../MAVLink/include/common/mavlink_msg_hil_gps.h</itemPath>
-        <itemPath>../../MAVLink/include/common/mavlink_msg_hil_optical_flow.h</itemPath>
-        <itemPath>../../MAVLink/include/common/mavlink_msg_hil_rc_inputs_raw.h</itemPath>
-        <itemPath>../../MAVLink/include/common/mavlink_msg_hil_sensor.h</itemPath>
-        <itemPath>../../MAVLink/include/common/mavlink_msg_hil_state.h</itemPath>
-        <itemPath>../../MAVLink/include/common/mavlink_msg_hil_state_quaternion.h</itemPath>
-        <itemPath>../../MAVLink/include/common/mavlink_msg_local_ned_position_setpoint_external.h</itemPath>
-        <itemPath>../../MAVLink/include/common/mavlink_msg_local_position_ned.h</itemPath>
-        <itemPath>../../MAVLink/include/common/mavlink_msg_local_position_ned_cov.h</itemPath>
-        <itemPath>../../MAVLink/include/common/mavlink_msg_local_position_ned_system_global_offset.h</itemPath>
-        <itemPath>../../MAVLink/include/common/mavlink_msg_local_position_setpoint.h</itemPath>
-        <itemPath>../../MAVLink/include/common/mavlink_msg_log_data.h</itemPath>
-        <itemPath>../../MAVLink/include/common/mavlink_msg_log_entry.h</itemPath>
-        <itemPath>../../MAVLink/include/common/mavlink_msg_log_erase.h</itemPath>
-        <itemPath>../../MAVLink/include/common/mavlink_msg_log_request_data.h</itemPath>
-        <itemPath>../../MAVLink/include/common/mavlink_msg_log_request_end.h</itemPath>
-        <itemPath>../../MAVLink/include/common/mavlink_msg_log_request_list.h</itemPath>
-        <itemPath>../../MAVLink/include/common/mavlink_msg_manual_control.h</itemPath>
-        <itemPath>../../MAVLink/include/common/mavlink_msg_manual_setpoint.h</itemPath>
-        <itemPath>../../MAVLink/include/common/mavlink_msg_memory_vect.h</itemPath>
-        <itemPath>../../MAVLink/include/common/mavlink_msg_mission_ack.h</itemPath>
-        <itemPath>../../MAVLink/include/common/mavlink_msg_mission_clear_all.h</itemPath>
-        <itemPath>../../MAVLink/include/common/mavlink_msg_mission_count.h</itemPath>
-        <itemPath>../../MAVLink/include/common/mavlink_msg_mission_current.h</itemPath>
-        <itemPath>../../MAVLink/include/common/mavlink_msg_mission_item.h</itemPath>
-        <itemPath>../../MAVLink/include/common/mavlink_msg_mission_item_int.h</itemPath>
-        <itemPath>../../MAVLink/include/common/mavlink_msg_mission_item_reached.h</itemPath>
-        <itemPath>../../MAVLink/include/common/mavlink_msg_mission_request.h</itemPath>
-        <itemPath>../../MAVLink/include/common/mavlink_msg_mission_request_list.h</itemPath>
-        <itemPath>../../MAVLink/include/common/mavlink_msg_mission_request_partial_list.h</itemPath>
-        <itemPath>../../MAVLink/include/common/mavlink_msg_mission_set_current.h</itemPath>
-        <itemPath>../../MAVLink/include/common/mavlink_msg_mission_write_partial_list.h</itemPath>
-        <itemPath>../../MAVLink/include/common/mavlink_msg_named_value_float.h</itemPath>
-        <itemPath>../../MAVLink/include/common/mavlink_msg_named_value_int.h</itemPath>
-        <itemPath>../../MAVLink/include/common/mavlink_msg_nav_controller_output.h</itemPath>
-        <itemPath>../../MAVLink/include/common/mavlink_msg_omnidirectional_flow.h</itemPath>
-        <itemPath>../../MAVLink/include/common/mavlink_msg_optical_flow.h</itemPath>
-        <itemPath>../../MAVLink/include/common/mavlink_msg_optical_flow_rad.h</itemPath>
-        <itemPath>../../MAVLink/include/common/mavlink_msg_param_request_list.h</itemPath>
-        <itemPath>../../MAVLink/include/common/mavlink_msg_param_request_read.h</itemPath>
-        <itemPath>../../MAVLink/include/common/mavlink_msg_param_set.h</itemPath>
-        <itemPath>../../MAVLink/include/common/mavlink_msg_param_value.h</itemPath>
-        <itemPath>../../MAVLink/include/common/mavlink_msg_ping.h</itemPath>
-        <itemPath>../../MAVLink/include/common/mavlink_msg_position_target_global_int.h</itemPath>
-        <itemPath>../../MAVLink/include/common/mavlink_msg_position_target_local_ned.h</itemPath>
-        <itemPath>../../MAVLink/include/common/mavlink_msg_power_status.h</itemPath>
-        <itemPath>../../MAVLink/include/common/mavlink_msg_radio_status.h</itemPath>
-        <itemPath>../../MAVLink/include/common/mavlink_msg_raw_imu.h</itemPath>
-        <itemPath>../../MAVLink/include/common/mavlink_msg_raw_pressure.h</itemPath>
-        <itemPath>../../MAVLink/include/common/mavlink_msg_rc_channels.h</itemPath>
-        <itemPath>../../MAVLink/include/common/mavlink_msg_rc_channels_override.h</itemPath>
-        <itemPath>../../MAVLink/include/common/mavlink_msg_rc_channels_raw.h</itemPath>
-        <itemPath>../../MAVLink/include/common/mavlink_msg_rc_channels_scaled.h</itemPath>
-        <itemPath>../../MAVLink/include/common/mavlink_msg_request_data_stream.h</itemPath>
-        <itemPath>../../MAVLink/include/common/mavlink_msg_roll_pitch_yaw_rates_thrust_setpoint.h</itemPath>
-        <itemPath>../../MAVLink/include/common/mavlink_msg_roll_pitch_yaw_speed_thrust_setpoint.h</itemPath>
-        <itemPath>../../MAVLink/include/common/mavlink_msg_roll_pitch_yaw_thrust_setpoint.h</itemPath>
-        <itemPath>../../MAVLink/include/common/mavlink_msg_safety_allowed_area.h</itemPath>
-        <itemPath>../../MAVLink/include/common/mavlink_msg_safety_set_allowed_area.h</itemPath>
-        <itemPath>../../MAVLink/include/common/mavlink_msg_scaled_imu.h</itemPath>
-        <itemPath>../../MAVLink/include/common/mavlink_msg_scaled_imu2.h</itemPath>
-        <itemPath>../../MAVLink/include/common/mavlink_msg_scaled_pressure.h</itemPath>
-        <itemPath>../../MAVLink/include/common/mavlink_msg_serial_control.h</itemPath>
-        <itemPath>../../MAVLink/include/common/mavlink_msg_servo_output_raw.h</itemPath>
-        <itemPath>../../MAVLink/include/common/mavlink_msg_setpoint_6dof.h</itemPath>
-        <itemPath>../../MAVLink/include/common/mavlink_msg_setpoint_8dof.h</itemPath>
-        <itemPath>../../MAVLink/include/common/mavlink_msg_set_attitude_target.h</itemPath>
-        <itemPath>../../MAVLink/include/common/mavlink_msg_set_global_position_setpoint_int.h</itemPath>
-        <itemPath>../../MAVLink/include/common/mavlink_msg_set_gps_global_origin.h</itemPath>
-        <itemPath>../../MAVLink/include/common/mavlink_msg_set_local_position_setpoint.h</itemPath>
-        <itemPath>../../MAVLink/include/common/mavlink_msg_set_mode.h</itemPath>
-        <itemPath>../../MAVLink/include/common/mavlink_msg_set_position_target_global_int.h</itemPath>
-        <itemPath>../../MAVLink/include/common/mavlink_msg_set_position_target_local_ned.h</itemPath>
-        <itemPath>../../MAVLink/include/common/mavlink_msg_set_quad_motors_setpoint.h</itemPath>
-        <itemPath>../../MAVLink/include/common/mavlink_msg_set_quad_swarm_led_roll_pitch_yaw_thrust.h</itemPath>
-        <itemPath>../../MAVLink/include/common/mavlink_msg_set_quad_swarm_roll_pitch_yaw_thrust.h</itemPath>
-        <itemPath>../../MAVLink/include/common/mavlink_msg_set_roll_pitch_yaw_speed_thrust.h</itemPath>
-        <itemPath>../../MAVLink/include/common/mavlink_msg_set_roll_pitch_yaw_thrust.h</itemPath>
-        <itemPath>../../MAVLink/include/common/mavlink_msg_sim_state.h</itemPath>
-        <itemPath>../../MAVLink/include/common/mavlink_msg_state_correction.h</itemPath>
-        <itemPath>../../MAVLink/include/common/mavlink_msg_statustext.h</itemPath>
-        <itemPath>../../MAVLink/include/common/mavlink_msg_system_time.h</itemPath>
-        <itemPath>../../MAVLink/include/common/mavlink_msg_sys_status.h</itemPath>
-        <itemPath>../../MAVLink/include/common/mavlink_msg_terrain_check.h</itemPath>
-        <itemPath>../../MAVLink/include/common/mavlink_msg_terrain_data.h</itemPath>
-        <itemPath>../../MAVLink/include/common/mavlink_msg_terrain_report.h</itemPath>
-        <itemPath>../../MAVLink/include/common/mavlink_msg_terrain_request.h</itemPath>
-        <itemPath>../../MAVLink/include/common/mavlink_msg_timesync.h</itemPath>
-        <itemPath>../../MAVLink/include/common/mavlink_msg_v2_extension.h</itemPath>
-        <itemPath>../../MAVLink/include/common/mavlink_msg_vfr_hud.h</itemPath>
-        <itemPath>../../MAVLink/include/common/mavlink_msg_vicon_position_estimate.h</itemPath>
-        <itemPath>../../MAVLink/include/common/mavlink_msg_vision_position_estimate.h</itemPath>
-        <itemPath>../../MAVLink/include/common/mavlink_msg_vision_speed_estimate.h</itemPath>
-        <itemPath>../../MAVLink/include/common/testsuite.h</itemPath>
-        <itemPath>../../MAVLink/include/common/version.h</itemPath>
-      </logicalFolder>
-        <itemPath>../../MAVLink/include/inttypes.h</itemPath>
-      <logicalFolder name="matrixpilot" displayName="matrixpilot" projectFiles="true">
-        <itemPath>../../MAVLink/include/matrixpilot/matrixpilot.h</itemPath>
-        <itemPath>../../MAVLink/include/matrixpilot/mavlink.h</itemPath>
-        <itemPath>../../MAVLink/include/matrixpilot/mavlink_msg_airspeeds.h</itemPath>
-        <itemPath>../../MAVLink/include/matrixpilot/mavlink_msg_altitudes.h</itemPath>
-        <itemPath>../../MAVLink/include/matrixpilot/mavlink_msg_flexifunction_buffer_function.h</itemPath>
-        <itemPath>../../MAVLink/include/matrixpilot/mavlink_msg_flexifunction_buffer_function_ack.h</itemPath>
-        <itemPath>../../MAVLink/include/matrixpilot/mavlink_msg_flexifunction_command.h</itemPath>
-        <itemPath>../../MAVLink/include/matrixpilot/mavlink_msg_flexifunction_command_ack.h</itemPath>
-        <itemPath>../../MAVLink/include/matrixpilot/mavlink_msg_flexifunction_directory.h</itemPath>
-        <itemPath>../../MAVLink/include/matrixpilot/mavlink_msg_flexifunction_directory_ack.h</itemPath>
-        <itemPath>../../MAVLink/include/matrixpilot/mavlink_msg_flexifunction_read_req.h</itemPath>
-        <itemPath>../../MAVLink/include/matrixpilot/mavlink_msg_flexifunction_set.h</itemPath>
-        <itemPath>../../MAVLink/include/matrixpilot/mavlink_msg_force.h</itemPath>
-        <itemPath>../../MAVLink/include/matrixpilot/mavlink_msg_serial_udb_extra_f13.h</itemPath>
-        <itemPath>../../MAVLink/include/matrixpilot/mavlink_msg_serial_udb_extra_f14.h</itemPath>
-        <itemPath>../../MAVLink/include/matrixpilot/mavlink_msg_serial_udb_extra_f15.h</itemPath>
-        <itemPath>../../MAVLink/include/matrixpilot/mavlink_msg_serial_udb_extra_f16.h</itemPath>
-        <itemPath>../../MAVLink/include/matrixpilot/mavlink_msg_serial_udb_extra_f2_a.h</itemPath>
-        <itemPath>../../MAVLink/include/matrixpilot/mavlink_msg_serial_udb_extra_f2_b.h</itemPath>
-        <itemPath>../../MAVLink/include/matrixpilot/mavlink_msg_serial_udb_extra_f4.h</itemPath>
-        <itemPath>../../MAVLink/include/matrixpilot/mavlink_msg_serial_udb_extra_f5.h</itemPath>
-        <itemPath>../../MAVLink/include/matrixpilot/mavlink_msg_serial_udb_extra_f6.h</itemPath>
-        <itemPath>../../MAVLink/include/matrixpilot/mavlink_msg_serial_udb_extra_f7.h</itemPath>
-        <itemPath>../../MAVLink/include/matrixpilot/mavlink_msg_serial_udb_extra_f8.h</itemPath>
-        <itemPath>../../MAVLink/include/matrixpilot/testsuite.h</itemPath>
-        <itemPath>../../MAVLink/include/matrixpilot/version.h</itemPath>
-      </logicalFolder>
-        <itemPath>../../MAVLink/include/matrixpilot_mavlink_bridge_header.h</itemPath>
-        <itemPath>../../MAVLink/include/mavlink_conversions.h</itemPath>
-        <itemPath>../../MAVLink/include/mavlink_helpers.h</itemPath>
-        <itemPath>../../MAVLink/include/mavlink_types.h</itemPath>
-        <itemPath>../../MAVLink/include/protocol.h</itemPath>
-      </logicalFolder>
+        <logicalFolder name="include" displayName="include" projectFiles="true">
+          <logicalFolder name="common" displayName="common" projectFiles="true">
+            <itemPath>../../MAVLink/include/common/common.h</itemPath>
+            <itemPath>../../MAVLink/include/common/mavlink.h</itemPath>
+            <itemPath>../../MAVLink/include/common/mavlink_msg_attitude.h</itemPath>
+            <itemPath>../../MAVLink/include/common/mavlink_msg_attitude_quaternion.h</itemPath>
+            <itemPath>../../MAVLink/include/common/mavlink_msg_attitude_quaternion_cov.h</itemPath>
+            <itemPath>../../MAVLink/include/common/mavlink_msg_attitude_setpoint_external.h</itemPath>
+            <itemPath>../../MAVLink/include/common/mavlink_msg_attitude_target.h</itemPath>
+            <itemPath>../../MAVLink/include/common/mavlink_msg_auth_key.h</itemPath>
+            <itemPath>../../MAVLink/include/common/mavlink_msg_autopilot_version.h</itemPath>
+            <itemPath>../../MAVLink/include/common/mavlink_msg_battery_status.h</itemPath>
+            <itemPath>../../MAVLink/include/common/mavlink_msg_change_operator_control.h</itemPath>
+            <itemPath>../../MAVLink/include/common/mavlink_msg_change_operator_control_ack.h</itemPath>
+            <itemPath>../../MAVLink/include/common/mavlink_msg_command_ack.h</itemPath>
+            <itemPath>../../MAVLink/include/common/mavlink_msg_command_int.h</itemPath>
+            <itemPath>../../MAVLink/include/common/mavlink_msg_command_long.h</itemPath>
+            <itemPath>../../MAVLink/include/common/mavlink_msg_data_stream.h</itemPath>
+            <itemPath>../../MAVLink/include/common/mavlink_msg_data_transmission_handshake.h</itemPath>
+            <itemPath>../../MAVLink/include/common/mavlink_msg_debug.h</itemPath>
+            <itemPath>../../MAVLink/include/common/mavlink_msg_debug_vect.h</itemPath>
+            <itemPath>../../MAVLink/include/common/mavlink_msg_distance_sensor.h</itemPath>
+            <itemPath>../../MAVLink/include/common/mavlink_msg_encapsulated_data.h</itemPath>
+            <itemPath>../../MAVLink/include/common/mavlink_msg_file_transfer_dir_list.h</itemPath>
+            <itemPath>../../MAVLink/include/common/mavlink_msg_file_transfer_protocol.h</itemPath>
+            <itemPath>../../MAVLink/include/common/mavlink_msg_file_transfer_res.h</itemPath>
+            <itemPath>../../MAVLink/include/common/mavlink_msg_file_transfer_start.h</itemPath>
+            <itemPath>../../MAVLink/include/common/mavlink_msg_global_position_int.h</itemPath>
+            <itemPath>../../MAVLink/include/common/mavlink_msg_global_position_int_cov.h</itemPath>
+            <itemPath>../../MAVLink/include/common/mavlink_msg_global_position_setpoint_external_int.h</itemPath>
+            <itemPath>../../MAVLink/include/common/mavlink_msg_global_position_setpoint_int.h</itemPath>
+            <itemPath>../../MAVLink/include/common/mavlink_msg_global_vision_position_estimate.h</itemPath>
+            <itemPath>../../MAVLink/include/common/mavlink_msg_gps2_raw.h</itemPath>
+            <itemPath>../../MAVLink/include/common/mavlink_msg_gps2_rtk.h</itemPath>
+            <itemPath>../../MAVLink/include/common/mavlink_msg_gps_global_origin.h</itemPath>
+            <itemPath>../../MAVLink/include/common/mavlink_msg_gps_inject_data.h</itemPath>
+            <itemPath>../../MAVLink/include/common/mavlink_msg_gps_raw_int.h</itemPath>
+            <itemPath>../../MAVLink/include/common/mavlink_msg_gps_rtk.h</itemPath>
+            <itemPath>../../MAVLink/include/common/mavlink_msg_gps_status.h</itemPath>
+            <itemPath>../../MAVLink/include/common/mavlink_msg_heartbeat.h</itemPath>
+            <itemPath>../../MAVLink/include/common/mavlink_msg_highres_imu.h</itemPath>
+            <itemPath>../../MAVLink/include/common/mavlink_msg_hil_controls.h</itemPath>
+            <itemPath>../../MAVLink/include/common/mavlink_msg_hil_gps.h</itemPath>
+            <itemPath>../../MAVLink/include/common/mavlink_msg_hil_optical_flow.h</itemPath>
+            <itemPath>../../MAVLink/include/common/mavlink_msg_hil_rc_inputs_raw.h</itemPath>
+            <itemPath>../../MAVLink/include/common/mavlink_msg_hil_sensor.h</itemPath>
+            <itemPath>../../MAVLink/include/common/mavlink_msg_hil_state.h</itemPath>
+            <itemPath>../../MAVLink/include/common/mavlink_msg_hil_state_quaternion.h</itemPath>
+            <itemPath>../../MAVLink/include/common/mavlink_msg_local_ned_position_setpoint_external.h</itemPath>
+            <itemPath>../../MAVLink/include/common/mavlink_msg_local_position_ned.h</itemPath>
+            <itemPath>../../MAVLink/include/common/mavlink_msg_local_position_ned_cov.h</itemPath>
+            <itemPath>../../MAVLink/include/common/mavlink_msg_local_position_ned_system_global_offset.h</itemPath>
+            <itemPath>../../MAVLink/include/common/mavlink_msg_local_position_setpoint.h</itemPath>
+            <itemPath>../../MAVLink/include/common/mavlink_msg_log_data.h</itemPath>
+            <itemPath>../../MAVLink/include/common/mavlink_msg_log_entry.h</itemPath>
+            <itemPath>../../MAVLink/include/common/mavlink_msg_log_erase.h</itemPath>
+            <itemPath>../../MAVLink/include/common/mavlink_msg_log_request_data.h</itemPath>
+            <itemPath>../../MAVLink/include/common/mavlink_msg_log_request_end.h</itemPath>
+            <itemPath>../../MAVLink/include/common/mavlink_msg_log_request_list.h</itemPath>
+            <itemPath>../../MAVLink/include/common/mavlink_msg_manual_control.h</itemPath>
+            <itemPath>../../MAVLink/include/common/mavlink_msg_manual_setpoint.h</itemPath>
+            <itemPath>../../MAVLink/include/common/mavlink_msg_memory_vect.h</itemPath>
+            <itemPath>../../MAVLink/include/common/mavlink_msg_mission_ack.h</itemPath>
+            <itemPath>../../MAVLink/include/common/mavlink_msg_mission_clear_all.h</itemPath>
+            <itemPath>../../MAVLink/include/common/mavlink_msg_mission_count.h</itemPath>
+            <itemPath>../../MAVLink/include/common/mavlink_msg_mission_current.h</itemPath>
+            <itemPath>../../MAVLink/include/common/mavlink_msg_mission_item.h</itemPath>
+            <itemPath>../../MAVLink/include/common/mavlink_msg_mission_item_int.h</itemPath>
+            <itemPath>../../MAVLink/include/common/mavlink_msg_mission_item_reached.h</itemPath>
+            <itemPath>../../MAVLink/include/common/mavlink_msg_mission_request.h</itemPath>
+            <itemPath>../../MAVLink/include/common/mavlink_msg_mission_request_list.h</itemPath>
+            <itemPath>../../MAVLink/include/common/mavlink_msg_mission_request_partial_list.h</itemPath>
+            <itemPath>../../MAVLink/include/common/mavlink_msg_mission_set_current.h</itemPath>
+            <itemPath>../../MAVLink/include/common/mavlink_msg_mission_write_partial_list.h</itemPath>
+            <itemPath>../../MAVLink/include/common/mavlink_msg_named_value_float.h</itemPath>
+            <itemPath>../../MAVLink/include/common/mavlink_msg_named_value_int.h</itemPath>
+            <itemPath>../../MAVLink/include/common/mavlink_msg_nav_controller_output.h</itemPath>
+            <itemPath>../../MAVLink/include/common/mavlink_msg_omnidirectional_flow.h</itemPath>
+            <itemPath>../../MAVLink/include/common/mavlink_msg_optical_flow.h</itemPath>
+            <itemPath>../../MAVLink/include/common/mavlink_msg_optical_flow_rad.h</itemPath>
+            <itemPath>../../MAVLink/include/common/mavlink_msg_param_request_list.h</itemPath>
+            <itemPath>../../MAVLink/include/common/mavlink_msg_param_request_read.h</itemPath>
+            <itemPath>../../MAVLink/include/common/mavlink_msg_param_set.h</itemPath>
+            <itemPath>../../MAVLink/include/common/mavlink_msg_param_value.h</itemPath>
+            <itemPath>../../MAVLink/include/common/mavlink_msg_ping.h</itemPath>
+            <itemPath>../../MAVLink/include/common/mavlink_msg_position_target_global_int.h</itemPath>
+            <itemPath>../../MAVLink/include/common/mavlink_msg_position_target_local_ned.h</itemPath>
+            <itemPath>../../MAVLink/include/common/mavlink_msg_power_status.h</itemPath>
+            <itemPath>../../MAVLink/include/common/mavlink_msg_radio_status.h</itemPath>
+            <itemPath>../../MAVLink/include/common/mavlink_msg_raw_imu.h</itemPath>
+            <itemPath>../../MAVLink/include/common/mavlink_msg_raw_pressure.h</itemPath>
+            <itemPath>../../MAVLink/include/common/mavlink_msg_rc_channels.h</itemPath>
+            <itemPath>../../MAVLink/include/common/mavlink_msg_rc_channels_override.h</itemPath>
+            <itemPath>../../MAVLink/include/common/mavlink_msg_rc_channels_raw.h</itemPath>
+            <itemPath>../../MAVLink/include/common/mavlink_msg_rc_channels_scaled.h</itemPath>
+            <itemPath>../../MAVLink/include/common/mavlink_msg_request_data_stream.h</itemPath>
+            <itemPath>../../MAVLink/include/common/mavlink_msg_roll_pitch_yaw_rates_thrust_setpoint.h</itemPath>
+            <itemPath>../../MAVLink/include/common/mavlink_msg_roll_pitch_yaw_speed_thrust_setpoint.h</itemPath>
+            <itemPath>../../MAVLink/include/common/mavlink_msg_roll_pitch_yaw_thrust_setpoint.h</itemPath>
+            <itemPath>../../MAVLink/include/common/mavlink_msg_safety_allowed_area.h</itemPath>
+            <itemPath>../../MAVLink/include/common/mavlink_msg_safety_set_allowed_area.h</itemPath>
+            <itemPath>../../MAVLink/include/common/mavlink_msg_scaled_imu.h</itemPath>
+            <itemPath>../../MAVLink/include/common/mavlink_msg_scaled_imu2.h</itemPath>
+            <itemPath>../../MAVLink/include/common/mavlink_msg_scaled_pressure.h</itemPath>
+            <itemPath>../../MAVLink/include/common/mavlink_msg_serial_control.h</itemPath>
+            <itemPath>../../MAVLink/include/common/mavlink_msg_servo_output_raw.h</itemPath>
+            <itemPath>../../MAVLink/include/common/mavlink_msg_setpoint_6dof.h</itemPath>
+            <itemPath>../../MAVLink/include/common/mavlink_msg_setpoint_8dof.h</itemPath>
+            <itemPath>../../MAVLink/include/common/mavlink_msg_set_attitude_target.h</itemPath>
+            <itemPath>../../MAVLink/include/common/mavlink_msg_set_global_position_setpoint_int.h</itemPath>
+            <itemPath>../../MAVLink/include/common/mavlink_msg_set_gps_global_origin.h</itemPath>
+            <itemPath>../../MAVLink/include/common/mavlink_msg_set_local_position_setpoint.h</itemPath>
+            <itemPath>../../MAVLink/include/common/mavlink_msg_set_mode.h</itemPath>
+            <itemPath>../../MAVLink/include/common/mavlink_msg_set_position_target_global_int.h</itemPath>
+            <itemPath>../../MAVLink/include/common/mavlink_msg_set_position_target_local_ned.h</itemPath>
+            <itemPath>../../MAVLink/include/common/mavlink_msg_set_quad_motors_setpoint.h</itemPath>
+            <itemPath>../../MAVLink/include/common/mavlink_msg_set_quad_swarm_led_roll_pitch_yaw_thrust.h</itemPath>
+            <itemPath>../../MAVLink/include/common/mavlink_msg_set_quad_swarm_roll_pitch_yaw_thrust.h</itemPath>
+            <itemPath>../../MAVLink/include/common/mavlink_msg_set_roll_pitch_yaw_speed_thrust.h</itemPath>
+            <itemPath>../../MAVLink/include/common/mavlink_msg_set_roll_pitch_yaw_thrust.h</itemPath>
+            <itemPath>../../MAVLink/include/common/mavlink_msg_sim_state.h</itemPath>
+            <itemPath>../../MAVLink/include/common/mavlink_msg_state_correction.h</itemPath>
+            <itemPath>../../MAVLink/include/common/mavlink_msg_statustext.h</itemPath>
+            <itemPath>../../MAVLink/include/common/mavlink_msg_system_time.h</itemPath>
+            <itemPath>../../MAVLink/include/common/mavlink_msg_sys_status.h</itemPath>
+            <itemPath>../../MAVLink/include/common/mavlink_msg_terrain_check.h</itemPath>
+            <itemPath>../../MAVLink/include/common/mavlink_msg_terrain_data.h</itemPath>
+            <itemPath>../../MAVLink/include/common/mavlink_msg_terrain_report.h</itemPath>
+            <itemPath>../../MAVLink/include/common/mavlink_msg_terrain_request.h</itemPath>
+            <itemPath>../../MAVLink/include/common/mavlink_msg_timesync.h</itemPath>
+            <itemPath>../../MAVLink/include/common/mavlink_msg_v2_extension.h</itemPath>
+            <itemPath>../../MAVLink/include/common/mavlink_msg_vfr_hud.h</itemPath>
+            <itemPath>../../MAVLink/include/common/mavlink_msg_vicon_position_estimate.h</itemPath>
+            <itemPath>../../MAVLink/include/common/mavlink_msg_vision_position_estimate.h</itemPath>
+            <itemPath>../../MAVLink/include/common/mavlink_msg_vision_speed_estimate.h</itemPath>
+            <itemPath>../../MAVLink/include/common/testsuite.h</itemPath>
+            <itemPath>../../MAVLink/include/common/version.h</itemPath>
+          </logicalFolder>
+          <logicalFolder name="matrixpilot" displayName="matrixpilot" projectFiles="true">
+            <itemPath>../../MAVLink/include/matrixpilot/matrixpilot.h</itemPath>
+            <itemPath>../../MAVLink/include/matrixpilot/mavlink.h</itemPath>
+            <itemPath>../../MAVLink/include/matrixpilot/mavlink_msg_airspeeds.h</itemPath>
+            <itemPath>../../MAVLink/include/matrixpilot/mavlink_msg_altitudes.h</itemPath>
+            <itemPath>../../MAVLink/include/matrixpilot/mavlink_msg_flexifunction_buffer_function.h</itemPath>
+            <itemPath>../../MAVLink/include/matrixpilot/mavlink_msg_flexifunction_buffer_function_ack.h</itemPath>
+            <itemPath>../../MAVLink/include/matrixpilot/mavlink_msg_flexifunction_command.h</itemPath>
+            <itemPath>../../MAVLink/include/matrixpilot/mavlink_msg_flexifunction_command_ack.h</itemPath>
+            <itemPath>../../MAVLink/include/matrixpilot/mavlink_msg_flexifunction_directory.h</itemPath>
+            <itemPath>../../MAVLink/include/matrixpilot/mavlink_msg_flexifunction_directory_ack.h</itemPath>
+            <itemPath>../../MAVLink/include/matrixpilot/mavlink_msg_flexifunction_read_req.h</itemPath>
+            <itemPath>../../MAVLink/include/matrixpilot/mavlink_msg_flexifunction_set.h</itemPath>
+            <itemPath>../../MAVLink/include/matrixpilot/mavlink_msg_force.h</itemPath>
+            <itemPath>../../MAVLink/include/matrixpilot/mavlink_msg_serial_udb_extra_f13.h</itemPath>
+            <itemPath>../../MAVLink/include/matrixpilot/mavlink_msg_serial_udb_extra_f14.h</itemPath>
+            <itemPath>../../MAVLink/include/matrixpilot/mavlink_msg_serial_udb_extra_f15.h</itemPath>
+            <itemPath>../../MAVLink/include/matrixpilot/mavlink_msg_serial_udb_extra_f16.h</itemPath>
+            <itemPath>../../MAVLink/include/matrixpilot/mavlink_msg_serial_udb_extra_f2_a.h</itemPath>
+            <itemPath>../../MAVLink/include/matrixpilot/mavlink_msg_serial_udb_extra_f2_b.h</itemPath>
+            <itemPath>../../MAVLink/include/matrixpilot/mavlink_msg_serial_udb_extra_f4.h</itemPath>
+            <itemPath>../../MAVLink/include/matrixpilot/mavlink_msg_serial_udb_extra_f5.h</itemPath>
+            <itemPath>../../MAVLink/include/matrixpilot/mavlink_msg_serial_udb_extra_f6.h</itemPath>
+            <itemPath>../../MAVLink/include/matrixpilot/mavlink_msg_serial_udb_extra_f7.h</itemPath>
+            <itemPath>../../MAVLink/include/matrixpilot/mavlink_msg_serial_udb_extra_f8.h</itemPath>
+            <itemPath>../../MAVLink/include/matrixpilot/testsuite.h</itemPath>
+            <itemPath>../../MAVLink/include/matrixpilot/version.h</itemPath>
+          </logicalFolder>
+          <itemPath>../../MAVLink/include/checksum.h</itemPath>
+          <itemPath>../../MAVLink/include/inttypes.h</itemPath>
+          <itemPath>../../MAVLink/include/matrixpilot_mavlink_bridge_header.h</itemPath>
+          <itemPath>../../MAVLink/include/mavlink_conversions.h</itemPath>
+          <itemPath>../../MAVLink/include/mavlink_helpers.h</itemPath>
+          <itemPath>../../MAVLink/include/mavlink_types.h</itemPath>
+          <itemPath>../../MAVLink/include/protocol.h</itemPath>
+        </logicalFolder>
         <itemPath>../../MAVLink/MAVFTP.h</itemPath>
       </logicalFolder>
-      <logicalFolder name="libDCM" displayName="libDCM" projectFiles="true">
-        <itemPath>../../libDCM/dcmTypes.h</itemPath>
-        <itemPath>../../libDCM/deadReckoning.h</itemPath>
-        <itemPath>../../libDCM/estAltitude.h</itemPath>
-        <itemPath>../../libDCM/estLocation.h</itemPath>
-        <itemPath>../../libDCM/estWind.h</itemPath>
-        <itemPath>../../libDCM/estYawDrift.h</itemPath>
-        <itemPath>../../libDCM/gpsData.h</itemPath>
-        <itemPath>../../libDCM/gpsParseCommon.h</itemPath>
-        <itemPath>../../libDCM/libDCM.h</itemPath>
-        <itemPath>../../libDCM/libDCM_defines.h</itemPath>
-        <itemPath>../../libDCM/libDCM_internal.h</itemPath>
-        <itemPath>../../libDCM/mag_drift.h</itemPath>
-        <itemPath>../../libDCM/mathlib.h</itemPath>
-        <itemPath>../../libDCM/mathlibNAV.h</itemPath>
-        <itemPath>../../libDCM/rmat.h</itemPath>
-      </logicalFolder>
-      <logicalFolder name="libUDB" displayName="libUDB" projectFiles="true">
-        <itemPath>../../libUDB/ADchannel.h</itemPath>
-        <itemPath>../../libUDB/analogs.h</itemPath>
-        <itemPath>../../libUDB/barometer.h</itemPath>
-        <itemPath>../../libUDB/boardRotation_defines.h</itemPath>
-        <itemPath>../../libUDB/builtins.h</itemPath>
-        <itemPath>../../libUDB/ConfigAUAV3.h</itemPath>
-        <itemPath>../../libUDB/ConfigHILSIM.h</itemPath>
-        <itemPath>../../libUDB/ConfigPX4.h</itemPath>
-        <itemPath>../../libUDB/ConfigUDB4.h</itemPath>
-        <itemPath>../../libUDB/ConfigUDB5.h</itemPath>
-        <itemPath>../../libUDB/eeprom_udb4.h</itemPath>
-        <itemPath>../../libUDB/events.h</itemPath>
-        <itemPath>../../libUDB/fixDeps.h</itemPath>
-        <itemPath>../../libUDB/heartbeat.h</itemPath>
-        <itemPath>../../libUDB/I2C.h</itemPath>
-        <itemPath>../../libUDB/interrupt.h</itemPath>
-        <itemPath>../../libUDB/libUDB.h</itemPath>
-        <itemPath>../../libUDB/libUDB_defines.h</itemPath>
-        <itemPath>../../libUDB/libUDB_internal.h</itemPath>
-        <itemPath>../../libUDB/magnetometer.h</itemPath>
-        <itemPath>../../libUDB/mcu.h</itemPath>
-        <itemPath>../../libUDB/mpu6000.h</itemPath>
-        <itemPath>../../libUDB/mpu_spi.h</itemPath>
-        <itemPath>../../libUDB/NV_memory.h</itemPath>
-        <itemPath>../../libUDB/oscillator.h</itemPath>
-        <itemPath>../../libUDB/osd.h</itemPath>
-        <itemPath>../../libUDB/radioIn.h</itemPath>
-        <itemPath>../../libUDB/serialIO.h</itemPath>
-        <itemPath>../../libUDB/servoOut.h</itemPath>
-        <itemPath>../../libUDB/sonarIn.h</itemPath>
-        <itemPath>../../libUDB/uart.h</itemPath>
-        <itemPath>../../libUDB/udbTypes.h</itemPath>
-      </logicalFolder>
-      <logicalFolder name="libVectorMatrix" displayName="libVectorMatrix" projectFiles="true">
-        <itemPath>../../libVectorMatrix/dspcommon.inc</itemPath>
-      </logicalFolder>
-      <logicalFolder name="libFlashFS" displayName="libFlashFS" projectFiles="true">
-        <itemPath>../../libFlashFS/AT45D.h</itemPath>
-        <itemPath>../../libFlashFS/EEPROM.h</itemPath>
-        <itemPath>../../libFlashFS/filesys.h</itemPath>
-        <itemPath>../../libFlashFS/MDD_AT45D.h</itemPath>
-        <itemPath>../../libFlashFS/MDD_EEPROM.h</itemPath>
-      </logicalFolder>
       <logicalFolder name="Microchip" displayName="Microchip" projectFiles="true">
+        <logicalFolder name="Include" displayName="Include" projectFiles="true">
+          <logicalFolder name="MDD-File-System"
+                         displayName="MDD-File-System"
+                         projectFiles="true">
+            <itemPath>../../Microchip/Include/MDD-File-System/FSDefs.h</itemPath>
+            <itemPath>../../Microchip/Include/MDD-File-System/FSIO.h</itemPath>
+            <itemPath>../../Microchip/Include/MDD-File-System/SD-SPI.h</itemPath>
+          </logicalFolder>
+          <logicalFolder name="USB" displayName="USB" projectFiles="true">
+            <itemPath>../../Microchip/Include/USB/usb.h</itemPath>
+            <itemPath>../../Microchip/Include/USB/usb_ch9.h</itemPath>
+            <itemPath>../../Microchip/Include/USB/usb_common.h</itemPath>
+            <itemPath>../../Microchip/Include/USB/usb_device.h</itemPath>
+            <itemPath>../../Microchip/Include/USB/usb_function_cdc.h</itemPath>
+            <itemPath>../../Microchip/Include/USB/usb_function_msd.h</itemPath>
+            <itemPath>../../Microchip/Include/USB/usb_hal.h</itemPath>
+            <itemPath>../../Microchip/Include/USB/usb_hal_dspic33E.h</itemPath>
+          </logicalFolder>
+          <itemPath>../../Microchip/Include/Compiler.h</itemPath>
+          <itemPath>../../Microchip/Include/GenericTypeDefs.h</itemPath>
+        </logicalFolder>
+        <logicalFolder name="USB" displayName="USB" projectFiles="true">
+          <itemPath>../../Microchip/USB/usb_device_local.h</itemPath>
+        </logicalFolder>
         <itemPath>../../Microchip/HardwareProfile.h</itemPath>
-      <logicalFolder name="Include" displayName="Include" projectFiles="true">
-        <itemPath>../../Microchip/Include/Compiler.h</itemPath>
-        <itemPath>../../Microchip/Include/GenericTypeDefs.h</itemPath>
-      <logicalFolder name="MDD-File-System" displayName="MDD-File-System" projectFiles="true">
-        <itemPath>../../Microchip/Include/MDD-File-System/FSDefs.h</itemPath>
-        <itemPath>../../Microchip/Include/MDD-File-System/FSIO.h</itemPath>
-        <itemPath>../../Microchip/Include/MDD-File-System/SD-SPI.h</itemPath>
-      </logicalFolder>
-      <logicalFolder name="USB" displayName="USB" projectFiles="true">
-        <itemPath>../../Microchip/Include/USB/usb.h</itemPath>
-        <itemPath>../../Microchip/Include/USB/usb_ch9.h</itemPath>
-        <itemPath>../../Microchip/Include/USB/usb_common.h</itemPath>
-        <itemPath>../../Microchip/Include/USB/usb_device.h</itemPath>
-        <itemPath>../../Microchip/Include/USB/usb_function_cdc.h</itemPath>
-        <itemPath>../../Microchip/Include/USB/usb_function_msd.h</itemPath>
-        <itemPath>../../Microchip/Include/USB/usb_hal.h</itemPath>
-        <itemPath>../../Microchip/Include/USB/usb_hal_dspic33E.h</itemPath>
-      </logicalFolder>
-      </logicalFolder>
         <itemPath>../../Microchip/NetConfig.h</itemPath>
         <itemPath>../../Microchip/Sockets.h</itemPath>
-      <logicalFolder name="USB" displayName="USB" projectFiles="true">
-        <itemPath>../../Microchip/USB/usb_device_local.h</itemPath>
-      </logicalFolder>
         <itemPath>../../Microchip/usb_cdc.h</itemPath>
         <itemPath>../../Microchip/usb_config.h</itemPath>
       </logicalFolder>
-</logicalFolder>
-    <logicalFolder name="LinkerScript" displayName="Linker Files"
-    projectFiles="true"></logicalFolder>
-    <logicalFolder name="SourceFiles" displayName="Source Files"
-    projectFiles="true">      <logicalFolder name="MatrixPilot" displayName="MatrixPilot" projectFiles="true">
+    </logicalFolder>
+    <logicalFolder name="LinkerScript"
+                   displayName="Linker Files"
+                   projectFiles="true">
+    </logicalFolder>
+    <logicalFolder name="SourceFiles"
+                   displayName="Source Files"
+                   projectFiles="true">
+      <logicalFolder name="libDCM" displayName="libDCM" projectFiles="true">
+        <itemPath>../../libDCM/deadReckoning.c</itemPath>
+        <itemPath>../../libDCM/estAirspeed.c</itemPath>
+        <itemPath>../../libDCM/estAltitude.c</itemPath>
+        <itemPath>../../libDCM/estLocation.c</itemPath>
+        <itemPath>../../libDCM/estWind.c</itemPath>
+        <itemPath>../../libDCM/estYawDrift.c</itemPath>
+        <itemPath>../../libDCM/gpsData.c</itemPath>
+        <itemPath>../../libDCM/gpsParseCommon.c</itemPath>
+        <itemPath>../../libDCM/gpsParseMTEK.c</itemPath>
+        <itemPath>../../libDCM/gpsParseNMEA.c</itemPath>
+        <itemPath>../../libDCM/gpsParseSTD.c</itemPath>
+        <itemPath>../../libDCM/gpsParseUBX.c</itemPath>
+        <itemPath>../../libDCM/hilsim.c</itemPath>
+        <itemPath>../../libDCM/libDCM.c</itemPath>
+        <itemPath>../../libDCM/mag_drift.c</itemPath>
+        <itemPath>../../libDCM/mathlib.c</itemPath>
+        <itemPath>../../libDCM/mathlibNAV.c</itemPath>
+        <itemPath>../../libDCM/rmat.c</itemPath>
+      </logicalFolder>
+      <logicalFolder name="libFlashFS" displayName="libFlashFS" projectFiles="true">
+        <itemPath>../../libFlashFS/AT45D.c</itemPath>
+        <itemPath>../../libFlashFS/AT45D_DMA.c</itemPath>
+        <itemPath>../../libFlashFS/AT45D_FS.c</itemPath>
+        <itemPath>../../libFlashFS/EEPROM.c</itemPath>
+        <itemPath>../../libFlashFS/EEPROM_FS.c</itemPath>
+        <itemPath>../../libFlashFS/filesys.c</itemPath>
+        <itemPath>../../libFlashFS/MDD_AT45D.c</itemPath>
+        <itemPath>../../libFlashFS/MDD_EEPROM.c</itemPath>
+        <itemPath>../../libFlashFS/usb.c</itemPath>
+        <itemPath>../../libFlashFS/usb_cdc.c</itemPath>
+        <itemPath>../../libFlashFS/usb_descriptors.c</itemPath>
+        <itemPath>../../libFlashFS/usb_msd.c</itemPath>
+      </logicalFolder>
+      <logicalFolder name="libUDB" displayName="libUDB" projectFiles="true">
+        <itemPath>../../libUDB/24LC256.c</itemPath>
+        <itemPath>../../libUDB/ADchannel.c</itemPath>
+        <itemPath>../../libUDB/analog2digital_auav3.c</itemPath>
+        <itemPath>../../libUDB/analog2digital_udb4.c</itemPath>
+        <itemPath>../../libUDB/analog2digital_udb5.c</itemPath>
+        <itemPath>../../libUDB/analogs.c</itemPath>
+        <itemPath>../../libUDB/background.c</itemPath>
+        <itemPath>../../libUDB/barometer.c</itemPath>
+        <itemPath>../../libUDB/eeprom_udb4.c</itemPath>
+        <itemPath>../../libUDB/events.c</itemPath>
+        <itemPath>../../libUDB/fbcl.s</itemPath>
+        <itemPath>../../libUDB/heartbeat.c</itemPath>
+        <itemPath>../../libUDB/I2C1.c</itemPath>
+        <itemPath>../../libUDB/I2C2.c</itemPath>
+        <itemPath>../../libUDB/libUDB.c</itemPath>
+        <itemPath>../../libUDB/magnetometer.c</itemPath>
+        <itemPath>../../libUDB/mcu.c</itemPath>
+        <itemPath>../../libUDB/mpu6000.c</itemPath>
+        <itemPath>../../libUDB/mpu_spi.c</itemPath>
+        <itemPath>../../libUDB/osd.c</itemPath>
+        <itemPath>../../libUDB/osd_bit.c</itemPath>
+        <itemPath>../../libUDB/osd_spi.c</itemPath>
+        <itemPath>../../libUDB/radioIn.c</itemPath>
+        <itemPath>../../libUDB/read.c</itemPath>
+        <itemPath>../../libUDB/serialIO.c</itemPath>
+        <itemPath>../../libUDB/servoOut.c</itemPath>
+        <itemPath>../../libUDB/sonarIn.c</itemPath>
+        <itemPath>../../libUDB/traps.c</itemPath>
+        <itemPath>../../libUDB/traps_asm.s</itemPath>
+        <itemPath>../../libUDB/uart.c</itemPath>
+        <itemPath>../../libUDB/write.c</itemPath>
+      </logicalFolder>
+      <logicalFolder name="libVectorMatrix"
+                     displayName="libVectorMatrix"
+                     projectFiles="true">
+        <itemPath>../../libVectorMatrix/madd.s</itemPath>
+        <itemPath>../../libVectorMatrix/mmul.s</itemPath>
+        <itemPath>../../libVectorMatrix/mscl.s</itemPath>
+        <itemPath>../../libVectorMatrix/msub.s</itemPath>
+        <itemPath>../../libVectorMatrix/mtrp.s</itemPath>
+        <itemPath>../../libVectorMatrix/vadd.s</itemPath>
+        <itemPath>../../libVectorMatrix/vcon.s</itemPath>
+        <itemPath>../../libVectorMatrix/vcopy.s</itemPath>
+        <itemPath>../../libVectorMatrix/vcor.s</itemPath>
+        <itemPath>../../libVectorMatrix/vdot.s</itemPath>
+        <itemPath>../../libVectorMatrix/vmax.s</itemPath>
+        <itemPath>../../libVectorMatrix/vmin.s</itemPath>
+        <itemPath>../../libVectorMatrix/vmul.s</itemPath>
+        <itemPath>../../libVectorMatrix/vneg.s</itemPath>
+        <itemPath>../../libVectorMatrix/vpow.s</itemPath>
+        <itemPath>../../libVectorMatrix/vscl.s</itemPath>
+        <itemPath>../../libVectorMatrix/vsub.s</itemPath>
+        <itemPath>../../libVectorMatrix/vzpad.s</itemPath>
+      </logicalFolder>
+      <logicalFolder name="MatrixPilot" displayName="MatrixPilot" projectFiles="true">
         <itemPath>../../MatrixPilot/airspeedCntrl.c</itemPath>
         <itemPath>../../MatrixPilot/altitudeCntrl.c</itemPath>
         <itemPath>../../MatrixPilot/altitudeCntrlVariable.c</itemPath>
@@ -403,117 +503,37 @@
         <itemPath>../../MatrixPilot/yawCntrl.c</itemPath>
       </logicalFolder>
       <logicalFolder name="MAVLink" displayName="MAVLink" projectFiles="true">
-      <logicalFolder name="include" displayName="include" projectFiles="true">
-        <itemPath>../../MAVLink/include/bittest.c</itemPath>
-      </logicalFolder>
+        <logicalFolder name="include" displayName="include" projectFiles="true">
+          <itemPath>../../MAVLink/include/bittest.c</itemPath>
+        </logicalFolder>
         <itemPath>../../MAVLink/MAVFTP.c</itemPath>
       </logicalFolder>
-      <logicalFolder name="libDCM" displayName="libDCM" projectFiles="true">
-        <itemPath>../../libDCM/deadReckoning.c</itemPath>
-        <itemPath>../../libDCM/estAirspeed.c</itemPath>
-        <itemPath>../../libDCM/estAltitude.c</itemPath>
-        <itemPath>../../libDCM/estLocation.c</itemPath>
-        <itemPath>../../libDCM/estWind.c</itemPath>
-        <itemPath>../../libDCM/estYawDrift.c</itemPath>
-        <itemPath>../../libDCM/gpsData.c</itemPath>
-        <itemPath>../../libDCM/gpsParseCommon.c</itemPath>
-        <itemPath>../../libDCM/gpsParseMTEK.c</itemPath>
-        <itemPath>../../libDCM/gpsParseNMEA.c</itemPath>
-        <itemPath>../../libDCM/gpsParseSTD.c</itemPath>
-        <itemPath>../../libDCM/gpsParseUBX.c</itemPath>
-        <itemPath>../../libDCM/hilsim.c</itemPath>
-        <itemPath>../../libDCM/libDCM.c</itemPath>
-        <itemPath>../../libDCM/mag_drift.c</itemPath>
-        <itemPath>../../libDCM/mathlib.c</itemPath>
-        <itemPath>../../libDCM/mathlibNAV.c</itemPath>
-        <itemPath>../../libDCM/rmat.c</itemPath>
-      </logicalFolder>
-      <logicalFolder name="libUDB" displayName="libUDB" projectFiles="true">
-        <itemPath>../../libUDB/24LC256.c</itemPath>
-        <itemPath>../../libUDB/ADchannel.c</itemPath>
-        <itemPath>../../libUDB/analog2digital_auav3.c</itemPath>
-        <itemPath>../../libUDB/analog2digital_udb4.c</itemPath>
-        <itemPath>../../libUDB/analog2digital_udb5.c</itemPath>
-        <itemPath>../../libUDB/analogs.c</itemPath>
-        <itemPath>../../libUDB/background.c</itemPath>
-        <itemPath>../../libUDB/barometer.c</itemPath>
-        <itemPath>../../libUDB/eeprom_udb4.c</itemPath>
-        <itemPath>../../libUDB/events.c</itemPath>
-        <itemPath>../../libUDB/fbcl.s</itemPath>
-        <itemPath>../../libUDB/heartbeat.c</itemPath>
-        <itemPath>../../libUDB/I2C1.c</itemPath>
-        <itemPath>../../libUDB/I2C2.c</itemPath>
-        <itemPath>../../libUDB/libUDB.c</itemPath>
-        <itemPath>../../libUDB/magnetometer.c</itemPath>
-        <itemPath>../../libUDB/mcu.c</itemPath>
-        <itemPath>../../libUDB/mpu6000.c</itemPath>
-        <itemPath>../../libUDB/mpu_spi.c</itemPath>
-        <itemPath>../../libUDB/osd.c</itemPath>
-        <itemPath>../../libUDB/osd_bit.c</itemPath>
-        <itemPath>../../libUDB/osd_spi.c</itemPath>
-        <itemPath>../../libUDB/radioIn.c</itemPath>
-        <itemPath>../../libUDB/read.c</itemPath>
-        <itemPath>../../libUDB/serialIO.c</itemPath>
-        <itemPath>../../libUDB/servoOut.c</itemPath>
-        <itemPath>../../libUDB/sonarIn.c</itemPath>
-        <itemPath>../../libUDB/traps.c</itemPath>
-        <itemPath>../../libUDB/traps_asm.s</itemPath>
-        <itemPath>../../libUDB/uart.c</itemPath>
-        <itemPath>../../libUDB/write.c</itemPath>
-      </logicalFolder>
-      <logicalFolder name="libVectorMatrix" displayName="libVectorMatrix" projectFiles="true">
-        <itemPath>../../libVectorMatrix/madd.s</itemPath>
-        <itemPath>../../libVectorMatrix/mmul.s</itemPath>
-        <itemPath>../../libVectorMatrix/mscl.s</itemPath>
-        <itemPath>../../libVectorMatrix/msub.s</itemPath>
-        <itemPath>../../libVectorMatrix/mtrp.s</itemPath>
-        <itemPath>../../libVectorMatrix/vadd.s</itemPath>
-        <itemPath>../../libVectorMatrix/vcon.s</itemPath>
-        <itemPath>../../libVectorMatrix/vcopy.s</itemPath>
-        <itemPath>../../libVectorMatrix/vcor.s</itemPath>
-        <itemPath>../../libVectorMatrix/vdot.s</itemPath>
-        <itemPath>../../libVectorMatrix/vmax.s</itemPath>
-        <itemPath>../../libVectorMatrix/vmin.s</itemPath>
-        <itemPath>../../libVectorMatrix/vmul.s</itemPath>
-        <itemPath>../../libVectorMatrix/vneg.s</itemPath>
-        <itemPath>../../libVectorMatrix/vpow.s</itemPath>
-        <itemPath>../../libVectorMatrix/vscl.s</itemPath>
-        <itemPath>../../libVectorMatrix/vsub.s</itemPath>
-        <itemPath>../../libVectorMatrix/vzpad.s</itemPath>
-      </logicalFolder>
-      <logicalFolder name="libFlashFS" displayName="libFlashFS" projectFiles="true">
-        <itemPath>../../libFlashFS/AT45D.c</itemPath>
-        <itemPath>../../libFlashFS/AT45D_DMA.c</itemPath>
-        <itemPath>../../libFlashFS/AT45D_FS.c</itemPath>
-        <itemPath>../../libFlashFS/EEPROM.c</itemPath>
-        <itemPath>../../libFlashFS/EEPROM_FS.c</itemPath>
-        <itemPath>../../libFlashFS/filesys.c</itemPath>
-        <itemPath>../../libFlashFS/MDD_AT45D.c</itemPath>
-        <itemPath>../../libFlashFS/MDD_EEPROM.c</itemPath>
-        <itemPath>../../libFlashFS/usb.c</itemPath>
-        <itemPath>../../libFlashFS/usb_cdc.c</itemPath>
-        <itemPath>../../libFlashFS/usb_descriptors.c</itemPath>
-        <itemPath>../../libFlashFS/usb_msd.c</itemPath>
-      </logicalFolder>
       <logicalFolder name="Microchip" displayName="Microchip" projectFiles="true">
-      <logicalFolder name="MDD-File-System" displayName="MDD-File-System" projectFiles="true">
-        <itemPath>../../Microchip/MDD-File-System/FSIO.c</itemPath>
-        <itemPath>../../Microchip/MDD-File-System/SD-SPI.c</itemPath>
+        <logicalFolder name="MDD-File-System"
+                       displayName="MDD-File-System"
+                       projectFiles="true">
+          <itemPath>../../Microchip/MDD-File-System/FSIO.c</itemPath>
+          <itemPath>../../Microchip/MDD-File-System/SD-SPI.c</itemPath>
+        </logicalFolder>
+        <logicalFolder name="USB" displayName="USB" projectFiles="true">
+          <logicalFolder name="CDC-Device-Driver"
+                         displayName="CDC-Device-Driver"
+                         projectFiles="true">
+            <itemPath>../../Microchip/USB/CDC-Device-Driver/usb_function_cdc.c</itemPath>
+          </logicalFolder>
+          <logicalFolder name="MSD-Device-Driver"
+                         displayName="MSD-Device-Driver"
+                         projectFiles="true">
+            <itemPath>../../Microchip/USB/MSD-Device-Driver/usb_function_msd.c</itemPath>
+          </logicalFolder>
+          <itemPath>../../Microchip/USB/usb_device.c</itemPath>
+          <itemPath>../../Microchip/USB/usb_hal_dspic33e.c</itemPath>
+        </logicalFolder>
       </logicalFolder>
-      <logicalFolder name="USB" displayName="USB" projectFiles="true">
-      <logicalFolder name="CDC-Device-Driver" displayName="CDC-Device-Driver" projectFiles="true">
-        <itemPath>../../Microchip/USB/CDC-Device-Driver/usb_function_cdc.c</itemPath>
-      </logicalFolder>
-      <logicalFolder name="MSD-Device-Driver" displayName="MSD-Device-Driver" projectFiles="true">
-        <itemPath>../../Microchip/USB/MSD-Device-Driver/usb_function_msd.c</itemPath>
-      </logicalFolder>
-        <itemPath>../../Microchip/USB/usb_device.c</itemPath>
-        <itemPath>../../Microchip/USB/usb_hal_dspic33e.c</itemPath>
-      </logicalFolder>
-      </logicalFolder>
-</logicalFolder>
+    </logicalFolder>
     <logicalFolder name="ExternalFiles"
-    displayName="Important Files" projectFiles="false">
+                   displayName="Important Files"
+                   projectFiles="false">
       <itemPath>Makefile</itemPath>
     </logicalFolder>
   </logicalFolder>
@@ -534,149 +554,229 @@
         <targetPluginBoard></targetPluginBoard>
         <platformTool>PICkit3PlatformTool</platformTool>
         <languageToolchain>XC16</languageToolchain>
-        <languageToolchainVersion>1.10</languageToolchainVersion>
-        <platform>3</platform>
+        <languageToolchainVersion>1.26</languageToolchainVersion>
+        <platform>4</platform>
       </toolsSet>
       <compileType>
         <linkerTool>
-          <linkerLibItems></linkerLibItems>
+          <linkerLibItems>
+          </linkerLibItems>
         </linkerTool>
+        <archiverTool>
+        </archiverTool>
         <loading>
-          <useAlternateLoadableFile>
-          false</useAlternateLoadableFile>
+          <useAlternateLoadableFile>false</useAlternateLoadableFile>
+          <parseOnProdLoad>false</parseOnProdLoad>
           <alternateLoadableFile></alternateLoadableFile>
         </loading>
       </compileType>
       <makeCustomizationType>
-        <makeCustomizationPreStepEnabled>
-        false</makeCustomizationPreStepEnabled>
+        <makeCustomizationPreStepEnabled>false</makeCustomizationPreStepEnabled>
         <makeCustomizationPreStep></makeCustomizationPreStep>
-        <makeCustomizationPostStepEnabled>
-        false</makeCustomizationPostStepEnabled>
+        <makeCustomizationPostStepEnabled>false</makeCustomizationPostStepEnabled>
         <makeCustomizationPostStep></makeCustomizationPostStep>
-        <makeCustomizationPutChecksumInUserID>
-        false</makeCustomizationPutChecksumInUserID>
-        <makeCustomizationEnableLongLines>
-        false</makeCustomizationEnableLongLines>
-        <makeCustomizationNormalizeHexFile>
-        false</makeCustomizationNormalizeHexFile>
+        <makeCustomizationPutChecksumInUserID>false</makeCustomizationPutChecksumInUserID>
+        <makeCustomizationEnableLongLines>false</makeCustomizationEnableLongLines>
+        <makeCustomizationNormalizeHexFile>false</makeCustomizationNormalizeHexFile>
       </makeCustomizationType>
       <C30>
-        <property key="code-model" value="large-code" />
-        <property key="const-model" value="default" />
-        <property key="data-model" value="large-data" />
-        <property key="enable-all-warnings" value="true" />
-        <property key="enable-ansi-std" value="false" />
-        <property key="enable-ansi-warnings" value="false" />
-        <property key="enable-fatal-warnings" value="false" />
-        <property key="enable-large-arrays" value="false" />
-        <property key="enable-omit-frame-pointer" value="false" />
-        <property key="enable-procedural-abstraction"
-        value="false" />
-        <property key="enable-short-double" value="false" />
-        <property key="enable-symbols" value="true" />
-        <property key="enable-unroll-loops" value="false" />
+        <property key="code-model" value="large-code"/>
+        <property key="const-model" value="default"/>
+        <property key="data-model" value="large-data"/>
+        <property key="disable-instruction-scheduling" value="false"/>
+        <property key="enable-all-warnings" value="true"/>
+        <property key="enable-ansi-std" value="false"/>
+        <property key="enable-ansi-warnings" value="false"/>
+        <property key="enable-fatal-warnings" value="false"/>
+        <property key="enable-large-arrays" value="false"/>
+        <property key="enable-omit-frame-pointer" value="false"/>
+        <property key="enable-procedural-abstraction" value="false"/>
+        <property key="enable-short-double" value="false"/>
+        <property key="enable-symbols" value="true"/>
+        <property key="enable-unroll-loops" value="false"/>
         <property key="extra-include-directories"
-        value="../../Config;../../MAVLink/include;../../Microchip;../../Microchip/Include;../../libVectorMatrix" />
-        <property key="isolate-each-function" value="false" />
-        <property key="keep-inline" value="false" />
-        <property key="oXC16gcc-align-arr" value="false" />
-        <property key="oXC16gcc-cnsts-mauxflash" value="false" />
-        <property key="oXC16gcc-data-sects" value="false" />
-        <property key="oXC16gcc-errata" value="" />
-        <property key="oXC16gcc-fillupper" value="" />
-        <property key="oXC16gcc-large-aggregate" value="false" />
-        <property key="oXC16gcc-mauxflash" value="false" />
-        <property key="oXC16gcc-mpa-lvl" value="" />
-        <property key="oXC16gcc-name-text-sec" value="" />
-        <property key="oXC16gcc-near-chars" value="false" />
-        <property key="oXC16gcc-no-isr-warn" value="false" />
-        <property key="oXC16gcc-sfr-warn" value="false" />
-        <property key="oXC16gcc-smar-io-lvl" value="1" />
-        <property key="oXC16gcc-smart-io-fmt" value="" />
-        <property key="optimization-level" value="0" />
-        <property key="post-instruction-scheduling"
-        value="default" />
-        <property key="pre-instruction-scheduling"
-        value="default" />
-        <property key="preprocessor-macros"
-        value="UDB4=1;" />
-        <property key="scalar-model" value="default" />
-        <property key="use-cci" value="false" />
+                  value="../../Config;../../MAVLink/include;../../Microchip;../../Microchip/Include;../../libVectorMatrix"/>
+        <property key="isolate-each-function" value="false"/>
+        <property key="keep-inline" value="false"/>
+        <property key="oXC16gcc-align-arr" value="false"/>
+        <property key="oXC16gcc-cnsts-mauxflash" value="false"/>
+        <property key="oXC16gcc-data-sects" value="false"/>
+        <property key="oXC16gcc-errata" value=""/>
+        <property key="oXC16gcc-fillupper" value=""/>
+        <property key="oXC16gcc-large-aggregate" value="false"/>
+        <property key="oXC16gcc-mauxflash" value="false"/>
+        <property key="oXC16gcc-mpa-lvl" value=""/>
+        <property key="oXC16gcc-name-text-sec" value=""/>
+        <property key="oXC16gcc-near-chars" value="false"/>
+        <property key="oXC16gcc-no-isr-warn" value="false"/>
+        <property key="oXC16gcc-sfr-warn" value="false"/>
+        <property key="oXC16gcc-smar-io-lvl" value="1"/>
+        <property key="oXC16gcc-smart-io-fmt" value=""/>
+        <property key="optimization-level" value="0"/>
+        <property key="post-instruction-scheduling" value="default"/>
+        <property key="pre-instruction-scheduling" value="default"/>
+        <property key="preprocessor-macros" value="UDB4=1"/>
+        <property key="scalar-model" value="default"/>
+        <property key="use-cci" value="false"/>
+        <property key="use-iar" value="false"/>
       </C30>
+      <C30-AR>
+        <property key="additional-options-chop-files" value="false"/>
+      </C30-AR>
       <C30-AS>
-        <property key="assembler-symbols" value="PSV_ERRATA=1" />
-        <property key="expand-macros" value="false" />
+        <property key="assembler-symbols" value="PSV_ERRATA=1"/>
+        <property key="expand-macros" value="false"/>
         <property key="extra-include-directories-for-assembler"
-        value="..;../../libVectorMatrix" />
-        <property key="extra-include-directories-for-preprocessor"
-        value="" />
-        <property key="false-conditionals" value="false" />
-        <property key="keep-locals" value="false" />
-        <property key="list-assembly" value="false" />
-        <property key="list-section-info" value="false" />
-        <property key="list-source" value="false" />
-        <property key="list-symbols" value="false" />
-        <property key="oXC16asm-extra-opts" value="" />
-        <property key="oXC16asm-list-to-file" value="false" />
-        <property key="omit-debug-dirs" value="false" />
-        <property key="omit-forms" value="false" />
-        <property key="preprocessor-macros" value="" />
-        <property key="relax" value="false" />
-        <property key="warning-level" value="emit-warnings" />
-        <appendMe value="-g" />
+                  value="..;../../libVectorMatrix"/>
+        <property key="extra-include-directories-for-preprocessor" value=""/>
+        <property key="false-conditionals" value="false"/>
+        <property key="keep-locals" value="false"/>
+        <property key="list-assembly" value="false"/>
+        <property key="list-section-info" value="false"/>
+        <property key="list-source" value="false"/>
+        <property key="list-symbols" value="false"/>
+        <property key="oXC16asm-extra-opts" value=""/>
+        <property key="oXC16asm-list-to-file" value="false"/>
+        <property key="omit-debug-dirs" value="false"/>
+        <property key="omit-forms" value="false"/>
+        <property key="preprocessor-macros" value=""/>
+        <property key="relax" value="false"/>
+        <property key="warning-level" value="emit-warnings"/>
+        <appendMe value="-g"/>
       </C30-AS>
       <C30-LD>
-        <property key="additional-options-use-response-files"
-        value="false" />
-        <property key="boot-eeprom" value="no_eeprom" />
-        <property key="boot-flash" value="no_flash" />
-        <property key="boot-ram" value="no_ram" />
-        <property key="boot-write-protect"
-        value="no_write_protect" />
-        <property key="enable-check-sections" value="false" />
-        <property key="enable-data-init" value="true" />
-        <property key="enable-default-isr" value="true" />
-        <property key="enable-handles" value="true" />
-        <property key="enable-pack-data" value="true" />
-        <property key="extra-lib-directories" value="" />
-        <property key="general-code-protect"
-        value="no_code_protect" />
-        <property key="general-write-protect"
-        value="no_write_protect" />
-        <property key="generate-cross-reference-file"
-        value="false" />
-        <property key="heap-size" value="256" />
-        <property key="input-libraries" value="" />
-        <property key="linker-symbols" value="" />
+        <property key="additional-options-use-response-files" value="false"/>
+        <property key="boot-eeprom" value="no_eeprom"/>
+        <property key="boot-flash" value="no_flash"/>
+        <property key="boot-ram" value="no_ram"/>
+        <property key="boot-write-protect" value="no_write_protect"/>
+        <property key="enable-check-sections" value="false"/>
+        <property key="enable-data-init" value="true"/>
+        <property key="enable-default-isr" value="true"/>
+        <property key="enable-handles" value="true"/>
+        <property key="enable-pack-data" value="true"/>
+        <property key="extra-lib-directories" value=""/>
+        <property key="fill-flash-options-addr" value=""/>
+        <property key="fill-flash-options-const" value=""/>
+        <property key="fill-flash-options-how" value="0"/>
+        <property key="fill-flash-options-inc-const" value="1"/>
+        <property key="fill-flash-options-increment" value=""/>
+        <property key="fill-flash-options-seq" value=""/>
+        <property key="fill-flash-options-what" value="0"/>
+        <property key="general-code-protect" value="no_code_protect"/>
+        <property key="general-write-protect" value="no_write_protect"/>
+        <property key="generate-cross-reference-file" value="false"/>
+        <property key="heap-size" value="256"/>
+        <property key="input-libraries" value=""/>
+        <property key="linker-stack" value="true"/>
+        <property key="linker-symbols" value=""/>
         <property key="map-file"
-        value="&quot;${DISTDIR}/MatrixPilot-UDB4.X.${IMAGE_TYPE}.map&quot;" />
-        <property key="oXC16ld-extra-opts" value="" />
-        <property key="oXC16ld-fill-upper" value="0" />
-        <property key="oXC16ld-force-link" value="false" />
-        <property key="oXC16ld-no-smart-io" value="false" />
-        <property key="oXC16ld-nostdlib" value="false" />
-        <property key="oXC16ld-stackguard" value="16" />
-        <property key="preprocessor-macros" value="" />
-        <property key="remove-unused-sections" value="false" />
-        <property key="report-memory-usage" value="false" />
-        <property key="secure-eeprom" value="no_eeprom" />
-        <property key="secure-flash" value="no_flash" />
-        <property key="secure-ram" value="no_ram" />
-        <property key="secure-write-protect"
-        value="no_write_protect" />
-        <property key="stack-size" value="16" />
-        <property key="symbol-stripping" value="" />
-        <property key="trace-symbols" value="" />
-        <property key="warn-section-align" value="false" />
+                  value="&quot;${DISTDIR}/MatrixPilot-UDB4.X.${IMAGE_TYPE}.map&quot;"/>
+        <property key="oXC16ld-extra-opts" value=""/>
+        <property key="oXC16ld-fill-upper" value="0"/>
+        <property key="oXC16ld-force-link" value="false"/>
+        <property key="oXC16ld-no-smart-io" value="false"/>
+        <property key="oXC16ld-nostdlib" value="false"/>
+        <property key="oXC16ld-stackguard" value="16"/>
+        <property key="preprocessor-macros" value=""/>
+        <property key="remove-unused-sections" value="false"/>
+        <property key="report-memory-usage" value="false"/>
+        <property key="secure-eeprom" value="no_eeprom"/>
+        <property key="secure-flash" value="no_flash"/>
+        <property key="secure-ram" value="no_ram"/>
+        <property key="secure-write-protect" value="no_write_protect"/>
+        <property key="stack-size" value="16"/>
+        <property key="symbol-stripping" value=""/>
+        <property key="trace-symbols" value=""/>
+        <property key="warn-section-align" value="false"/>
       </C30-LD>
       <C30Global>
-        <property key="fast-math" value="false" />
-        <property key="generic-16-bit" value="false" />
-        <property key="legacy-libc" value="true" />
-        <property key="oXC16glb-macros" value="" />
-        <property key="output-file-format" value="elf" />
+        <property key="common-include-directories" value=""/>
+        <property key="dual-boot-partition" value="0"/>
+        <property key="fast-math" value="false"/>
+        <property key="generic-16-bit" value="false"/>
+        <property key="legacy-libc" value="true"/>
+        <property key="oXC16glb-macros" value=""/>
+        <property key="output-file-format" value="elf"/>
+        <property key="relaxed-math" value="false"/>
+        <property key="save-temps" value="false"/>
       </C30Global>
+      <PICkit3PlatformTool>
+        <property key="ADC 1" value="true"/>
+        <property key="ADC 2" value="true"/>
+        <property key="AutoSelectMemRanges" value="auto"/>
+        <property key="DCI" value="true"/>
+        <property key="Freeze All Other Peripherals" value="true"/>
+        <property key="I2C1" value="true"/>
+        <property key="I2C2" value="true"/>
+        <property key="INPUT CAPTURE 1" value="true"/>
+        <property key="INPUT CAPTURE 2" value="true"/>
+        <property key="INPUT CAPTURE 3" value="true"/>
+        <property key="INPUT CAPTURE 4" value="true"/>
+        <property key="INPUT CAPTURE 5" value="true"/>
+        <property key="INPUT CAPTURE 6" value="true"/>
+        <property key="INPUT CAPTURE 7" value="true"/>
+        <property key="INPUT CAPTURE 8" value="true"/>
+        <property key="OUTPUT COMPARE 1" value="true"/>
+        <property key="OUTPUT COMPARE 2" value="true"/>
+        <property key="OUTPUT COMPARE 3" value="true"/>
+        <property key="OUTPUT COMPARE 4" value="true"/>
+        <property key="OUTPUT COMPARE 5" value="true"/>
+        <property key="OUTPUT COMPARE 6" value="true"/>
+        <property key="OUTPUT COMPARE 7" value="true"/>
+        <property key="OUTPUT COMPARE 8" value="true"/>
+        <property key="SPI 1" value="true"/>
+        <property key="SPI 2" value="true"/>
+        <property key="SecureSegment.SegmentProgramming" value="FullChipProgramming"/>
+        <property key="TIMER1" value="true"/>
+        <property key="TIMER2" value="true"/>
+        <property key="TIMER3" value="true"/>
+        <property key="TIMER4" value="true"/>
+        <property key="TIMER5" value="true"/>
+        <property key="TIMER6" value="true"/>
+        <property key="TIMER7" value="true"/>
+        <property key="TIMER8" value="true"/>
+        <property key="TIMER9" value="true"/>
+        <property key="ToolFirmwareFilePath"
+                  value="Press to browse for a specific firmware version"/>
+        <property key="ToolFirmwareOption.UseLatestFirmware" value="true"/>
+        <property key="UART 1" value="true"/>
+        <property key="UART 2" value="true"/>
+        <property key="hwtoolclock.frcindebug" value="false"/>
+        <property key="memories.aux" value="false"/>
+        <property key="memories.bootflash" value="true"/>
+        <property key="memories.configurationmemory" value="true"/>
+        <property key="memories.configurationmemory2" value="true"/>
+        <property key="memories.dataflash" value="true"/>
+        <property key="memories.eeprom" value="true"/>
+        <property key="memories.flashdata" value="true"/>
+        <property key="memories.id" value="true"/>
+        <property key="memories.programmemory" value="true"/>
+        <property key="memories.programmemory.end" value="0x2abff"/>
+        <property key="memories.programmemory.partition2" value="true"/>
+        <property key="memories.programmemory.partition2.end"
+                  value="${memories.programmemory.partition2.end.value}"/>
+        <property key="memories.programmemory.partition2.start"
+                  value="${memories.programmemory.partition2.start.value}"/>
+        <property key="memories.programmemory.start" value="0x0"/>
+        <property key="poweroptions.powerenable" value="false"/>
+        <property key="programmertogo.imagename" value=""/>
+        <property key="programoptions.donoteraseauxmem" value="false"/>
+        <property key="programoptions.eraseb4program" value="true"/>
+        <property key="programoptions.pgmspeed" value="2"/>
+        <property key="programoptions.preservedataflash" value="false"/>
+        <property key="programoptions.preserveeeprom" value="false"/>
+        <property key="programoptions.preserveprogramrange" value="false"/>
+        <property key="programoptions.preserveprogramrange.end" value="0x2abff"/>
+        <property key="programoptions.preserveprogramrange.start" value="0x0"/>
+        <property key="programoptions.preserveuserid" value="false"/>
+        <property key="programoptions.programcalmem" value="false"/>
+        <property key="programoptions.programuserotp" value="false"/>
+        <property key="programoptions.testmodeentrymethod" value="VDDFirst"/>
+        <property key="programoptions.usehighvoltageonmclr" value="false"/>
+        <property key="programoptions.uselvpprogramming" value="false"/>
+        <property key="voltagevalue" value="3.25"/>
+      </PICkit3PlatformTool>
     </conf>
   </confs>
 </configurationDescriptor>

--- a/MatrixPilot/MatrixPilot-udb5.X/nbproject/configurations.xml
+++ b/MatrixPilot/MatrixPilot-udb5.X/nbproject/configurations.xml
@@ -1,24 +1,25 @@
-<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="UTF-8"?>
 <configurationDescriptor version="62">
-  <logicalFolder name="root" displayName="root"
-  projectFiles="true">
-    <logicalFolder name="HeaderFiles" displayName="Header Files"
-    projectFiles="true">      <logicalFolder name="Config" displayName="Config" projectFiles="true">
+  <logicalFolder name="root" displayName="root" projectFiles="true">
+    <logicalFolder name="HeaderFiles"
+                   displayName="Header Files"
+                   projectFiles="true">
+      <logicalFolder name="Config" displayName="Config" projectFiles="true">
+        <logicalFolder name="Cessna" displayName="Cessna" projectFiles="true">
+          <itemPath>../../Config/Cessna/airspeed_options.h</itemPath>
+          <itemPath>../../Config/Cessna/FSconfig.h</itemPath>
+          <itemPath>../../Config/Cessna/magnetometerOptions.h</itemPath>
+          <itemPath>../../Config/Cessna/mavlink_options.h</itemPath>
+          <itemPath>../../Config/Cessna/nv_memory_options.h</itemPath>
+          <itemPath>../../Config/Cessna/options.h</itemPath>
+          <itemPath>../../Config/Cessna/options_auav3.h</itemPath>
+          <itemPath>../../Config/Cessna/osd_config.h</itemPath>
+          <itemPath>../../Config/Cessna/ports_config.h</itemPath>
+        </logicalFolder>
+        <logicalFolder name="CloudsFly" displayName="CloudsFly" projectFiles="true">
+          <itemPath>../../Config/CloudsFly/options.h</itemPath>
+        </logicalFolder>
         <itemPath>../../Config/airspeed_options.h</itemPath>
-      <logicalFolder name="Cessna" displayName="Cessna" projectFiles="true">
-        <itemPath>../../Config/Cessna/airspeed_options.h</itemPath>
-        <itemPath>../../Config/Cessna/FSconfig.h</itemPath>
-        <itemPath>../../Config/Cessna/magnetometerOptions.h</itemPath>
-        <itemPath>../../Config/Cessna/mavlink_options.h</itemPath>
-        <itemPath>../../Config/Cessna/nv_memory_options.h</itemPath>
-        <itemPath>../../Config/Cessna/options.h</itemPath>
-        <itemPath>../../Config/Cessna/options_auav3.h</itemPath>
-        <itemPath>../../Config/Cessna/osd_config.h</itemPath>
-        <itemPath>../../Config/Cessna/ports_config.h</itemPath>
-      </logicalFolder>
-      <logicalFolder name="CloudsFly" displayName="CloudsFly" projectFiles="true">
-        <itemPath>../../Config/CloudsFly/options.h</itemPath>
-      </logicalFolder>
         <itemPath>../../Config/FSconfig.h</itemPath>
         <itemPath>../../Config/magnetometerOptions.h</itemPath>
         <itemPath>../../Config/mavlink_options.h</itemPath>
@@ -28,7 +29,81 @@
         <itemPath>../../Config/osd_config.h</itemPath>
         <itemPath>../../Config/ports_config.h</itemPath>
       </logicalFolder>
+      <logicalFolder name="libDCM" displayName="libDCM" projectFiles="true">
+        <itemPath>../../libDCM/dcmTypes.h</itemPath>
+        <itemPath>../../libDCM/deadReckoning.h</itemPath>
+        <itemPath>../../libDCM/estAltitude.h</itemPath>
+        <itemPath>../../libDCM/estLocation.h</itemPath>
+        <itemPath>../../libDCM/estWind.h</itemPath>
+        <itemPath>../../libDCM/estYawDrift.h</itemPath>
+        <itemPath>../../libDCM/gpsData.h</itemPath>
+        <itemPath>../../libDCM/gpsParseCommon.h</itemPath>
+        <itemPath>../../libDCM/libDCM.h</itemPath>
+        <itemPath>../../libDCM/libDCM_defines.h</itemPath>
+        <itemPath>../../libDCM/libDCM_internal.h</itemPath>
+        <itemPath>../../libDCM/mag_drift.h</itemPath>
+        <itemPath>../../libDCM/mathlib.h</itemPath>
+        <itemPath>../../libDCM/mathlibNAV.h</itemPath>
+        <itemPath>../../libDCM/rmat.h</itemPath>
+      </logicalFolder>
+      <logicalFolder name="libFlashFS" displayName="libFlashFS" projectFiles="true">
+        <itemPath>../../libFlashFS/AT45D.h</itemPath>
+        <itemPath>../../libFlashFS/EEPROM.h</itemPath>
+        <itemPath>../../libFlashFS/filesys.h</itemPath>
+        <itemPath>../../libFlashFS/MDD_AT45D.h</itemPath>
+        <itemPath>../../libFlashFS/MDD_EEPROM.h</itemPath>
+      </logicalFolder>
+      <logicalFolder name="libUDB" displayName="libUDB" projectFiles="true">
+        <itemPath>../../libUDB/ADchannel.h</itemPath>
+        <itemPath>../../libUDB/analogs.h</itemPath>
+        <itemPath>../../libUDB/barometer.h</itemPath>
+        <itemPath>../../libUDB/boardRotation_defines.h</itemPath>
+        <itemPath>../../libUDB/builtins.h</itemPath>
+        <itemPath>../../libUDB/ConfigAUAV3.h</itemPath>
+        <itemPath>../../libUDB/ConfigHILSIM.h</itemPath>
+        <itemPath>../../libUDB/ConfigPX4.h</itemPath>
+        <itemPath>../../libUDB/ConfigUDB4.h</itemPath>
+        <itemPath>../../libUDB/ConfigUDB5.h</itemPath>
+        <itemPath>../../libUDB/eeprom_udb4.h</itemPath>
+        <itemPath>../../libUDB/events.h</itemPath>
+        <itemPath>../../libUDB/fixDeps.h</itemPath>
+        <itemPath>../../libUDB/heartbeat.h</itemPath>
+        <itemPath>../../libUDB/I2C.h</itemPath>
+        <itemPath>../../libUDB/interrupt.h</itemPath>
+        <itemPath>../../libUDB/libUDB.h</itemPath>
+        <itemPath>../../libUDB/libUDB_defines.h</itemPath>
+        <itemPath>../../libUDB/libUDB_internal.h</itemPath>
+        <itemPath>../../libUDB/magnetometer.h</itemPath>
+        <itemPath>../../libUDB/mcu.h</itemPath>
+        <itemPath>../../libUDB/mpu6000.h</itemPath>
+        <itemPath>../../libUDB/mpu_spi.h</itemPath>
+        <itemPath>../../libUDB/NV_memory.h</itemPath>
+        <itemPath>../../libUDB/oscillator.h</itemPath>
+        <itemPath>../../libUDB/osd.h</itemPath>
+        <itemPath>../../libUDB/radioIn.h</itemPath>
+        <itemPath>../../libUDB/serialIO.h</itemPath>
+        <itemPath>../../libUDB/servoOut.h</itemPath>
+        <itemPath>../../libUDB/sonarIn.h</itemPath>
+        <itemPath>../../libUDB/uart.h</itemPath>
+        <itemPath>../../libUDB/udbTypes.h</itemPath>
+      </logicalFolder>
+      <logicalFolder name="libVectorMatrix"
+                     displayName="libVectorMatrix"
+                     projectFiles="true">
+        <itemPath>../../libVectorMatrix/dspcommon.inc</itemPath>
+      </logicalFolder>
       <logicalFolder name="MatrixPilot" displayName="MatrixPilot" projectFiles="true">
+        <logicalFolder name="example-options-files"
+                       displayName="example-options-files"
+                       projectFiles="true">
+          <itemPath>../../MatrixPilot/example-options-files/options.AcroMaster-ben.h</itemPath>
+          <itemPath>../../MatrixPilot/example-options-files/options.Delta-Phil.h</itemPath>
+          <itemPath>../../MatrixPilot/example-options-files/options.EasyStar-Bill.h</itemPath>
+          <itemPath>../../MatrixPilot/example-options-files/options.GentleLady-Bill.h</itemPath>
+          <itemPath>../../MatrixPilot/example-options-files/options.HILSIM-B747-Bill.h</itemPath>
+          <itemPath>../../MatrixPilot/example-options-files/options.HILSIM-Cessna-ben.h</itemPath>
+          <itemPath>../../MatrixPilot/example-options-files/options.MiniMag-ben.h</itemPath>
+        </logicalFolder>
         <itemPath>../../MatrixPilot/airspeedCntrl.h</itemPath>
         <itemPath>../../MatrixPilot/altitudeCntrl.h</itemPath>
         <itemPath>../../MatrixPilot/behaviour.h</itemPath>
@@ -39,15 +114,6 @@
         <itemPath>../../MatrixPilot/data_storage.h</itemPath>
         <itemPath>../../MatrixPilot/defines.h</itemPath>
         <itemPath>../../MatrixPilot/euler_angles.h</itemPath>
-      <logicalFolder name="example-options-files" displayName="example-options-files" projectFiles="true">
-        <itemPath>../../MatrixPilot/example-options-files/options.AcroMaster-ben.h</itemPath>
-        <itemPath>../../MatrixPilot/example-options-files/options.Delta-Phil.h</itemPath>
-        <itemPath>../../MatrixPilot/example-options-files/options.EasyStar-Bill.h</itemPath>
-        <itemPath>../../MatrixPilot/example-options-files/options.GentleLady-Bill.h</itemPath>
-        <itemPath>../../MatrixPilot/example-options-files/options.HILSIM-B747-Bill.h</itemPath>
-        <itemPath>../../MatrixPilot/example-options-files/options.HILSIM-Cessna-ben.h</itemPath>
-        <itemPath>../../MatrixPilot/example-options-files/options.MiniMag-ben.h</itemPath>
-      </logicalFolder>
         <itemPath>../../MatrixPilot/flightplan-logo.h</itemPath>
         <itemPath>../../MatrixPilot/flightplan-waypoints.h</itemPath>
         <itemPath>../../MatrixPilot/flightplan.h</itemPath>
@@ -84,277 +150,311 @@
         <itemPath>../../MatrixPilot/waypoints.h</itemPath>
       </logicalFolder>
       <logicalFolder name="MAVLink" displayName="MAVLink" projectFiles="true">
-      <logicalFolder name="include" displayName="include" projectFiles="true">
-        <itemPath>../../MAVLink/include/checksum.h</itemPath>
-      <logicalFolder name="common" displayName="common" projectFiles="true">
-        <itemPath>../../MAVLink/include/common/common.h</itemPath>
-        <itemPath>../../MAVLink/include/common/mavlink.h</itemPath>
-        <itemPath>../../MAVLink/include/common/mavlink_msg_attitude.h</itemPath>
-        <itemPath>../../MAVLink/include/common/mavlink_msg_attitude_quaternion.h</itemPath>
-        <itemPath>../../MAVLink/include/common/mavlink_msg_attitude_quaternion_cov.h</itemPath>
-        <itemPath>../../MAVLink/include/common/mavlink_msg_attitude_setpoint_external.h</itemPath>
-        <itemPath>../../MAVLink/include/common/mavlink_msg_attitude_target.h</itemPath>
-        <itemPath>../../MAVLink/include/common/mavlink_msg_auth_key.h</itemPath>
-        <itemPath>../../MAVLink/include/common/mavlink_msg_autopilot_version.h</itemPath>
-        <itemPath>../../MAVLink/include/common/mavlink_msg_battery_status.h</itemPath>
-        <itemPath>../../MAVLink/include/common/mavlink_msg_change_operator_control.h</itemPath>
-        <itemPath>../../MAVLink/include/common/mavlink_msg_change_operator_control_ack.h</itemPath>
-        <itemPath>../../MAVLink/include/common/mavlink_msg_command_ack.h</itemPath>
-        <itemPath>../../MAVLink/include/common/mavlink_msg_command_int.h</itemPath>
-        <itemPath>../../MAVLink/include/common/mavlink_msg_command_long.h</itemPath>
-        <itemPath>../../MAVLink/include/common/mavlink_msg_data_stream.h</itemPath>
-        <itemPath>../../MAVLink/include/common/mavlink_msg_data_transmission_handshake.h</itemPath>
-        <itemPath>../../MAVLink/include/common/mavlink_msg_debug.h</itemPath>
-        <itemPath>../../MAVLink/include/common/mavlink_msg_debug_vect.h</itemPath>
-        <itemPath>../../MAVLink/include/common/mavlink_msg_distance_sensor.h</itemPath>
-        <itemPath>../../MAVLink/include/common/mavlink_msg_encapsulated_data.h</itemPath>
-        <itemPath>../../MAVLink/include/common/mavlink_msg_file_transfer_dir_list.h</itemPath>
-        <itemPath>../../MAVLink/include/common/mavlink_msg_file_transfer_protocol.h</itemPath>
-        <itemPath>../../MAVLink/include/common/mavlink_msg_file_transfer_res.h</itemPath>
-        <itemPath>../../MAVLink/include/common/mavlink_msg_file_transfer_start.h</itemPath>
-        <itemPath>../../MAVLink/include/common/mavlink_msg_global_position_int.h</itemPath>
-        <itemPath>../../MAVLink/include/common/mavlink_msg_global_position_int_cov.h</itemPath>
-        <itemPath>../../MAVLink/include/common/mavlink_msg_global_position_setpoint_external_int.h</itemPath>
-        <itemPath>../../MAVLink/include/common/mavlink_msg_global_position_setpoint_int.h</itemPath>
-        <itemPath>../../MAVLink/include/common/mavlink_msg_global_vision_position_estimate.h</itemPath>
-        <itemPath>../../MAVLink/include/common/mavlink_msg_gps2_raw.h</itemPath>
-        <itemPath>../../MAVLink/include/common/mavlink_msg_gps2_rtk.h</itemPath>
-        <itemPath>../../MAVLink/include/common/mavlink_msg_gps_global_origin.h</itemPath>
-        <itemPath>../../MAVLink/include/common/mavlink_msg_gps_inject_data.h</itemPath>
-        <itemPath>../../MAVLink/include/common/mavlink_msg_gps_raw_int.h</itemPath>
-        <itemPath>../../MAVLink/include/common/mavlink_msg_gps_rtk.h</itemPath>
-        <itemPath>../../MAVLink/include/common/mavlink_msg_gps_status.h</itemPath>
-        <itemPath>../../MAVLink/include/common/mavlink_msg_heartbeat.h</itemPath>
-        <itemPath>../../MAVLink/include/common/mavlink_msg_highres_imu.h</itemPath>
-        <itemPath>../../MAVLink/include/common/mavlink_msg_hil_controls.h</itemPath>
-        <itemPath>../../MAVLink/include/common/mavlink_msg_hil_gps.h</itemPath>
-        <itemPath>../../MAVLink/include/common/mavlink_msg_hil_optical_flow.h</itemPath>
-        <itemPath>../../MAVLink/include/common/mavlink_msg_hil_rc_inputs_raw.h</itemPath>
-        <itemPath>../../MAVLink/include/common/mavlink_msg_hil_sensor.h</itemPath>
-        <itemPath>../../MAVLink/include/common/mavlink_msg_hil_state.h</itemPath>
-        <itemPath>../../MAVLink/include/common/mavlink_msg_hil_state_quaternion.h</itemPath>
-        <itemPath>../../MAVLink/include/common/mavlink_msg_local_ned_position_setpoint_external.h</itemPath>
-        <itemPath>../../MAVLink/include/common/mavlink_msg_local_position_ned.h</itemPath>
-        <itemPath>../../MAVLink/include/common/mavlink_msg_local_position_ned_cov.h</itemPath>
-        <itemPath>../../MAVLink/include/common/mavlink_msg_local_position_ned_system_global_offset.h</itemPath>
-        <itemPath>../../MAVLink/include/common/mavlink_msg_local_position_setpoint.h</itemPath>
-        <itemPath>../../MAVLink/include/common/mavlink_msg_log_data.h</itemPath>
-        <itemPath>../../MAVLink/include/common/mavlink_msg_log_entry.h</itemPath>
-        <itemPath>../../MAVLink/include/common/mavlink_msg_log_erase.h</itemPath>
-        <itemPath>../../MAVLink/include/common/mavlink_msg_log_request_data.h</itemPath>
-        <itemPath>../../MAVLink/include/common/mavlink_msg_log_request_end.h</itemPath>
-        <itemPath>../../MAVLink/include/common/mavlink_msg_log_request_list.h</itemPath>
-        <itemPath>../../MAVLink/include/common/mavlink_msg_manual_control.h</itemPath>
-        <itemPath>../../MAVLink/include/common/mavlink_msg_manual_setpoint.h</itemPath>
-        <itemPath>../../MAVLink/include/common/mavlink_msg_memory_vect.h</itemPath>
-        <itemPath>../../MAVLink/include/common/mavlink_msg_mission_ack.h</itemPath>
-        <itemPath>../../MAVLink/include/common/mavlink_msg_mission_clear_all.h</itemPath>
-        <itemPath>../../MAVLink/include/common/mavlink_msg_mission_count.h</itemPath>
-        <itemPath>../../MAVLink/include/common/mavlink_msg_mission_current.h</itemPath>
-        <itemPath>../../MAVLink/include/common/mavlink_msg_mission_item.h</itemPath>
-        <itemPath>../../MAVLink/include/common/mavlink_msg_mission_item_int.h</itemPath>
-        <itemPath>../../MAVLink/include/common/mavlink_msg_mission_item_reached.h</itemPath>
-        <itemPath>../../MAVLink/include/common/mavlink_msg_mission_request.h</itemPath>
-        <itemPath>../../MAVLink/include/common/mavlink_msg_mission_request_list.h</itemPath>
-        <itemPath>../../MAVLink/include/common/mavlink_msg_mission_request_partial_list.h</itemPath>
-        <itemPath>../../MAVLink/include/common/mavlink_msg_mission_set_current.h</itemPath>
-        <itemPath>../../MAVLink/include/common/mavlink_msg_mission_write_partial_list.h</itemPath>
-        <itemPath>../../MAVLink/include/common/mavlink_msg_named_value_float.h</itemPath>
-        <itemPath>../../MAVLink/include/common/mavlink_msg_named_value_int.h</itemPath>
-        <itemPath>../../MAVLink/include/common/mavlink_msg_nav_controller_output.h</itemPath>
-        <itemPath>../../MAVLink/include/common/mavlink_msg_omnidirectional_flow.h</itemPath>
-        <itemPath>../../MAVLink/include/common/mavlink_msg_optical_flow.h</itemPath>
-        <itemPath>../../MAVLink/include/common/mavlink_msg_optical_flow_rad.h</itemPath>
-        <itemPath>../../MAVLink/include/common/mavlink_msg_param_request_list.h</itemPath>
-        <itemPath>../../MAVLink/include/common/mavlink_msg_param_request_read.h</itemPath>
-        <itemPath>../../MAVLink/include/common/mavlink_msg_param_set.h</itemPath>
-        <itemPath>../../MAVLink/include/common/mavlink_msg_param_value.h</itemPath>
-        <itemPath>../../MAVLink/include/common/mavlink_msg_ping.h</itemPath>
-        <itemPath>../../MAVLink/include/common/mavlink_msg_position_target_global_int.h</itemPath>
-        <itemPath>../../MAVLink/include/common/mavlink_msg_position_target_local_ned.h</itemPath>
-        <itemPath>../../MAVLink/include/common/mavlink_msg_power_status.h</itemPath>
-        <itemPath>../../MAVLink/include/common/mavlink_msg_radio_status.h</itemPath>
-        <itemPath>../../MAVLink/include/common/mavlink_msg_raw_imu.h</itemPath>
-        <itemPath>../../MAVLink/include/common/mavlink_msg_raw_pressure.h</itemPath>
-        <itemPath>../../MAVLink/include/common/mavlink_msg_rc_channels.h</itemPath>
-        <itemPath>../../MAVLink/include/common/mavlink_msg_rc_channels_override.h</itemPath>
-        <itemPath>../../MAVLink/include/common/mavlink_msg_rc_channels_raw.h</itemPath>
-        <itemPath>../../MAVLink/include/common/mavlink_msg_rc_channels_scaled.h</itemPath>
-        <itemPath>../../MAVLink/include/common/mavlink_msg_request_data_stream.h</itemPath>
-        <itemPath>../../MAVLink/include/common/mavlink_msg_roll_pitch_yaw_rates_thrust_setpoint.h</itemPath>
-        <itemPath>../../MAVLink/include/common/mavlink_msg_roll_pitch_yaw_speed_thrust_setpoint.h</itemPath>
-        <itemPath>../../MAVLink/include/common/mavlink_msg_roll_pitch_yaw_thrust_setpoint.h</itemPath>
-        <itemPath>../../MAVLink/include/common/mavlink_msg_safety_allowed_area.h</itemPath>
-        <itemPath>../../MAVLink/include/common/mavlink_msg_safety_set_allowed_area.h</itemPath>
-        <itemPath>../../MAVLink/include/common/mavlink_msg_scaled_imu.h</itemPath>
-        <itemPath>../../MAVLink/include/common/mavlink_msg_scaled_imu2.h</itemPath>
-        <itemPath>../../MAVLink/include/common/mavlink_msg_scaled_pressure.h</itemPath>
-        <itemPath>../../MAVLink/include/common/mavlink_msg_serial_control.h</itemPath>
-        <itemPath>../../MAVLink/include/common/mavlink_msg_servo_output_raw.h</itemPath>
-        <itemPath>../../MAVLink/include/common/mavlink_msg_setpoint_6dof.h</itemPath>
-        <itemPath>../../MAVLink/include/common/mavlink_msg_setpoint_8dof.h</itemPath>
-        <itemPath>../../MAVLink/include/common/mavlink_msg_set_attitude_target.h</itemPath>
-        <itemPath>../../MAVLink/include/common/mavlink_msg_set_global_position_setpoint_int.h</itemPath>
-        <itemPath>../../MAVLink/include/common/mavlink_msg_set_gps_global_origin.h</itemPath>
-        <itemPath>../../MAVLink/include/common/mavlink_msg_set_local_position_setpoint.h</itemPath>
-        <itemPath>../../MAVLink/include/common/mavlink_msg_set_mode.h</itemPath>
-        <itemPath>../../MAVLink/include/common/mavlink_msg_set_position_target_global_int.h</itemPath>
-        <itemPath>../../MAVLink/include/common/mavlink_msg_set_position_target_local_ned.h</itemPath>
-        <itemPath>../../MAVLink/include/common/mavlink_msg_set_quad_motors_setpoint.h</itemPath>
-        <itemPath>../../MAVLink/include/common/mavlink_msg_set_quad_swarm_led_roll_pitch_yaw_thrust.h</itemPath>
-        <itemPath>../../MAVLink/include/common/mavlink_msg_set_quad_swarm_roll_pitch_yaw_thrust.h</itemPath>
-        <itemPath>../../MAVLink/include/common/mavlink_msg_set_roll_pitch_yaw_speed_thrust.h</itemPath>
-        <itemPath>../../MAVLink/include/common/mavlink_msg_set_roll_pitch_yaw_thrust.h</itemPath>
-        <itemPath>../../MAVLink/include/common/mavlink_msg_sim_state.h</itemPath>
-        <itemPath>../../MAVLink/include/common/mavlink_msg_state_correction.h</itemPath>
-        <itemPath>../../MAVLink/include/common/mavlink_msg_statustext.h</itemPath>
-        <itemPath>../../MAVLink/include/common/mavlink_msg_system_time.h</itemPath>
-        <itemPath>../../MAVLink/include/common/mavlink_msg_sys_status.h</itemPath>
-        <itemPath>../../MAVLink/include/common/mavlink_msg_terrain_check.h</itemPath>
-        <itemPath>../../MAVLink/include/common/mavlink_msg_terrain_data.h</itemPath>
-        <itemPath>../../MAVLink/include/common/mavlink_msg_terrain_report.h</itemPath>
-        <itemPath>../../MAVLink/include/common/mavlink_msg_terrain_request.h</itemPath>
-        <itemPath>../../MAVLink/include/common/mavlink_msg_timesync.h</itemPath>
-        <itemPath>../../MAVLink/include/common/mavlink_msg_v2_extension.h</itemPath>
-        <itemPath>../../MAVLink/include/common/mavlink_msg_vfr_hud.h</itemPath>
-        <itemPath>../../MAVLink/include/common/mavlink_msg_vicon_position_estimate.h</itemPath>
-        <itemPath>../../MAVLink/include/common/mavlink_msg_vision_position_estimate.h</itemPath>
-        <itemPath>../../MAVLink/include/common/mavlink_msg_vision_speed_estimate.h</itemPath>
-        <itemPath>../../MAVLink/include/common/testsuite.h</itemPath>
-        <itemPath>../../MAVLink/include/common/version.h</itemPath>
-      </logicalFolder>
-        <itemPath>../../MAVLink/include/inttypes.h</itemPath>
-      <logicalFolder name="matrixpilot" displayName="matrixpilot" projectFiles="true">
-        <itemPath>../../MAVLink/include/matrixpilot/matrixpilot.h</itemPath>
-        <itemPath>../../MAVLink/include/matrixpilot/mavlink.h</itemPath>
-        <itemPath>../../MAVLink/include/matrixpilot/mavlink_msg_airspeeds.h</itemPath>
-        <itemPath>../../MAVLink/include/matrixpilot/mavlink_msg_altitudes.h</itemPath>
-        <itemPath>../../MAVLink/include/matrixpilot/mavlink_msg_flexifunction_buffer_function.h</itemPath>
-        <itemPath>../../MAVLink/include/matrixpilot/mavlink_msg_flexifunction_buffer_function_ack.h</itemPath>
-        <itemPath>../../MAVLink/include/matrixpilot/mavlink_msg_flexifunction_command.h</itemPath>
-        <itemPath>../../MAVLink/include/matrixpilot/mavlink_msg_flexifunction_command_ack.h</itemPath>
-        <itemPath>../../MAVLink/include/matrixpilot/mavlink_msg_flexifunction_directory.h</itemPath>
-        <itemPath>../../MAVLink/include/matrixpilot/mavlink_msg_flexifunction_directory_ack.h</itemPath>
-        <itemPath>../../MAVLink/include/matrixpilot/mavlink_msg_flexifunction_read_req.h</itemPath>
-        <itemPath>../../MAVLink/include/matrixpilot/mavlink_msg_flexifunction_set.h</itemPath>
-        <itemPath>../../MAVLink/include/matrixpilot/mavlink_msg_force.h</itemPath>
-        <itemPath>../../MAVLink/include/matrixpilot/mavlink_msg_serial_udb_extra_f13.h</itemPath>
-        <itemPath>../../MAVLink/include/matrixpilot/mavlink_msg_serial_udb_extra_f14.h</itemPath>
-        <itemPath>../../MAVLink/include/matrixpilot/mavlink_msg_serial_udb_extra_f15.h</itemPath>
-        <itemPath>../../MAVLink/include/matrixpilot/mavlink_msg_serial_udb_extra_f16.h</itemPath>
-        <itemPath>../../MAVLink/include/matrixpilot/mavlink_msg_serial_udb_extra_f2_a.h</itemPath>
-        <itemPath>../../MAVLink/include/matrixpilot/mavlink_msg_serial_udb_extra_f2_b.h</itemPath>
-        <itemPath>../../MAVLink/include/matrixpilot/mavlink_msg_serial_udb_extra_f4.h</itemPath>
-        <itemPath>../../MAVLink/include/matrixpilot/mavlink_msg_serial_udb_extra_f5.h</itemPath>
-        <itemPath>../../MAVLink/include/matrixpilot/mavlink_msg_serial_udb_extra_f6.h</itemPath>
-        <itemPath>../../MAVLink/include/matrixpilot/mavlink_msg_serial_udb_extra_f7.h</itemPath>
-        <itemPath>../../MAVLink/include/matrixpilot/mavlink_msg_serial_udb_extra_f8.h</itemPath>
-        <itemPath>../../MAVLink/include/matrixpilot/testsuite.h</itemPath>
-        <itemPath>../../MAVLink/include/matrixpilot/version.h</itemPath>
-      </logicalFolder>
-        <itemPath>../../MAVLink/include/matrixpilot_mavlink_bridge_header.h</itemPath>
-        <itemPath>../../MAVLink/include/mavlink_conversions.h</itemPath>
-        <itemPath>../../MAVLink/include/mavlink_helpers.h</itemPath>
-        <itemPath>../../MAVLink/include/mavlink_types.h</itemPath>
-        <itemPath>../../MAVLink/include/protocol.h</itemPath>
-      </logicalFolder>
+        <logicalFolder name="include" displayName="include" projectFiles="true">
+          <logicalFolder name="common" displayName="common" projectFiles="true">
+            <itemPath>../../MAVLink/include/common/common.h</itemPath>
+            <itemPath>../../MAVLink/include/common/mavlink.h</itemPath>
+            <itemPath>../../MAVLink/include/common/mavlink_msg_attitude.h</itemPath>
+            <itemPath>../../MAVLink/include/common/mavlink_msg_attitude_quaternion.h</itemPath>
+            <itemPath>../../MAVLink/include/common/mavlink_msg_attitude_quaternion_cov.h</itemPath>
+            <itemPath>../../MAVLink/include/common/mavlink_msg_attitude_setpoint_external.h</itemPath>
+            <itemPath>../../MAVLink/include/common/mavlink_msg_attitude_target.h</itemPath>
+            <itemPath>../../MAVLink/include/common/mavlink_msg_auth_key.h</itemPath>
+            <itemPath>../../MAVLink/include/common/mavlink_msg_autopilot_version.h</itemPath>
+            <itemPath>../../MAVLink/include/common/mavlink_msg_battery_status.h</itemPath>
+            <itemPath>../../MAVLink/include/common/mavlink_msg_change_operator_control.h</itemPath>
+            <itemPath>../../MAVLink/include/common/mavlink_msg_change_operator_control_ack.h</itemPath>
+            <itemPath>../../MAVLink/include/common/mavlink_msg_command_ack.h</itemPath>
+            <itemPath>../../MAVLink/include/common/mavlink_msg_command_int.h</itemPath>
+            <itemPath>../../MAVLink/include/common/mavlink_msg_command_long.h</itemPath>
+            <itemPath>../../MAVLink/include/common/mavlink_msg_data_stream.h</itemPath>
+            <itemPath>../../MAVLink/include/common/mavlink_msg_data_transmission_handshake.h</itemPath>
+            <itemPath>../../MAVLink/include/common/mavlink_msg_debug.h</itemPath>
+            <itemPath>../../MAVLink/include/common/mavlink_msg_debug_vect.h</itemPath>
+            <itemPath>../../MAVLink/include/common/mavlink_msg_distance_sensor.h</itemPath>
+            <itemPath>../../MAVLink/include/common/mavlink_msg_encapsulated_data.h</itemPath>
+            <itemPath>../../MAVLink/include/common/mavlink_msg_file_transfer_dir_list.h</itemPath>
+            <itemPath>../../MAVLink/include/common/mavlink_msg_file_transfer_protocol.h</itemPath>
+            <itemPath>../../MAVLink/include/common/mavlink_msg_file_transfer_res.h</itemPath>
+            <itemPath>../../MAVLink/include/common/mavlink_msg_file_transfer_start.h</itemPath>
+            <itemPath>../../MAVLink/include/common/mavlink_msg_global_position_int.h</itemPath>
+            <itemPath>../../MAVLink/include/common/mavlink_msg_global_position_int_cov.h</itemPath>
+            <itemPath>../../MAVLink/include/common/mavlink_msg_global_position_setpoint_external_int.h</itemPath>
+            <itemPath>../../MAVLink/include/common/mavlink_msg_global_position_setpoint_int.h</itemPath>
+            <itemPath>../../MAVLink/include/common/mavlink_msg_global_vision_position_estimate.h</itemPath>
+            <itemPath>../../MAVLink/include/common/mavlink_msg_gps2_raw.h</itemPath>
+            <itemPath>../../MAVLink/include/common/mavlink_msg_gps2_rtk.h</itemPath>
+            <itemPath>../../MAVLink/include/common/mavlink_msg_gps_global_origin.h</itemPath>
+            <itemPath>../../MAVLink/include/common/mavlink_msg_gps_inject_data.h</itemPath>
+            <itemPath>../../MAVLink/include/common/mavlink_msg_gps_raw_int.h</itemPath>
+            <itemPath>../../MAVLink/include/common/mavlink_msg_gps_rtk.h</itemPath>
+            <itemPath>../../MAVLink/include/common/mavlink_msg_gps_status.h</itemPath>
+            <itemPath>../../MAVLink/include/common/mavlink_msg_heartbeat.h</itemPath>
+            <itemPath>../../MAVLink/include/common/mavlink_msg_highres_imu.h</itemPath>
+            <itemPath>../../MAVLink/include/common/mavlink_msg_hil_controls.h</itemPath>
+            <itemPath>../../MAVLink/include/common/mavlink_msg_hil_gps.h</itemPath>
+            <itemPath>../../MAVLink/include/common/mavlink_msg_hil_optical_flow.h</itemPath>
+            <itemPath>../../MAVLink/include/common/mavlink_msg_hil_rc_inputs_raw.h</itemPath>
+            <itemPath>../../MAVLink/include/common/mavlink_msg_hil_sensor.h</itemPath>
+            <itemPath>../../MAVLink/include/common/mavlink_msg_hil_state.h</itemPath>
+            <itemPath>../../MAVLink/include/common/mavlink_msg_hil_state_quaternion.h</itemPath>
+            <itemPath>../../MAVLink/include/common/mavlink_msg_local_ned_position_setpoint_external.h</itemPath>
+            <itemPath>../../MAVLink/include/common/mavlink_msg_local_position_ned.h</itemPath>
+            <itemPath>../../MAVLink/include/common/mavlink_msg_local_position_ned_cov.h</itemPath>
+            <itemPath>../../MAVLink/include/common/mavlink_msg_local_position_ned_system_global_offset.h</itemPath>
+            <itemPath>../../MAVLink/include/common/mavlink_msg_local_position_setpoint.h</itemPath>
+            <itemPath>../../MAVLink/include/common/mavlink_msg_log_data.h</itemPath>
+            <itemPath>../../MAVLink/include/common/mavlink_msg_log_entry.h</itemPath>
+            <itemPath>../../MAVLink/include/common/mavlink_msg_log_erase.h</itemPath>
+            <itemPath>../../MAVLink/include/common/mavlink_msg_log_request_data.h</itemPath>
+            <itemPath>../../MAVLink/include/common/mavlink_msg_log_request_end.h</itemPath>
+            <itemPath>../../MAVLink/include/common/mavlink_msg_log_request_list.h</itemPath>
+            <itemPath>../../MAVLink/include/common/mavlink_msg_manual_control.h</itemPath>
+            <itemPath>../../MAVLink/include/common/mavlink_msg_manual_setpoint.h</itemPath>
+            <itemPath>../../MAVLink/include/common/mavlink_msg_memory_vect.h</itemPath>
+            <itemPath>../../MAVLink/include/common/mavlink_msg_mission_ack.h</itemPath>
+            <itemPath>../../MAVLink/include/common/mavlink_msg_mission_clear_all.h</itemPath>
+            <itemPath>../../MAVLink/include/common/mavlink_msg_mission_count.h</itemPath>
+            <itemPath>../../MAVLink/include/common/mavlink_msg_mission_current.h</itemPath>
+            <itemPath>../../MAVLink/include/common/mavlink_msg_mission_item.h</itemPath>
+            <itemPath>../../MAVLink/include/common/mavlink_msg_mission_item_int.h</itemPath>
+            <itemPath>../../MAVLink/include/common/mavlink_msg_mission_item_reached.h</itemPath>
+            <itemPath>../../MAVLink/include/common/mavlink_msg_mission_request.h</itemPath>
+            <itemPath>../../MAVLink/include/common/mavlink_msg_mission_request_list.h</itemPath>
+            <itemPath>../../MAVLink/include/common/mavlink_msg_mission_request_partial_list.h</itemPath>
+            <itemPath>../../MAVLink/include/common/mavlink_msg_mission_set_current.h</itemPath>
+            <itemPath>../../MAVLink/include/common/mavlink_msg_mission_write_partial_list.h</itemPath>
+            <itemPath>../../MAVLink/include/common/mavlink_msg_named_value_float.h</itemPath>
+            <itemPath>../../MAVLink/include/common/mavlink_msg_named_value_int.h</itemPath>
+            <itemPath>../../MAVLink/include/common/mavlink_msg_nav_controller_output.h</itemPath>
+            <itemPath>../../MAVLink/include/common/mavlink_msg_omnidirectional_flow.h</itemPath>
+            <itemPath>../../MAVLink/include/common/mavlink_msg_optical_flow.h</itemPath>
+            <itemPath>../../MAVLink/include/common/mavlink_msg_optical_flow_rad.h</itemPath>
+            <itemPath>../../MAVLink/include/common/mavlink_msg_param_request_list.h</itemPath>
+            <itemPath>../../MAVLink/include/common/mavlink_msg_param_request_read.h</itemPath>
+            <itemPath>../../MAVLink/include/common/mavlink_msg_param_set.h</itemPath>
+            <itemPath>../../MAVLink/include/common/mavlink_msg_param_value.h</itemPath>
+            <itemPath>../../MAVLink/include/common/mavlink_msg_ping.h</itemPath>
+            <itemPath>../../MAVLink/include/common/mavlink_msg_position_target_global_int.h</itemPath>
+            <itemPath>../../MAVLink/include/common/mavlink_msg_position_target_local_ned.h</itemPath>
+            <itemPath>../../MAVLink/include/common/mavlink_msg_power_status.h</itemPath>
+            <itemPath>../../MAVLink/include/common/mavlink_msg_radio_status.h</itemPath>
+            <itemPath>../../MAVLink/include/common/mavlink_msg_raw_imu.h</itemPath>
+            <itemPath>../../MAVLink/include/common/mavlink_msg_raw_pressure.h</itemPath>
+            <itemPath>../../MAVLink/include/common/mavlink_msg_rc_channels.h</itemPath>
+            <itemPath>../../MAVLink/include/common/mavlink_msg_rc_channels_override.h</itemPath>
+            <itemPath>../../MAVLink/include/common/mavlink_msg_rc_channels_raw.h</itemPath>
+            <itemPath>../../MAVLink/include/common/mavlink_msg_rc_channels_scaled.h</itemPath>
+            <itemPath>../../MAVLink/include/common/mavlink_msg_request_data_stream.h</itemPath>
+            <itemPath>../../MAVLink/include/common/mavlink_msg_roll_pitch_yaw_rates_thrust_setpoint.h</itemPath>
+            <itemPath>../../MAVLink/include/common/mavlink_msg_roll_pitch_yaw_speed_thrust_setpoint.h</itemPath>
+            <itemPath>../../MAVLink/include/common/mavlink_msg_roll_pitch_yaw_thrust_setpoint.h</itemPath>
+            <itemPath>../../MAVLink/include/common/mavlink_msg_safety_allowed_area.h</itemPath>
+            <itemPath>../../MAVLink/include/common/mavlink_msg_safety_set_allowed_area.h</itemPath>
+            <itemPath>../../MAVLink/include/common/mavlink_msg_scaled_imu.h</itemPath>
+            <itemPath>../../MAVLink/include/common/mavlink_msg_scaled_imu2.h</itemPath>
+            <itemPath>../../MAVLink/include/common/mavlink_msg_scaled_pressure.h</itemPath>
+            <itemPath>../../MAVLink/include/common/mavlink_msg_serial_control.h</itemPath>
+            <itemPath>../../MAVLink/include/common/mavlink_msg_servo_output_raw.h</itemPath>
+            <itemPath>../../MAVLink/include/common/mavlink_msg_setpoint_6dof.h</itemPath>
+            <itemPath>../../MAVLink/include/common/mavlink_msg_setpoint_8dof.h</itemPath>
+            <itemPath>../../MAVLink/include/common/mavlink_msg_set_attitude_target.h</itemPath>
+            <itemPath>../../MAVLink/include/common/mavlink_msg_set_global_position_setpoint_int.h</itemPath>
+            <itemPath>../../MAVLink/include/common/mavlink_msg_set_gps_global_origin.h</itemPath>
+            <itemPath>../../MAVLink/include/common/mavlink_msg_set_local_position_setpoint.h</itemPath>
+            <itemPath>../../MAVLink/include/common/mavlink_msg_set_mode.h</itemPath>
+            <itemPath>../../MAVLink/include/common/mavlink_msg_set_position_target_global_int.h</itemPath>
+            <itemPath>../../MAVLink/include/common/mavlink_msg_set_position_target_local_ned.h</itemPath>
+            <itemPath>../../MAVLink/include/common/mavlink_msg_set_quad_motors_setpoint.h</itemPath>
+            <itemPath>../../MAVLink/include/common/mavlink_msg_set_quad_swarm_led_roll_pitch_yaw_thrust.h</itemPath>
+            <itemPath>../../MAVLink/include/common/mavlink_msg_set_quad_swarm_roll_pitch_yaw_thrust.h</itemPath>
+            <itemPath>../../MAVLink/include/common/mavlink_msg_set_roll_pitch_yaw_speed_thrust.h</itemPath>
+            <itemPath>../../MAVLink/include/common/mavlink_msg_set_roll_pitch_yaw_thrust.h</itemPath>
+            <itemPath>../../MAVLink/include/common/mavlink_msg_sim_state.h</itemPath>
+            <itemPath>../../MAVLink/include/common/mavlink_msg_state_correction.h</itemPath>
+            <itemPath>../../MAVLink/include/common/mavlink_msg_statustext.h</itemPath>
+            <itemPath>../../MAVLink/include/common/mavlink_msg_system_time.h</itemPath>
+            <itemPath>../../MAVLink/include/common/mavlink_msg_sys_status.h</itemPath>
+            <itemPath>../../MAVLink/include/common/mavlink_msg_terrain_check.h</itemPath>
+            <itemPath>../../MAVLink/include/common/mavlink_msg_terrain_data.h</itemPath>
+            <itemPath>../../MAVLink/include/common/mavlink_msg_terrain_report.h</itemPath>
+            <itemPath>../../MAVLink/include/common/mavlink_msg_terrain_request.h</itemPath>
+            <itemPath>../../MAVLink/include/common/mavlink_msg_timesync.h</itemPath>
+            <itemPath>../../MAVLink/include/common/mavlink_msg_v2_extension.h</itemPath>
+            <itemPath>../../MAVLink/include/common/mavlink_msg_vfr_hud.h</itemPath>
+            <itemPath>../../MAVLink/include/common/mavlink_msg_vicon_position_estimate.h</itemPath>
+            <itemPath>../../MAVLink/include/common/mavlink_msg_vision_position_estimate.h</itemPath>
+            <itemPath>../../MAVLink/include/common/mavlink_msg_vision_speed_estimate.h</itemPath>
+            <itemPath>../../MAVLink/include/common/testsuite.h</itemPath>
+            <itemPath>../../MAVLink/include/common/version.h</itemPath>
+          </logicalFolder>
+          <logicalFolder name="matrixpilot" displayName="matrixpilot" projectFiles="true">
+            <itemPath>../../MAVLink/include/matrixpilot/matrixpilot.h</itemPath>
+            <itemPath>../../MAVLink/include/matrixpilot/mavlink.h</itemPath>
+            <itemPath>../../MAVLink/include/matrixpilot/mavlink_msg_airspeeds.h</itemPath>
+            <itemPath>../../MAVLink/include/matrixpilot/mavlink_msg_altitudes.h</itemPath>
+            <itemPath>../../MAVLink/include/matrixpilot/mavlink_msg_flexifunction_buffer_function.h</itemPath>
+            <itemPath>../../MAVLink/include/matrixpilot/mavlink_msg_flexifunction_buffer_function_ack.h</itemPath>
+            <itemPath>../../MAVLink/include/matrixpilot/mavlink_msg_flexifunction_command.h</itemPath>
+            <itemPath>../../MAVLink/include/matrixpilot/mavlink_msg_flexifunction_command_ack.h</itemPath>
+            <itemPath>../../MAVLink/include/matrixpilot/mavlink_msg_flexifunction_directory.h</itemPath>
+            <itemPath>../../MAVLink/include/matrixpilot/mavlink_msg_flexifunction_directory_ack.h</itemPath>
+            <itemPath>../../MAVLink/include/matrixpilot/mavlink_msg_flexifunction_read_req.h</itemPath>
+            <itemPath>../../MAVLink/include/matrixpilot/mavlink_msg_flexifunction_set.h</itemPath>
+            <itemPath>../../MAVLink/include/matrixpilot/mavlink_msg_force.h</itemPath>
+            <itemPath>../../MAVLink/include/matrixpilot/mavlink_msg_serial_udb_extra_f13.h</itemPath>
+            <itemPath>../../MAVLink/include/matrixpilot/mavlink_msg_serial_udb_extra_f14.h</itemPath>
+            <itemPath>../../MAVLink/include/matrixpilot/mavlink_msg_serial_udb_extra_f15.h</itemPath>
+            <itemPath>../../MAVLink/include/matrixpilot/mavlink_msg_serial_udb_extra_f16.h</itemPath>
+            <itemPath>../../MAVLink/include/matrixpilot/mavlink_msg_serial_udb_extra_f2_a.h</itemPath>
+            <itemPath>../../MAVLink/include/matrixpilot/mavlink_msg_serial_udb_extra_f2_b.h</itemPath>
+            <itemPath>../../MAVLink/include/matrixpilot/mavlink_msg_serial_udb_extra_f4.h</itemPath>
+            <itemPath>../../MAVLink/include/matrixpilot/mavlink_msg_serial_udb_extra_f5.h</itemPath>
+            <itemPath>../../MAVLink/include/matrixpilot/mavlink_msg_serial_udb_extra_f6.h</itemPath>
+            <itemPath>../../MAVLink/include/matrixpilot/mavlink_msg_serial_udb_extra_f7.h</itemPath>
+            <itemPath>../../MAVLink/include/matrixpilot/mavlink_msg_serial_udb_extra_f8.h</itemPath>
+            <itemPath>../../MAVLink/include/matrixpilot/testsuite.h</itemPath>
+            <itemPath>../../MAVLink/include/matrixpilot/version.h</itemPath>
+          </logicalFolder>
+          <itemPath>../../MAVLink/include/checksum.h</itemPath>
+          <itemPath>../../MAVLink/include/inttypes.h</itemPath>
+          <itemPath>../../MAVLink/include/matrixpilot_mavlink_bridge_header.h</itemPath>
+          <itemPath>../../MAVLink/include/mavlink_conversions.h</itemPath>
+          <itemPath>../../MAVLink/include/mavlink_helpers.h</itemPath>
+          <itemPath>../../MAVLink/include/mavlink_types.h</itemPath>
+          <itemPath>../../MAVLink/include/protocol.h</itemPath>
+        </logicalFolder>
         <itemPath>../../MAVLink/MAVFTP.h</itemPath>
       </logicalFolder>
-      <logicalFolder name="libDCM" displayName="libDCM" projectFiles="true">
-        <itemPath>../../libDCM/dcmTypes.h</itemPath>
-        <itemPath>../../libDCM/deadReckoning.h</itemPath>
-        <itemPath>../../libDCM/estAltitude.h</itemPath>
-        <itemPath>../../libDCM/estLocation.h</itemPath>
-        <itemPath>../../libDCM/estWind.h</itemPath>
-        <itemPath>../../libDCM/estYawDrift.h</itemPath>
-        <itemPath>../../libDCM/gpsData.h</itemPath>
-        <itemPath>../../libDCM/gpsParseCommon.h</itemPath>
-        <itemPath>../../libDCM/libDCM.h</itemPath>
-        <itemPath>../../libDCM/libDCM_defines.h</itemPath>
-        <itemPath>../../libDCM/libDCM_internal.h</itemPath>
-        <itemPath>../../libDCM/mag_drift.h</itemPath>
-        <itemPath>../../libDCM/mathlib.h</itemPath>
-        <itemPath>../../libDCM/mathlibNAV.h</itemPath>
-        <itemPath>../../libDCM/rmat.h</itemPath>
-      </logicalFolder>
-      <logicalFolder name="libUDB" displayName="libUDB" projectFiles="true">
-        <itemPath>../../libUDB/ADchannel.h</itemPath>
-        <itemPath>../../libUDB/analogs.h</itemPath>
-        <itemPath>../../libUDB/barometer.h</itemPath>
-        <itemPath>../../libUDB/boardRotation_defines.h</itemPath>
-        <itemPath>../../libUDB/builtins.h</itemPath>
-        <itemPath>../../libUDB/ConfigAUAV3.h</itemPath>
-        <itemPath>../../libUDB/ConfigHILSIM.h</itemPath>
-        <itemPath>../../libUDB/ConfigPX4.h</itemPath>
-        <itemPath>../../libUDB/ConfigUDB4.h</itemPath>
-        <itemPath>../../libUDB/ConfigUDB5.h</itemPath>
-        <itemPath>../../libUDB/eeprom_udb4.h</itemPath>
-        <itemPath>../../libUDB/events.h</itemPath>
-        <itemPath>../../libUDB/fixDeps.h</itemPath>
-        <itemPath>../../libUDB/heartbeat.h</itemPath>
-        <itemPath>../../libUDB/I2C.h</itemPath>
-        <itemPath>../../libUDB/interrupt.h</itemPath>
-        <itemPath>../../libUDB/libUDB.h</itemPath>
-        <itemPath>../../libUDB/libUDB_defines.h</itemPath>
-        <itemPath>../../libUDB/libUDB_internal.h</itemPath>
-        <itemPath>../../libUDB/magnetometer.h</itemPath>
-        <itemPath>../../libUDB/mcu.h</itemPath>
-        <itemPath>../../libUDB/mpu6000.h</itemPath>
-        <itemPath>../../libUDB/mpu_spi.h</itemPath>
-        <itemPath>../../libUDB/NV_memory.h</itemPath>
-        <itemPath>../../libUDB/oscillator.h</itemPath>
-        <itemPath>../../libUDB/osd.h</itemPath>
-        <itemPath>../../libUDB/radioIn.h</itemPath>
-        <itemPath>../../libUDB/serialIO.h</itemPath>
-        <itemPath>../../libUDB/servoOut.h</itemPath>
-        <itemPath>../../libUDB/sonarIn.h</itemPath>
-        <itemPath>../../libUDB/uart.h</itemPath>
-        <itemPath>../../libUDB/udbTypes.h</itemPath>
-      </logicalFolder>
-      <logicalFolder name="libVectorMatrix" displayName="libVectorMatrix" projectFiles="true">
-        <itemPath>../../libVectorMatrix/dspcommon.inc</itemPath>
-      </logicalFolder>
-      <logicalFolder name="libFlashFS" displayName="libFlashFS" projectFiles="true">
-        <itemPath>../../libFlashFS/AT45D.h</itemPath>
-        <itemPath>../../libFlashFS/EEPROM.h</itemPath>
-        <itemPath>../../libFlashFS/filesys.h</itemPath>
-        <itemPath>../../libFlashFS/MDD_AT45D.h</itemPath>
-        <itemPath>../../libFlashFS/MDD_EEPROM.h</itemPath>
-      </logicalFolder>
       <logicalFolder name="Microchip" displayName="Microchip" projectFiles="true">
+        <logicalFolder name="Include" displayName="Include" projectFiles="true">
+          <logicalFolder name="MDD-File-System"
+                         displayName="MDD-File-System"
+                         projectFiles="true">
+            <itemPath>../../Microchip/Include/MDD-File-System/FSDefs.h</itemPath>
+            <itemPath>../../Microchip/Include/MDD-File-System/FSIO.h</itemPath>
+            <itemPath>../../Microchip/Include/MDD-File-System/SD-SPI.h</itemPath>
+          </logicalFolder>
+          <logicalFolder name="USB" displayName="USB" projectFiles="true">
+            <itemPath>../../Microchip/Include/USB/usb.h</itemPath>
+            <itemPath>../../Microchip/Include/USB/usb_ch9.h</itemPath>
+            <itemPath>../../Microchip/Include/USB/usb_common.h</itemPath>
+            <itemPath>../../Microchip/Include/USB/usb_device.h</itemPath>
+            <itemPath>../../Microchip/Include/USB/usb_function_cdc.h</itemPath>
+            <itemPath>../../Microchip/Include/USB/usb_function_msd.h</itemPath>
+            <itemPath>../../Microchip/Include/USB/usb_hal.h</itemPath>
+            <itemPath>../../Microchip/Include/USB/usb_hal_dspic33E.h</itemPath>
+          </logicalFolder>
+          <itemPath>../../Microchip/Include/Compiler.h</itemPath>
+          <itemPath>../../Microchip/Include/GenericTypeDefs.h</itemPath>
+        </logicalFolder>
+        <logicalFolder name="USB" displayName="USB" projectFiles="true">
+          <itemPath>../../Microchip/USB/usb_device_local.h</itemPath>
+        </logicalFolder>
         <itemPath>../../Microchip/HardwareProfile.h</itemPath>
-      <logicalFolder name="Include" displayName="Include" projectFiles="true">
-        <itemPath>../../Microchip/Include/Compiler.h</itemPath>
-        <itemPath>../../Microchip/Include/GenericTypeDefs.h</itemPath>
-      <logicalFolder name="MDD-File-System" displayName="MDD-File-System" projectFiles="true">
-        <itemPath>../../Microchip/Include/MDD-File-System/FSDefs.h</itemPath>
-        <itemPath>../../Microchip/Include/MDD-File-System/FSIO.h</itemPath>
-        <itemPath>../../Microchip/Include/MDD-File-System/SD-SPI.h</itemPath>
-      </logicalFolder>
-      <logicalFolder name="USB" displayName="USB" projectFiles="true">
-        <itemPath>../../Microchip/Include/USB/usb.h</itemPath>
-        <itemPath>../../Microchip/Include/USB/usb_ch9.h</itemPath>
-        <itemPath>../../Microchip/Include/USB/usb_common.h</itemPath>
-        <itemPath>../../Microchip/Include/USB/usb_device.h</itemPath>
-        <itemPath>../../Microchip/Include/USB/usb_function_cdc.h</itemPath>
-        <itemPath>../../Microchip/Include/USB/usb_function_msd.h</itemPath>
-        <itemPath>../../Microchip/Include/USB/usb_hal.h</itemPath>
-        <itemPath>../../Microchip/Include/USB/usb_hal_dspic33E.h</itemPath>
-      </logicalFolder>
-      </logicalFolder>
         <itemPath>../../Microchip/NetConfig.h</itemPath>
         <itemPath>../../Microchip/Sockets.h</itemPath>
-      <logicalFolder name="USB" displayName="USB" projectFiles="true">
-        <itemPath>../../Microchip/USB/usb_device_local.h</itemPath>
-      </logicalFolder>
         <itemPath>../../Microchip/usb_cdc.h</itemPath>
         <itemPath>../../Microchip/usb_config.h</itemPath>
       </logicalFolder>
-</logicalFolder>
-    <logicalFolder name="LinkerScript" displayName="Linker Files"
-    projectFiles="true"></logicalFolder>
-    <logicalFolder name="SourceFiles" displayName="Source Files"
-    projectFiles="true">      <logicalFolder name="MatrixPilot" displayName="MatrixPilot" projectFiles="true">
+    </logicalFolder>
+    <logicalFolder name="LinkerScript"
+                   displayName="Linker Files"
+                   projectFiles="true">
+    </logicalFolder>
+    <logicalFolder name="SourceFiles"
+                   displayName="Source Files"
+                   projectFiles="true">
+      <logicalFolder name="libDCM" displayName="libDCM" projectFiles="true">
+        <itemPath>../../libDCM/deadReckoning.c</itemPath>
+        <itemPath>../../libDCM/estAirspeed.c</itemPath>
+        <itemPath>../../libDCM/estAltitude.c</itemPath>
+        <itemPath>../../libDCM/estLocation.c</itemPath>
+        <itemPath>../../libDCM/estWind.c</itemPath>
+        <itemPath>../../libDCM/estYawDrift.c</itemPath>
+        <itemPath>../../libDCM/gpsData.c</itemPath>
+        <itemPath>../../libDCM/gpsParseCommon.c</itemPath>
+        <itemPath>../../libDCM/gpsParseMTEK.c</itemPath>
+        <itemPath>../../libDCM/gpsParseNMEA.c</itemPath>
+        <itemPath>../../libDCM/gpsParseSTD.c</itemPath>
+        <itemPath>../../libDCM/gpsParseUBX.c</itemPath>
+        <itemPath>../../libDCM/hilsim.c</itemPath>
+        <itemPath>../../libDCM/libDCM.c</itemPath>
+        <itemPath>../../libDCM/mag_drift.c</itemPath>
+        <itemPath>../../libDCM/mathlib.c</itemPath>
+        <itemPath>../../libDCM/mathlibNAV.c</itemPath>
+        <itemPath>../../libDCM/rmat.c</itemPath>
+      </logicalFolder>
+      <logicalFolder name="libFlashFS" displayName="libFlashFS" projectFiles="true">
+        <itemPath>../../libFlashFS/AT45D.c</itemPath>
+        <itemPath>../../libFlashFS/AT45D_DMA.c</itemPath>
+        <itemPath>../../libFlashFS/AT45D_FS.c</itemPath>
+        <itemPath>../../libFlashFS/EEPROM.c</itemPath>
+        <itemPath>../../libFlashFS/EEPROM_FS.c</itemPath>
+        <itemPath>../../libFlashFS/filesys.c</itemPath>
+        <itemPath>../../libFlashFS/MDD_AT45D.c</itemPath>
+        <itemPath>../../libFlashFS/MDD_EEPROM.c</itemPath>
+        <itemPath>../../libFlashFS/usb.c</itemPath>
+        <itemPath>../../libFlashFS/usb_cdc.c</itemPath>
+        <itemPath>../../libFlashFS/usb_descriptors.c</itemPath>
+        <itemPath>../../libFlashFS/usb_msd.c</itemPath>
+      </logicalFolder>
+      <logicalFolder name="libUDB" displayName="libUDB" projectFiles="true">
+        <itemPath>../../libUDB/24LC256.c</itemPath>
+        <itemPath>../../libUDB/ADchannel.c</itemPath>
+        <itemPath>../../libUDB/analog2digital_auav3.c</itemPath>
+        <itemPath>../../libUDB/analog2digital_udb4.c</itemPath>
+        <itemPath>../../libUDB/analog2digital_udb5.c</itemPath>
+        <itemPath>../../libUDB/analogs.c</itemPath>
+        <itemPath>../../libUDB/background.c</itemPath>
+        <itemPath>../../libUDB/barometer.c</itemPath>
+        <itemPath>../../libUDB/eeprom_udb4.c</itemPath>
+        <itemPath>../../libUDB/events.c</itemPath>
+        <itemPath>../../libUDB/fbcl.s</itemPath>
+        <itemPath>../../libUDB/heartbeat.c</itemPath>
+        <itemPath>../../libUDB/I2C1.c</itemPath>
+        <itemPath>../../libUDB/I2C2.c</itemPath>
+        <itemPath>../../libUDB/libUDB.c</itemPath>
+        <itemPath>../../libUDB/magnetometer.c</itemPath>
+        <itemPath>../../libUDB/mcu.c</itemPath>
+        <itemPath>../../libUDB/mpu6000.c</itemPath>
+        <itemPath>../../libUDB/mpu_spi.c</itemPath>
+        <itemPath>../../libUDB/osd.c</itemPath>
+        <itemPath>../../libUDB/osd_bit.c</itemPath>
+        <itemPath>../../libUDB/osd_spi.c</itemPath>
+        <itemPath>../../libUDB/radioIn.c</itemPath>
+        <itemPath>../../libUDB/read.c</itemPath>
+        <itemPath>../../libUDB/serialIO.c</itemPath>
+        <itemPath>../../libUDB/servoOut.c</itemPath>
+        <itemPath>../../libUDB/sonarIn.c</itemPath>
+        <itemPath>../../libUDB/traps.c</itemPath>
+        <itemPath>../../libUDB/traps_asm.s</itemPath>
+        <itemPath>../../libUDB/uart.c</itemPath>
+        <itemPath>../../libUDB/write.c</itemPath>
+      </logicalFolder>
+      <logicalFolder name="libVectorMatrix"
+                     displayName="libVectorMatrix"
+                     projectFiles="true">
+        <itemPath>../../libVectorMatrix/madd.s</itemPath>
+        <itemPath>../../libVectorMatrix/mmul.s</itemPath>
+        <itemPath>../../libVectorMatrix/mscl.s</itemPath>
+        <itemPath>../../libVectorMatrix/msub.s</itemPath>
+        <itemPath>../../libVectorMatrix/mtrp.s</itemPath>
+        <itemPath>../../libVectorMatrix/vadd.s</itemPath>
+        <itemPath>../../libVectorMatrix/vcon.s</itemPath>
+        <itemPath>../../libVectorMatrix/vcopy.s</itemPath>
+        <itemPath>../../libVectorMatrix/vcor.s</itemPath>
+        <itemPath>../../libVectorMatrix/vdot.s</itemPath>
+        <itemPath>../../libVectorMatrix/vmax.s</itemPath>
+        <itemPath>../../libVectorMatrix/vmin.s</itemPath>
+        <itemPath>../../libVectorMatrix/vmul.s</itemPath>
+        <itemPath>../../libVectorMatrix/vneg.s</itemPath>
+        <itemPath>../../libVectorMatrix/vpow.s</itemPath>
+        <itemPath>../../libVectorMatrix/vscl.s</itemPath>
+        <itemPath>../../libVectorMatrix/vsub.s</itemPath>
+        <itemPath>../../libVectorMatrix/vzpad.s</itemPath>
+      </logicalFolder>
+      <logicalFolder name="MatrixPilot" displayName="MatrixPilot" projectFiles="true">
         <itemPath>../../MatrixPilot/airspeedCntrl.c</itemPath>
         <itemPath>../../MatrixPilot/altitudeCntrl.c</itemPath>
         <itemPath>../../MatrixPilot/altitudeCntrlVariable.c</itemPath>
@@ -403,117 +503,37 @@
         <itemPath>../../MatrixPilot/yawCntrl.c</itemPath>
       </logicalFolder>
       <logicalFolder name="MAVLink" displayName="MAVLink" projectFiles="true">
-      <logicalFolder name="include" displayName="include" projectFiles="true">
-        <itemPath>../../MAVLink/include/bittest.c</itemPath>
-      </logicalFolder>
+        <logicalFolder name="include" displayName="include" projectFiles="true">
+          <itemPath>../../MAVLink/include/bittest.c</itemPath>
+        </logicalFolder>
         <itemPath>../../MAVLink/MAVFTP.c</itemPath>
       </logicalFolder>
-      <logicalFolder name="libDCM" displayName="libDCM" projectFiles="true">
-        <itemPath>../../libDCM/deadReckoning.c</itemPath>
-        <itemPath>../../libDCM/estAirspeed.c</itemPath>
-        <itemPath>../../libDCM/estAltitude.c</itemPath>
-        <itemPath>../../libDCM/estLocation.c</itemPath>
-        <itemPath>../../libDCM/estWind.c</itemPath>
-        <itemPath>../../libDCM/estYawDrift.c</itemPath>
-        <itemPath>../../libDCM/gpsData.c</itemPath>
-        <itemPath>../../libDCM/gpsParseCommon.c</itemPath>
-        <itemPath>../../libDCM/gpsParseMTEK.c</itemPath>
-        <itemPath>../../libDCM/gpsParseNMEA.c</itemPath>
-        <itemPath>../../libDCM/gpsParseSTD.c</itemPath>
-        <itemPath>../../libDCM/gpsParseUBX.c</itemPath>
-        <itemPath>../../libDCM/hilsim.c</itemPath>
-        <itemPath>../../libDCM/libDCM.c</itemPath>
-        <itemPath>../../libDCM/mag_drift.c</itemPath>
-        <itemPath>../../libDCM/mathlib.c</itemPath>
-        <itemPath>../../libDCM/mathlibNAV.c</itemPath>
-        <itemPath>../../libDCM/rmat.c</itemPath>
-      </logicalFolder>
-      <logicalFolder name="libUDB" displayName="libUDB" projectFiles="true">
-        <itemPath>../../libUDB/24LC256.c</itemPath>
-        <itemPath>../../libUDB/ADchannel.c</itemPath>
-        <itemPath>../../libUDB/analog2digital_auav3.c</itemPath>
-        <itemPath>../../libUDB/analog2digital_udb4.c</itemPath>
-        <itemPath>../../libUDB/analog2digital_udb5.c</itemPath>
-        <itemPath>../../libUDB/analogs.c</itemPath>
-        <itemPath>../../libUDB/background.c</itemPath>
-        <itemPath>../../libUDB/barometer.c</itemPath>
-        <itemPath>../../libUDB/eeprom_udb4.c</itemPath>
-        <itemPath>../../libUDB/events.c</itemPath>
-        <itemPath>../../libUDB/fbcl.s</itemPath>
-        <itemPath>../../libUDB/heartbeat.c</itemPath>
-        <itemPath>../../libUDB/I2C1.c</itemPath>
-        <itemPath>../../libUDB/I2C2.c</itemPath>
-        <itemPath>../../libUDB/libUDB.c</itemPath>
-        <itemPath>../../libUDB/magnetometer.c</itemPath>
-        <itemPath>../../libUDB/mcu.c</itemPath>
-        <itemPath>../../libUDB/mpu6000.c</itemPath>
-        <itemPath>../../libUDB/mpu_spi.c</itemPath>
-        <itemPath>../../libUDB/osd.c</itemPath>
-        <itemPath>../../libUDB/osd_bit.c</itemPath>
-        <itemPath>../../libUDB/osd_spi.c</itemPath>
-        <itemPath>../../libUDB/radioIn.c</itemPath>
-        <itemPath>../../libUDB/read.c</itemPath>
-        <itemPath>../../libUDB/serialIO.c</itemPath>
-        <itemPath>../../libUDB/servoOut.c</itemPath>
-        <itemPath>../../libUDB/sonarIn.c</itemPath>
-        <itemPath>../../libUDB/traps.c</itemPath>
-        <itemPath>../../libUDB/traps_asm.s</itemPath>
-        <itemPath>../../libUDB/uart.c</itemPath>
-        <itemPath>../../libUDB/write.c</itemPath>
-      </logicalFolder>
-      <logicalFolder name="libVectorMatrix" displayName="libVectorMatrix" projectFiles="true">
-        <itemPath>../../libVectorMatrix/madd.s</itemPath>
-        <itemPath>../../libVectorMatrix/mmul.s</itemPath>
-        <itemPath>../../libVectorMatrix/mscl.s</itemPath>
-        <itemPath>../../libVectorMatrix/msub.s</itemPath>
-        <itemPath>../../libVectorMatrix/mtrp.s</itemPath>
-        <itemPath>../../libVectorMatrix/vadd.s</itemPath>
-        <itemPath>../../libVectorMatrix/vcon.s</itemPath>
-        <itemPath>../../libVectorMatrix/vcopy.s</itemPath>
-        <itemPath>../../libVectorMatrix/vcor.s</itemPath>
-        <itemPath>../../libVectorMatrix/vdot.s</itemPath>
-        <itemPath>../../libVectorMatrix/vmax.s</itemPath>
-        <itemPath>../../libVectorMatrix/vmin.s</itemPath>
-        <itemPath>../../libVectorMatrix/vmul.s</itemPath>
-        <itemPath>../../libVectorMatrix/vneg.s</itemPath>
-        <itemPath>../../libVectorMatrix/vpow.s</itemPath>
-        <itemPath>../../libVectorMatrix/vscl.s</itemPath>
-        <itemPath>../../libVectorMatrix/vsub.s</itemPath>
-        <itemPath>../../libVectorMatrix/vzpad.s</itemPath>
-      </logicalFolder>
-      <logicalFolder name="libFlashFS" displayName="libFlashFS" projectFiles="true">
-        <itemPath>../../libFlashFS/AT45D.c</itemPath>
-        <itemPath>../../libFlashFS/AT45D_DMA.c</itemPath>
-        <itemPath>../../libFlashFS/AT45D_FS.c</itemPath>
-        <itemPath>../../libFlashFS/EEPROM.c</itemPath>
-        <itemPath>../../libFlashFS/EEPROM_FS.c</itemPath>
-        <itemPath>../../libFlashFS/filesys.c</itemPath>
-        <itemPath>../../libFlashFS/MDD_AT45D.c</itemPath>
-        <itemPath>../../libFlashFS/MDD_EEPROM.c</itemPath>
-        <itemPath>../../libFlashFS/usb.c</itemPath>
-        <itemPath>../../libFlashFS/usb_cdc.c</itemPath>
-        <itemPath>../../libFlashFS/usb_descriptors.c</itemPath>
-        <itemPath>../../libFlashFS/usb_msd.c</itemPath>
-      </logicalFolder>
       <logicalFolder name="Microchip" displayName="Microchip" projectFiles="true">
-      <logicalFolder name="MDD-File-System" displayName="MDD-File-System" projectFiles="true">
-        <itemPath>../../Microchip/MDD-File-System/FSIO.c</itemPath>
-        <itemPath>../../Microchip/MDD-File-System/SD-SPI.c</itemPath>
+        <logicalFolder name="MDD-File-System"
+                       displayName="MDD-File-System"
+                       projectFiles="true">
+          <itemPath>../../Microchip/MDD-File-System/FSIO.c</itemPath>
+          <itemPath>../../Microchip/MDD-File-System/SD-SPI.c</itemPath>
+        </logicalFolder>
+        <logicalFolder name="USB" displayName="USB" projectFiles="true">
+          <logicalFolder name="CDC-Device-Driver"
+                         displayName="CDC-Device-Driver"
+                         projectFiles="true">
+            <itemPath>../../Microchip/USB/CDC-Device-Driver/usb_function_cdc.c</itemPath>
+          </logicalFolder>
+          <logicalFolder name="MSD-Device-Driver"
+                         displayName="MSD-Device-Driver"
+                         projectFiles="true">
+            <itemPath>../../Microchip/USB/MSD-Device-Driver/usb_function_msd.c</itemPath>
+          </logicalFolder>
+          <itemPath>../../Microchip/USB/usb_device.c</itemPath>
+          <itemPath>../../Microchip/USB/usb_hal_dspic33e.c</itemPath>
+        </logicalFolder>
       </logicalFolder>
-      <logicalFolder name="USB" displayName="USB" projectFiles="true">
-      <logicalFolder name="CDC-Device-Driver" displayName="CDC-Device-Driver" projectFiles="true">
-        <itemPath>../../Microchip/USB/CDC-Device-Driver/usb_function_cdc.c</itemPath>
-      </logicalFolder>
-      <logicalFolder name="MSD-Device-Driver" displayName="MSD-Device-Driver" projectFiles="true">
-        <itemPath>../../Microchip/USB/MSD-Device-Driver/usb_function_msd.c</itemPath>
-      </logicalFolder>
-        <itemPath>../../Microchip/USB/usb_device.c</itemPath>
-        <itemPath>../../Microchip/USB/usb_hal_dspic33e.c</itemPath>
-      </logicalFolder>
-      </logicalFolder>
-</logicalFolder>
+    </logicalFolder>
     <logicalFolder name="ExternalFiles"
-    displayName="Important Files" projectFiles="false">
+                   displayName="Important Files"
+                   projectFiles="false">
       <itemPath>Makefile</itemPath>
     </logicalFolder>
   </logicalFolder>
@@ -534,149 +554,229 @@
         <targetPluginBoard></targetPluginBoard>
         <platformTool>PICkit3PlatformTool</platformTool>
         <languageToolchain>XC16</languageToolchain>
-        <languageToolchainVersion>1.10</languageToolchainVersion>
-        <platform>3</platform>
+        <languageToolchainVersion>1.26</languageToolchainVersion>
+        <platform>4</platform>
       </toolsSet>
       <compileType>
         <linkerTool>
-          <linkerLibItems></linkerLibItems>
+          <linkerLibItems>
+          </linkerLibItems>
         </linkerTool>
+        <archiverTool>
+        </archiverTool>
         <loading>
-          <useAlternateLoadableFile>
-          false</useAlternateLoadableFile>
+          <useAlternateLoadableFile>false</useAlternateLoadableFile>
+          <parseOnProdLoad>false</parseOnProdLoad>
           <alternateLoadableFile></alternateLoadableFile>
         </loading>
       </compileType>
       <makeCustomizationType>
-        <makeCustomizationPreStepEnabled>
-        false</makeCustomizationPreStepEnabled>
+        <makeCustomizationPreStepEnabled>false</makeCustomizationPreStepEnabled>
         <makeCustomizationPreStep></makeCustomizationPreStep>
-        <makeCustomizationPostStepEnabled>
-        false</makeCustomizationPostStepEnabled>
+        <makeCustomizationPostStepEnabled>false</makeCustomizationPostStepEnabled>
         <makeCustomizationPostStep></makeCustomizationPostStep>
-        <makeCustomizationPutChecksumInUserID>
-        false</makeCustomizationPutChecksumInUserID>
-        <makeCustomizationEnableLongLines>
-        false</makeCustomizationEnableLongLines>
-        <makeCustomizationNormalizeHexFile>
-        false</makeCustomizationNormalizeHexFile>
+        <makeCustomizationPutChecksumInUserID>false</makeCustomizationPutChecksumInUserID>
+        <makeCustomizationEnableLongLines>false</makeCustomizationEnableLongLines>
+        <makeCustomizationNormalizeHexFile>false</makeCustomizationNormalizeHexFile>
       </makeCustomizationType>
       <C30>
-        <property key="code-model" value="large-code" />
-        <property key="const-model" value="default" />
-        <property key="data-model" value="large-data" />
-        <property key="enable-all-warnings" value="true" />
-        <property key="enable-ansi-std" value="false" />
-        <property key="enable-ansi-warnings" value="false" />
-        <property key="enable-fatal-warnings" value="false" />
-        <property key="enable-large-arrays" value="false" />
-        <property key="enable-omit-frame-pointer" value="false" />
-        <property key="enable-procedural-abstraction"
-        value="false" />
-        <property key="enable-short-double" value="false" />
-        <property key="enable-symbols" value="true" />
-        <property key="enable-unroll-loops" value="false" />
+        <property key="code-model" value="large-code"/>
+        <property key="const-model" value="default"/>
+        <property key="data-model" value="large-data"/>
+        <property key="disable-instruction-scheduling" value="false"/>
+        <property key="enable-all-warnings" value="true"/>
+        <property key="enable-ansi-std" value="false"/>
+        <property key="enable-ansi-warnings" value="false"/>
+        <property key="enable-fatal-warnings" value="false"/>
+        <property key="enable-large-arrays" value="false"/>
+        <property key="enable-omit-frame-pointer" value="false"/>
+        <property key="enable-procedural-abstraction" value="false"/>
+        <property key="enable-short-double" value="false"/>
+        <property key="enable-symbols" value="true"/>
+        <property key="enable-unroll-loops" value="false"/>
         <property key="extra-include-directories"
-        value="../../Config;../../MAVLink/include;../../Microchip;../../Microchip/Include;../../libVectorMatrix" />
-        <property key="isolate-each-function" value="false" />
-        <property key="keep-inline" value="false" />
-        <property key="oXC16gcc-align-arr" value="false" />
-        <property key="oXC16gcc-cnsts-mauxflash" value="false" />
-        <property key="oXC16gcc-data-sects" value="false" />
-        <property key="oXC16gcc-errata" value="" />
-        <property key="oXC16gcc-fillupper" value="" />
-        <property key="oXC16gcc-large-aggregate" value="false" />
-        <property key="oXC16gcc-mauxflash" value="false" />
-        <property key="oXC16gcc-mpa-lvl" value="" />
-        <property key="oXC16gcc-name-text-sec" value="" />
-        <property key="oXC16gcc-near-chars" value="false" />
-        <property key="oXC16gcc-no-isr-warn" value="false" />
-        <property key="oXC16gcc-sfr-warn" value="false" />
-        <property key="oXC16gcc-smar-io-lvl" value="1" />
-        <property key="oXC16gcc-smart-io-fmt" value="" />
-        <property key="optimization-level" value="0" />
-        <property key="post-instruction-scheduling"
-        value="default" />
-        <property key="pre-instruction-scheduling"
-        value="default" />
-        <property key="preprocessor-macros"
-        value="UDB5=1;" />
-        <property key="scalar-model" value="default" />
-        <property key="use-cci" value="false" />
+                  value="../../Config;../../MAVLink/include;../../Microchip;../../Microchip/Include;../../libVectorMatrix"/>
+        <property key="isolate-each-function" value="false"/>
+        <property key="keep-inline" value="false"/>
+        <property key="oXC16gcc-align-arr" value="false"/>
+        <property key="oXC16gcc-cnsts-mauxflash" value="false"/>
+        <property key="oXC16gcc-data-sects" value="false"/>
+        <property key="oXC16gcc-errata" value=""/>
+        <property key="oXC16gcc-fillupper" value=""/>
+        <property key="oXC16gcc-large-aggregate" value="false"/>
+        <property key="oXC16gcc-mauxflash" value="false"/>
+        <property key="oXC16gcc-mpa-lvl" value=""/>
+        <property key="oXC16gcc-name-text-sec" value=""/>
+        <property key="oXC16gcc-near-chars" value="false"/>
+        <property key="oXC16gcc-no-isr-warn" value="false"/>
+        <property key="oXC16gcc-sfr-warn" value="false"/>
+        <property key="oXC16gcc-smar-io-lvl" value="1"/>
+        <property key="oXC16gcc-smart-io-fmt" value=""/>
+        <property key="optimization-level" value="0"/>
+        <property key="post-instruction-scheduling" value="default"/>
+        <property key="pre-instruction-scheduling" value="default"/>
+        <property key="preprocessor-macros" value="UDB5=1"/>
+        <property key="scalar-model" value="default"/>
+        <property key="use-cci" value="false"/>
+        <property key="use-iar" value="false"/>
       </C30>
+      <C30-AR>
+        <property key="additional-options-chop-files" value="false"/>
+      </C30-AR>
       <C30-AS>
-        <property key="assembler-symbols" value="PSV_ERRATA=1" />
-        <property key="expand-macros" value="false" />
+        <property key="assembler-symbols" value="PSV_ERRATA=1"/>
+        <property key="expand-macros" value="false"/>
         <property key="extra-include-directories-for-assembler"
-        value="..;../../libVectorMatrix" />
-        <property key="extra-include-directories-for-preprocessor"
-        value="" />
-        <property key="false-conditionals" value="false" />
-        <property key="keep-locals" value="false" />
-        <property key="list-assembly" value="false" />
-        <property key="list-section-info" value="false" />
-        <property key="list-source" value="false" />
-        <property key="list-symbols" value="false" />
-        <property key="oXC16asm-extra-opts" value="" />
-        <property key="oXC16asm-list-to-file" value="false" />
-        <property key="omit-debug-dirs" value="false" />
-        <property key="omit-forms" value="false" />
-        <property key="preprocessor-macros" value="" />
-        <property key="relax" value="false" />
-        <property key="warning-level" value="emit-warnings" />
-        <appendMe value="-g" />
+                  value="..;../../libVectorMatrix"/>
+        <property key="extra-include-directories-for-preprocessor" value=""/>
+        <property key="false-conditionals" value="false"/>
+        <property key="keep-locals" value="false"/>
+        <property key="list-assembly" value="false"/>
+        <property key="list-section-info" value="false"/>
+        <property key="list-source" value="false"/>
+        <property key="list-symbols" value="false"/>
+        <property key="oXC16asm-extra-opts" value=""/>
+        <property key="oXC16asm-list-to-file" value="false"/>
+        <property key="omit-debug-dirs" value="false"/>
+        <property key="omit-forms" value="false"/>
+        <property key="preprocessor-macros" value=""/>
+        <property key="relax" value="false"/>
+        <property key="warning-level" value="emit-warnings"/>
+        <appendMe value="-g"/>
       </C30-AS>
       <C30-LD>
-        <property key="additional-options-use-response-files"
-        value="false" />
-        <property key="boot-eeprom" value="no_eeprom" />
-        <property key="boot-flash" value="no_flash" />
-        <property key="boot-ram" value="no_ram" />
-        <property key="boot-write-protect"
-        value="no_write_protect" />
-        <property key="enable-check-sections" value="false" />
-        <property key="enable-data-init" value="true" />
-        <property key="enable-default-isr" value="true" />
-        <property key="enable-handles" value="true" />
-        <property key="enable-pack-data" value="true" />
-        <property key="extra-lib-directories" value="" />
-        <property key="general-code-protect"
-        value="no_code_protect" />
-        <property key="general-write-protect"
-        value="no_write_protect" />
-        <property key="generate-cross-reference-file"
-        value="false" />
-        <property key="heap-size" value="256" />
-        <property key="input-libraries" value="" />
-        <property key="linker-symbols" value="" />
+        <property key="additional-options-use-response-files" value="false"/>
+        <property key="boot-eeprom" value="no_eeprom"/>
+        <property key="boot-flash" value="no_flash"/>
+        <property key="boot-ram" value="no_ram"/>
+        <property key="boot-write-protect" value="no_write_protect"/>
+        <property key="enable-check-sections" value="false"/>
+        <property key="enable-data-init" value="true"/>
+        <property key="enable-default-isr" value="true"/>
+        <property key="enable-handles" value="true"/>
+        <property key="enable-pack-data" value="true"/>
+        <property key="extra-lib-directories" value=""/>
+        <property key="fill-flash-options-addr" value=""/>
+        <property key="fill-flash-options-const" value=""/>
+        <property key="fill-flash-options-how" value="0"/>
+        <property key="fill-flash-options-inc-const" value="1"/>
+        <property key="fill-flash-options-increment" value=""/>
+        <property key="fill-flash-options-seq" value=""/>
+        <property key="fill-flash-options-what" value="0"/>
+        <property key="general-code-protect" value="no_code_protect"/>
+        <property key="general-write-protect" value="no_write_protect"/>
+        <property key="generate-cross-reference-file" value="false"/>
+        <property key="heap-size" value="256"/>
+        <property key="input-libraries" value=""/>
+        <property key="linker-stack" value="true"/>
+        <property key="linker-symbols" value=""/>
         <property key="map-file"
-        value="&quot;${DISTDIR}/MatrixPilot-UDB5.X.${IMAGE_TYPE}.map&quot;" />
-        <property key="oXC16ld-extra-opts" value="" />
-        <property key="oXC16ld-fill-upper" value="0" />
-        <property key="oXC16ld-force-link" value="false" />
-        <property key="oXC16ld-no-smart-io" value="false" />
-        <property key="oXC16ld-nostdlib" value="false" />
-        <property key="oXC16ld-stackguard" value="16" />
-        <property key="preprocessor-macros" value="" />
-        <property key="remove-unused-sections" value="false" />
-        <property key="report-memory-usage" value="false" />
-        <property key="secure-eeprom" value="no_eeprom" />
-        <property key="secure-flash" value="no_flash" />
-        <property key="secure-ram" value="no_ram" />
-        <property key="secure-write-protect"
-        value="no_write_protect" />
-        <property key="stack-size" value="16" />
-        <property key="symbol-stripping" value="" />
-        <property key="trace-symbols" value="" />
-        <property key="warn-section-align" value="false" />
+                  value="&quot;${DISTDIR}/MatrixPilot-UDB5.X.${IMAGE_TYPE}.map&quot;"/>
+        <property key="oXC16ld-extra-opts" value=""/>
+        <property key="oXC16ld-fill-upper" value="0"/>
+        <property key="oXC16ld-force-link" value="false"/>
+        <property key="oXC16ld-no-smart-io" value="false"/>
+        <property key="oXC16ld-nostdlib" value="false"/>
+        <property key="oXC16ld-stackguard" value="16"/>
+        <property key="preprocessor-macros" value=""/>
+        <property key="remove-unused-sections" value="false"/>
+        <property key="report-memory-usage" value="false"/>
+        <property key="secure-eeprom" value="no_eeprom"/>
+        <property key="secure-flash" value="no_flash"/>
+        <property key="secure-ram" value="no_ram"/>
+        <property key="secure-write-protect" value="no_write_protect"/>
+        <property key="stack-size" value="16"/>
+        <property key="symbol-stripping" value=""/>
+        <property key="trace-symbols" value=""/>
+        <property key="warn-section-align" value="false"/>
       </C30-LD>
       <C30Global>
-        <property key="fast-math" value="false" />
-        <property key="generic-16-bit" value="false" />
-        <property key="legacy-libc" value="true" />
-        <property key="oXC16glb-macros" value="" />
-        <property key="output-file-format" value="elf" />
+        <property key="common-include-directories" value=""/>
+        <property key="dual-boot-partition" value="0"/>
+        <property key="fast-math" value="false"/>
+        <property key="generic-16-bit" value="false"/>
+        <property key="legacy-libc" value="true"/>
+        <property key="oXC16glb-macros" value=""/>
+        <property key="output-file-format" value="elf"/>
+        <property key="relaxed-math" value="false"/>
+        <property key="save-temps" value="false"/>
       </C30Global>
+      <PICkit3PlatformTool>
+        <property key="ADC 1" value="true"/>
+        <property key="ADC 2" value="true"/>
+        <property key="AutoSelectMemRanges" value="auto"/>
+        <property key="DCI" value="true"/>
+        <property key="Freeze All Other Peripherals" value="true"/>
+        <property key="I2C1" value="true"/>
+        <property key="I2C2" value="true"/>
+        <property key="INPUT CAPTURE 1" value="true"/>
+        <property key="INPUT CAPTURE 2" value="true"/>
+        <property key="INPUT CAPTURE 3" value="true"/>
+        <property key="INPUT CAPTURE 4" value="true"/>
+        <property key="INPUT CAPTURE 5" value="true"/>
+        <property key="INPUT CAPTURE 6" value="true"/>
+        <property key="INPUT CAPTURE 7" value="true"/>
+        <property key="INPUT CAPTURE 8" value="true"/>
+        <property key="OUTPUT COMPARE 1" value="true"/>
+        <property key="OUTPUT COMPARE 2" value="true"/>
+        <property key="OUTPUT COMPARE 3" value="true"/>
+        <property key="OUTPUT COMPARE 4" value="true"/>
+        <property key="OUTPUT COMPARE 5" value="true"/>
+        <property key="OUTPUT COMPARE 6" value="true"/>
+        <property key="OUTPUT COMPARE 7" value="true"/>
+        <property key="OUTPUT COMPARE 8" value="true"/>
+        <property key="SPI 1" value="true"/>
+        <property key="SPI 2" value="true"/>
+        <property key="SecureSegment.SegmentProgramming" value="FullChipProgramming"/>
+        <property key="TIMER1" value="true"/>
+        <property key="TIMER2" value="true"/>
+        <property key="TIMER3" value="true"/>
+        <property key="TIMER4" value="true"/>
+        <property key="TIMER5" value="true"/>
+        <property key="TIMER6" value="true"/>
+        <property key="TIMER7" value="true"/>
+        <property key="TIMER8" value="true"/>
+        <property key="TIMER9" value="true"/>
+        <property key="ToolFirmwareFilePath"
+                  value="Press to browse for a specific firmware version"/>
+        <property key="ToolFirmwareOption.UseLatestFirmware" value="true"/>
+        <property key="UART 1" value="true"/>
+        <property key="UART 2" value="true"/>
+        <property key="hwtoolclock.frcindebug" value="false"/>
+        <property key="memories.aux" value="false"/>
+        <property key="memories.bootflash" value="true"/>
+        <property key="memories.configurationmemory" value="true"/>
+        <property key="memories.configurationmemory2" value="true"/>
+        <property key="memories.dataflash" value="true"/>
+        <property key="memories.eeprom" value="true"/>
+        <property key="memories.flashdata" value="true"/>
+        <property key="memories.id" value="true"/>
+        <property key="memories.programmemory" value="true"/>
+        <property key="memories.programmemory.end" value="0x2abff"/>
+        <property key="memories.programmemory.partition2" value="true"/>
+        <property key="memories.programmemory.partition2.end"
+                  value="${memories.programmemory.partition2.end.value}"/>
+        <property key="memories.programmemory.partition2.start"
+                  value="${memories.programmemory.partition2.start.value}"/>
+        <property key="memories.programmemory.start" value="0x0"/>
+        <property key="poweroptions.powerenable" value="false"/>
+        <property key="programmertogo.imagename" value=""/>
+        <property key="programoptions.donoteraseauxmem" value="false"/>
+        <property key="programoptions.eraseb4program" value="true"/>
+        <property key="programoptions.pgmspeed" value="2"/>
+        <property key="programoptions.preservedataflash" value="false"/>
+        <property key="programoptions.preserveeeprom" value="false"/>
+        <property key="programoptions.preserveprogramrange" value="false"/>
+        <property key="programoptions.preserveprogramrange.end" value="0x2abff"/>
+        <property key="programoptions.preserveprogramrange.start" value="0x0"/>
+        <property key="programoptions.preserveuserid" value="false"/>
+        <property key="programoptions.programcalmem" value="false"/>
+        <property key="programoptions.programuserotp" value="false"/>
+        <property key="programoptions.testmodeentrymethod" value="VDDFirst"/>
+        <property key="programoptions.usehighvoltageonmclr" value="false"/>
+        <property key="programoptions.uselvpprogramming" value="false"/>
+        <property key="voltagevalue" value="3.25"/>
+      </PICkit3PlatformTool>
     </conf>
   </confs>
 </configurationDescriptor>

--- a/RollPitchYaw/RollPitchYaw-auav3.X/nbproject/configurations.xml
+++ b/RollPitchYaw/RollPitchYaw-auav3.X/nbproject/configurations.xml
@@ -255,7 +255,7 @@
         <platformTool>PICkit3PlatformTool</platformTool>
         <languageToolchain>XC16</languageToolchain>
         <languageToolchainVersion>1.26</languageToolchainVersion>
-        <platform>3</platform>
+        <platform>4</platform>
       </toolsSet>
       <compileType>
         <linkerTool>
@@ -283,6 +283,7 @@
         <property key="code-model" value="large-code"/>
         <property key="const-model" value="default"/>
         <property key="data-model" value="large-data"/>
+        <property key="disable-instruction-scheduling" value="false"/>
         <property key="enable-all-warnings" value="true"/>
         <property key="enable-ansi-std" value="false"/>
         <property key="enable-ansi-warnings" value="false"/>
@@ -317,6 +318,7 @@
         <property key="preprocessor-macros" value="AUAV3"/>
         <property key="scalar-model" value="default"/>
         <property key="use-cci" value="false"/>
+        <property key="use-iar" value="false"/>
       </C30>
       <C30-AR>
         <property key="additional-options-chop-files" value="false"/>
@@ -354,11 +356,19 @@
         <property key="enable-handles" value="true"/>
         <property key="enable-pack-data" value="true"/>
         <property key="extra-lib-directories" value=""/>
+        <property key="fill-flash-options-addr" value=""/>
+        <property key="fill-flash-options-const" value=""/>
+        <property key="fill-flash-options-how" value="0"/>
+        <property key="fill-flash-options-inc-const" value="1"/>
+        <property key="fill-flash-options-increment" value=""/>
+        <property key="fill-flash-options-seq" value=""/>
+        <property key="fill-flash-options-what" value="0"/>
         <property key="general-code-protect" value="no_code_protect"/>
         <property key="general-write-protect" value="no_write_protect"/>
         <property key="generate-cross-reference-file" value="false"/>
         <property key="heap-size" value="256"/>
         <property key="input-libraries" value=""/>
+        <property key="linker-stack" value="true"/>
         <property key="linker-symbols" value=""/>
         <property key="map-file"
                   value="&quot;${DISTDIR}/RollPitchYaw-AUAV3.X.${IMAGE_TYPE}.map&quot;"/>
@@ -381,12 +391,118 @@
         <property key="warn-section-align" value="false"/>
       </C30-LD>
       <C30Global>
+        <property key="common-include-directories" value=""/>
+        <property key="dual-boot-partition" value="0"/>
         <property key="fast-math" value="false"/>
         <property key="generic-16-bit" value="false"/>
         <property key="legacy-libc" value="true"/>
         <property key="oXC16glb-macros" value=""/>
         <property key="output-file-format" value="elf"/>
+        <property key="relaxed-math" value="false"/>
+        <property key="save-temps" value="false"/>
       </C30Global>
+      <PICkit3PlatformTool>
+        <property key="ADC 1" value="true"/>
+        <property key="ADC 2" value="true"/>
+        <property key="AutoSelectMemRanges" value="auto"/>
+        <property key="COMPARATOR" value="true"/>
+        <property key="CRC" value="true"/>
+        <property key="DCI" value="true"/>
+        <property key="Freeze All Other Peripherals" value="true"/>
+        <property key="I2C1" value="true"/>
+        <property key="I2C2" value="true"/>
+        <property key="INPUT CAPTURE 1" value="true"/>
+        <property key="INPUT CAPTURE 10" value="true"/>
+        <property key="INPUT CAPTURE 11" value="true"/>
+        <property key="INPUT CAPTURE 12" value="true"/>
+        <property key="INPUT CAPTURE 13" value="true"/>
+        <property key="INPUT CAPTURE 14" value="true"/>
+        <property key="INPUT CAPTURE 15" value="true"/>
+        <property key="INPUT CAPTURE 16" value="true"/>
+        <property key="INPUT CAPTURE 2" value="true"/>
+        <property key="INPUT CAPTURE 3" value="true"/>
+        <property key="INPUT CAPTURE 4" value="true"/>
+        <property key="INPUT CAPTURE 5" value="true"/>
+        <property key="INPUT CAPTURE 6" value="true"/>
+        <property key="INPUT CAPTURE 7" value="true"/>
+        <property key="INPUT CAPTURE 8" value="true"/>
+        <property key="INPUT CAPTURE 9" value="true"/>
+        <property key="OUTPUT COMPARE 1" value="true"/>
+        <property key="OUTPUT COMPARE 10" value="true"/>
+        <property key="OUTPUT COMPARE 11" value="true"/>
+        <property key="OUTPUT COMPARE 12" value="true"/>
+        <property key="OUTPUT COMPARE 13" value="true"/>
+        <property key="OUTPUT COMPARE 14" value="true"/>
+        <property key="OUTPUT COMPARE 15" value="true"/>
+        <property key="OUTPUT COMPARE 16" value="true"/>
+        <property key="OUTPUT COMPARE 2" value="true"/>
+        <property key="OUTPUT COMPARE 3" value="true"/>
+        <property key="OUTPUT COMPARE 4" value="true"/>
+        <property key="OUTPUT COMPARE 5" value="true"/>
+        <property key="OUTPUT COMPARE 6" value="true"/>
+        <property key="OUTPUT COMPARE 7" value="true"/>
+        <property key="OUTPUT COMPARE 8" value="true"/>
+        <property key="OUTPUT COMPARE 9" value="true"/>
+        <property key="PARALLEL MASTER/SLAVE PORT" value="true"/>
+        <property key="PWM" value="true"/>
+        <property key="REAL TIME CLOCK AND CALENDAR" value="true"/>
+        <property key="SPI 1" value="true"/>
+        <property key="SPI 2" value="true"/>
+        <property key="SPI 3" value="true"/>
+        <property key="SPI 4" value="true"/>
+        <property key="SecureSegment.SegmentProgramming" value="FullChipProgramming"/>
+        <property key="TIMER1" value="true"/>
+        <property key="TIMER2" value="true"/>
+        <property key="TIMER3" value="true"/>
+        <property key="TIMER4" value="true"/>
+        <property key="TIMER5" value="true"/>
+        <property key="TIMER6" value="true"/>
+        <property key="TIMER7" value="true"/>
+        <property key="TIMER8" value="true"/>
+        <property key="TIMER9" value="true"/>
+        <property key="ToolFirmwareFilePath"
+                  value="Press to browse for a specific firmware version"/>
+        <property key="ToolFirmwareOption.UseLatestFirmware" value="true"/>
+        <property key="UART 1" value="true"/>
+        <property key="UART 2" value="true"/>
+        <property key="UART 3" value="true"/>
+        <property key="UART 4" value="true"/>
+        <property key="USB" value="true"/>
+        <property key="hwtoolclock.frcindebug" value="false"/>
+        <property key="memories.aux" value="false"/>
+        <property key="memories.bootflash" value="true"/>
+        <property key="memories.configurationmemory" value="true"/>
+        <property key="memories.configurationmemory2" value="true"/>
+        <property key="memories.dataflash" value="true"/>
+        <property key="memories.eeprom" value="true"/>
+        <property key="memories.flashdata" value="true"/>
+        <property key="memories.id" value="true"/>
+        <property key="memories.programmemory" value="true"/>
+        <property key="memories.programmemory.end" value="0x557ff"/>
+        <property key="memories.programmemory.partition2" value="true"/>
+        <property key="memories.programmemory.partition2.end"
+                  value="${memories.programmemory.partition2.end.value}"/>
+        <property key="memories.programmemory.partition2.start"
+                  value="${memories.programmemory.partition2.start.value}"/>
+        <property key="memories.programmemory.start" value="0x0"/>
+        <property key="poweroptions.powerenable" value="false"/>
+        <property key="programmertogo.imagename" value=""/>
+        <property key="programoptions.donoteraseauxmem" value="false"/>
+        <property key="programoptions.eraseb4program" value="true"/>
+        <property key="programoptions.pgmspeed" value="2"/>
+        <property key="programoptions.preservedataflash" value="false"/>
+        <property key="programoptions.preserveeeprom" value="false"/>
+        <property key="programoptions.preserveprogramrange" value="false"/>
+        <property key="programoptions.preserveprogramrange.end" value="0x557ff"/>
+        <property key="programoptions.preserveprogramrange.start" value="0x0"/>
+        <property key="programoptions.preserveuserid" value="false"/>
+        <property key="programoptions.programcalmem" value="false"/>
+        <property key="programoptions.programuserotp" value="false"/>
+        <property key="programoptions.testmodeentrymethod" value="VDDFirst"/>
+        <property key="programoptions.usehighvoltageonmclr" value="false"/>
+        <property key="programoptions.uselvpprogramming" value="false"/>
+        <property key="voltagevalue" value="3.25"/>
+      </PICkit3PlatformTool>
     </conf>
   </confs>
 </configurationDescriptor>

--- a/RollPitchYaw/RollPitchYaw-udb4.X/nbproject/configurations.xml
+++ b/RollPitchYaw/RollPitchYaw-udb4.X/nbproject/configurations.xml
@@ -255,7 +255,7 @@
         <platformTool>PICkit3PlatformTool</platformTool>
         <languageToolchain>XC16</languageToolchain>
         <languageToolchainVersion>1.26</languageToolchainVersion>
-        <platform>3</platform>
+        <platform>4</platform>
       </toolsSet>
       <compileType>
         <linkerTool>
@@ -283,6 +283,7 @@
         <property key="code-model" value="large-code"/>
         <property key="const-model" value="default"/>
         <property key="data-model" value="large-data"/>
+        <property key="disable-instruction-scheduling" value="false"/>
         <property key="enable-all-warnings" value="true"/>
         <property key="enable-ansi-std" value="false"/>
         <property key="enable-ansi-warnings" value="false"/>
@@ -317,6 +318,7 @@
         <property key="preprocessor-macros" value="UDB4"/>
         <property key="scalar-model" value="default"/>
         <property key="use-cci" value="false"/>
+        <property key="use-iar" value="false"/>
       </C30>
       <C30-AR>
         <property key="additional-options-chop-files" value="false"/>
@@ -354,11 +356,19 @@
         <property key="enable-handles" value="true"/>
         <property key="enable-pack-data" value="true"/>
         <property key="extra-lib-directories" value=""/>
+        <property key="fill-flash-options-addr" value=""/>
+        <property key="fill-flash-options-const" value=""/>
+        <property key="fill-flash-options-how" value="0"/>
+        <property key="fill-flash-options-inc-const" value="1"/>
+        <property key="fill-flash-options-increment" value=""/>
+        <property key="fill-flash-options-seq" value=""/>
+        <property key="fill-flash-options-what" value="0"/>
         <property key="general-code-protect" value="no_code_protect"/>
         <property key="general-write-protect" value="no_write_protect"/>
         <property key="generate-cross-reference-file" value="false"/>
         <property key="heap-size" value="256"/>
         <property key="input-libraries" value=""/>
+        <property key="linker-stack" value="true"/>
         <property key="linker-symbols" value=""/>
         <property key="map-file"
                   value="&quot;${DISTDIR}/RollPitchYaw-UDB4.X.${IMAGE_TYPE}.map&quot;"/>
@@ -381,12 +391,92 @@
         <property key="warn-section-align" value="false"/>
       </C30-LD>
       <C30Global>
+        <property key="common-include-directories" value=""/>
+        <property key="dual-boot-partition" value="0"/>
         <property key="fast-math" value="false"/>
         <property key="generic-16-bit" value="false"/>
         <property key="legacy-libc" value="true"/>
         <property key="oXC16glb-macros" value=""/>
         <property key="output-file-format" value="elf"/>
+        <property key="relaxed-math" value="false"/>
+        <property key="save-temps" value="false"/>
       </C30Global>
+      <PICkit3PlatformTool>
+        <property key="ADC 1" value="true"/>
+        <property key="ADC 2" value="true"/>
+        <property key="AutoSelectMemRanges" value="auto"/>
+        <property key="DCI" value="true"/>
+        <property key="Freeze All Other Peripherals" value="true"/>
+        <property key="I2C1" value="true"/>
+        <property key="I2C2" value="true"/>
+        <property key="INPUT CAPTURE 1" value="true"/>
+        <property key="INPUT CAPTURE 2" value="true"/>
+        <property key="INPUT CAPTURE 3" value="true"/>
+        <property key="INPUT CAPTURE 4" value="true"/>
+        <property key="INPUT CAPTURE 5" value="true"/>
+        <property key="INPUT CAPTURE 6" value="true"/>
+        <property key="INPUT CAPTURE 7" value="true"/>
+        <property key="INPUT CAPTURE 8" value="true"/>
+        <property key="OUTPUT COMPARE 1" value="true"/>
+        <property key="OUTPUT COMPARE 2" value="true"/>
+        <property key="OUTPUT COMPARE 3" value="true"/>
+        <property key="OUTPUT COMPARE 4" value="true"/>
+        <property key="OUTPUT COMPARE 5" value="true"/>
+        <property key="OUTPUT COMPARE 6" value="true"/>
+        <property key="OUTPUT COMPARE 7" value="true"/>
+        <property key="OUTPUT COMPARE 8" value="true"/>
+        <property key="SPI 1" value="true"/>
+        <property key="SPI 2" value="true"/>
+        <property key="SecureSegment.SegmentProgramming" value="FullChipProgramming"/>
+        <property key="TIMER1" value="true"/>
+        <property key="TIMER2" value="true"/>
+        <property key="TIMER3" value="true"/>
+        <property key="TIMER4" value="true"/>
+        <property key="TIMER5" value="true"/>
+        <property key="TIMER6" value="true"/>
+        <property key="TIMER7" value="true"/>
+        <property key="TIMER8" value="true"/>
+        <property key="TIMER9" value="true"/>
+        <property key="ToolFirmwareFilePath"
+                  value="Press to browse for a specific firmware version"/>
+        <property key="ToolFirmwareOption.UseLatestFirmware" value="true"/>
+        <property key="UART 1" value="true"/>
+        <property key="UART 2" value="true"/>
+        <property key="hwtoolclock.frcindebug" value="false"/>
+        <property key="memories.aux" value="false"/>
+        <property key="memories.bootflash" value="true"/>
+        <property key="memories.configurationmemory" value="true"/>
+        <property key="memories.configurationmemory2" value="true"/>
+        <property key="memories.dataflash" value="true"/>
+        <property key="memories.eeprom" value="true"/>
+        <property key="memories.flashdata" value="true"/>
+        <property key="memories.id" value="true"/>
+        <property key="memories.programmemory" value="true"/>
+        <property key="memories.programmemory.end" value="0x2abff"/>
+        <property key="memories.programmemory.partition2" value="true"/>
+        <property key="memories.programmemory.partition2.end"
+                  value="${memories.programmemory.partition2.end.value}"/>
+        <property key="memories.programmemory.partition2.start"
+                  value="${memories.programmemory.partition2.start.value}"/>
+        <property key="memories.programmemory.start" value="0x0"/>
+        <property key="poweroptions.powerenable" value="false"/>
+        <property key="programmertogo.imagename" value=""/>
+        <property key="programoptions.donoteraseauxmem" value="false"/>
+        <property key="programoptions.eraseb4program" value="true"/>
+        <property key="programoptions.pgmspeed" value="2"/>
+        <property key="programoptions.preservedataflash" value="false"/>
+        <property key="programoptions.preserveeeprom" value="false"/>
+        <property key="programoptions.preserveprogramrange" value="false"/>
+        <property key="programoptions.preserveprogramrange.end" value="0x2abff"/>
+        <property key="programoptions.preserveprogramrange.start" value="0x0"/>
+        <property key="programoptions.preserveuserid" value="false"/>
+        <property key="programoptions.programcalmem" value="false"/>
+        <property key="programoptions.programuserotp" value="false"/>
+        <property key="programoptions.testmodeentrymethod" value="VDDFirst"/>
+        <property key="programoptions.usehighvoltageonmclr" value="false"/>
+        <property key="programoptions.uselvpprogramming" value="false"/>
+        <property key="voltagevalue" value="3.25"/>
+      </PICkit3PlatformTool>
     </conf>
   </confs>
 </configurationDescriptor>

--- a/RollPitchYaw/RollPitchYaw-udb5.X/nbproject/configurations.xml
+++ b/RollPitchYaw/RollPitchYaw-udb5.X/nbproject/configurations.xml
@@ -255,7 +255,7 @@
         <platformTool>PICkit3PlatformTool</platformTool>
         <languageToolchain>XC16</languageToolchain>
         <languageToolchainVersion>1.26</languageToolchainVersion>
-        <platform>3</platform>
+        <platform>4</platform>
       </toolsSet>
       <compileType>
         <linkerTool>
@@ -283,6 +283,7 @@
         <property key="code-model" value="large-code"/>
         <property key="const-model" value="default"/>
         <property key="data-model" value="large-data"/>
+        <property key="disable-instruction-scheduling" value="false"/>
         <property key="enable-all-warnings" value="true"/>
         <property key="enable-ansi-std" value="false"/>
         <property key="enable-ansi-warnings" value="false"/>
@@ -317,6 +318,7 @@
         <property key="preprocessor-macros" value="UDB5"/>
         <property key="scalar-model" value="default"/>
         <property key="use-cci" value="false"/>
+        <property key="use-iar" value="false"/>
       </C30>
       <C30-AR>
         <property key="additional-options-chop-files" value="false"/>
@@ -354,11 +356,19 @@
         <property key="enable-handles" value="true"/>
         <property key="enable-pack-data" value="true"/>
         <property key="extra-lib-directories" value=""/>
+        <property key="fill-flash-options-addr" value=""/>
+        <property key="fill-flash-options-const" value=""/>
+        <property key="fill-flash-options-how" value="0"/>
+        <property key="fill-flash-options-inc-const" value="1"/>
+        <property key="fill-flash-options-increment" value=""/>
+        <property key="fill-flash-options-seq" value=""/>
+        <property key="fill-flash-options-what" value="0"/>
         <property key="general-code-protect" value="no_code_protect"/>
         <property key="general-write-protect" value="no_write_protect"/>
         <property key="generate-cross-reference-file" value="false"/>
         <property key="heap-size" value="256"/>
         <property key="input-libraries" value=""/>
+        <property key="linker-stack" value="true"/>
         <property key="linker-symbols" value=""/>
         <property key="map-file"
                   value="&quot;${DISTDIR}/RollPitchYaw-UDB5.X.${IMAGE_TYPE}.map&quot;"/>
@@ -381,12 +391,92 @@
         <property key="warn-section-align" value="false"/>
       </C30-LD>
       <C30Global>
+        <property key="common-include-directories" value=""/>
+        <property key="dual-boot-partition" value="0"/>
         <property key="fast-math" value="false"/>
         <property key="generic-16-bit" value="false"/>
         <property key="legacy-libc" value="true"/>
         <property key="oXC16glb-macros" value=""/>
         <property key="output-file-format" value="elf"/>
+        <property key="relaxed-math" value="false"/>
+        <property key="save-temps" value="false"/>
       </C30Global>
+      <PICkit3PlatformTool>
+        <property key="ADC 1" value="true"/>
+        <property key="ADC 2" value="true"/>
+        <property key="AutoSelectMemRanges" value="auto"/>
+        <property key="DCI" value="true"/>
+        <property key="Freeze All Other Peripherals" value="true"/>
+        <property key="I2C1" value="true"/>
+        <property key="I2C2" value="true"/>
+        <property key="INPUT CAPTURE 1" value="true"/>
+        <property key="INPUT CAPTURE 2" value="true"/>
+        <property key="INPUT CAPTURE 3" value="true"/>
+        <property key="INPUT CAPTURE 4" value="true"/>
+        <property key="INPUT CAPTURE 5" value="true"/>
+        <property key="INPUT CAPTURE 6" value="true"/>
+        <property key="INPUT CAPTURE 7" value="true"/>
+        <property key="INPUT CAPTURE 8" value="true"/>
+        <property key="OUTPUT COMPARE 1" value="true"/>
+        <property key="OUTPUT COMPARE 2" value="true"/>
+        <property key="OUTPUT COMPARE 3" value="true"/>
+        <property key="OUTPUT COMPARE 4" value="true"/>
+        <property key="OUTPUT COMPARE 5" value="true"/>
+        <property key="OUTPUT COMPARE 6" value="true"/>
+        <property key="OUTPUT COMPARE 7" value="true"/>
+        <property key="OUTPUT COMPARE 8" value="true"/>
+        <property key="SPI 1" value="true"/>
+        <property key="SPI 2" value="true"/>
+        <property key="SecureSegment.SegmentProgramming" value="FullChipProgramming"/>
+        <property key="TIMER1" value="true"/>
+        <property key="TIMER2" value="true"/>
+        <property key="TIMER3" value="true"/>
+        <property key="TIMER4" value="true"/>
+        <property key="TIMER5" value="true"/>
+        <property key="TIMER6" value="true"/>
+        <property key="TIMER7" value="true"/>
+        <property key="TIMER8" value="true"/>
+        <property key="TIMER9" value="true"/>
+        <property key="ToolFirmwareFilePath"
+                  value="Press to browse for a specific firmware version"/>
+        <property key="ToolFirmwareOption.UseLatestFirmware" value="true"/>
+        <property key="UART 1" value="true"/>
+        <property key="UART 2" value="true"/>
+        <property key="hwtoolclock.frcindebug" value="false"/>
+        <property key="memories.aux" value="false"/>
+        <property key="memories.bootflash" value="true"/>
+        <property key="memories.configurationmemory" value="true"/>
+        <property key="memories.configurationmemory2" value="true"/>
+        <property key="memories.dataflash" value="true"/>
+        <property key="memories.eeprom" value="true"/>
+        <property key="memories.flashdata" value="true"/>
+        <property key="memories.id" value="true"/>
+        <property key="memories.programmemory" value="true"/>
+        <property key="memories.programmemory.end" value="0x2abff"/>
+        <property key="memories.programmemory.partition2" value="true"/>
+        <property key="memories.programmemory.partition2.end"
+                  value="${memories.programmemory.partition2.end.value}"/>
+        <property key="memories.programmemory.partition2.start"
+                  value="${memories.programmemory.partition2.start.value}"/>
+        <property key="memories.programmemory.start" value="0x0"/>
+        <property key="poweroptions.powerenable" value="false"/>
+        <property key="programmertogo.imagename" value=""/>
+        <property key="programoptions.donoteraseauxmem" value="false"/>
+        <property key="programoptions.eraseb4program" value="true"/>
+        <property key="programoptions.pgmspeed" value="2"/>
+        <property key="programoptions.preservedataflash" value="false"/>
+        <property key="programoptions.preserveeeprom" value="false"/>
+        <property key="programoptions.preserveprogramrange" value="false"/>
+        <property key="programoptions.preserveprogramrange.end" value="0x2abff"/>
+        <property key="programoptions.preserveprogramrange.start" value="0x0"/>
+        <property key="programoptions.preserveuserid" value="false"/>
+        <property key="programoptions.programcalmem" value="false"/>
+        <property key="programoptions.programuserotp" value="false"/>
+        <property key="programoptions.testmodeentrymethod" value="VDDFirst"/>
+        <property key="programoptions.usehighvoltageonmclr" value="false"/>
+        <property key="programoptions.uselvpprogramming" value="false"/>
+        <property key="voltagevalue" value="3.25"/>
+      </PICkit3PlatformTool>
     </conf>
   </confs>
 </configurationDescriptor>

--- a/Tools/LedTest/LedTest-auav3.X/nbproject/configurations.xml
+++ b/Tools/LedTest/LedTest-auav3.X/nbproject/configurations.xml
@@ -1,27 +1,15 @@
-<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="UTF-8"?>
 <configurationDescriptor version="62">
-  <logicalFolder name="root" displayName="root"
-  projectFiles="true">
-    <logicalFolder name="HeaderFiles" displayName="Header Files"
-    projectFiles="true">      <logicalFolder name="Tools/LedTest/Config" displayName="Tools/LedTest/Config" projectFiles="true">
-        <itemPath>../../../Tools/LedTest/Config/FSconfig.h</itemPath>
-        <itemPath>../../../Tools/LedTest/Config/magnetometerOptions.h</itemPath>
-        <itemPath>../../../Tools/LedTest/Config/nv_memory_options.h</itemPath>
-        <itemPath>../../../Tools/LedTest/Config/options.h</itemPath>
-        <itemPath>../../../Tools/LedTest/Config/osd_config.h</itemPath>
-        <itemPath>../../../Tools/LedTest/Config/ports_config.h</itemPath>
-      </logicalFolder>
-      <logicalFolder name="Tools/LedTest" displayName="Tools/LedTest" projectFiles="true">
-      <logicalFolder name="Config" displayName="Config" projectFiles="true">
-        <itemPath>../../../Tools/LedTest/Config/FSconfig.h</itemPath>
-        <itemPath>../../../Tools/LedTest/Config/magnetometerOptions.h</itemPath>
-        <itemPath>../../../Tools/LedTest/Config/nv_memory_options.h</itemPath>
-        <itemPath>../../../Tools/LedTest/Config/options.h</itemPath>
-        <itemPath>../../../Tools/LedTest/Config/osd_config.h</itemPath>
-        <itemPath>../../../Tools/LedTest/Config/ports_config.h</itemPath>
-      </logicalFolder>
-        <itemPath>../../../Tools/LedTest/nv_memory_options.h</itemPath>
-        <itemPath>../../../Tools/LedTest/options.h</itemPath>
+  <logicalFolder name="root" displayName="root" projectFiles="true">
+    <logicalFolder name="HeaderFiles"
+                   displayName="Header Files"
+                   projectFiles="true">
+      <logicalFolder name="libFlashFS" displayName="libFlashFS" projectFiles="true">
+        <itemPath>../../../libFlashFS/AT45D.h</itemPath>
+        <itemPath>../../../libFlashFS/EEPROM.h</itemPath>
+        <itemPath>../../../libFlashFS/filesys.h</itemPath>
+        <itemPath>../../../libFlashFS/MDD_AT45D.h</itemPath>
+        <itemPath>../../../libFlashFS/MDD_EEPROM.h</itemPath>
       </logicalFolder>
       <logicalFolder name="libUDB" displayName="libUDB" projectFiles="true">
         <itemPath>../../../libUDB/ADchannel.h</itemPath>
@@ -57,56 +45,73 @@
         <itemPath>../../../libUDB/uart.h</itemPath>
         <itemPath>../../../libUDB/udbTypes.h</itemPath>
       </logicalFolder>
-      <logicalFolder name="libFlashFS" displayName="libFlashFS" projectFiles="true">
-        <itemPath>../../../libFlashFS/AT45D.h</itemPath>
-        <itemPath>../../../libFlashFS/EEPROM.h</itemPath>
-        <itemPath>../../../libFlashFS/filesys.h</itemPath>
-        <itemPath>../../../libFlashFS/FSconfig.h</itemPath>
-        <itemPath>../../../libFlashFS/MDD_AT45D.h</itemPath>
-        <itemPath>../../../libFlashFS/MDD_EEPROM.h</itemPath>
-      </logicalFolder>
-      <logicalFolder name="libVectorMatrix" displayName="libVectorMatrix" projectFiles="true">
+      <logicalFolder name="libVectorMatrix"
+                     displayName="libVectorMatrix"
+                     projectFiles="true">
         <itemPath>../../../libVectorMatrix/dspcommon.inc</itemPath>
       </logicalFolder>
       <logicalFolder name="Microchip" displayName="Microchip" projectFiles="true">
+        <logicalFolder name="Include" displayName="Include" projectFiles="true">
+          <logicalFolder name="MDD-File-System"
+                         displayName="MDD-File-System"
+                         projectFiles="true">
+            <itemPath>../../../Microchip/Include/MDD-File-System/FSDefs.h</itemPath>
+            <itemPath>../../../Microchip/Include/MDD-File-System/FSIO.h</itemPath>
+            <itemPath>../../../Microchip/Include/MDD-File-System/SD-SPI.h</itemPath>
+          </logicalFolder>
+          <logicalFolder name="USB" displayName="USB" projectFiles="true">
+            <itemPath>../../../Microchip/Include/USB/usb.h</itemPath>
+            <itemPath>../../../Microchip/Include/USB/usb_ch9.h</itemPath>
+            <itemPath>../../../Microchip/Include/USB/usb_common.h</itemPath>
+            <itemPath>../../../Microchip/Include/USB/usb_device.h</itemPath>
+            <itemPath>../../../Microchip/Include/USB/usb_function_cdc.h</itemPath>
+            <itemPath>../../../Microchip/Include/USB/usb_function_msd.h</itemPath>
+            <itemPath>../../../Microchip/Include/USB/usb_hal.h</itemPath>
+            <itemPath>../../../Microchip/Include/USB/usb_hal_dspic33E.h</itemPath>
+          </logicalFolder>
+          <itemPath>../../../Microchip/Include/Compiler.h</itemPath>
+          <itemPath>../../../Microchip/Include/GenericTypeDefs.h</itemPath>
+        </logicalFolder>
+        <logicalFolder name="USB" displayName="USB" projectFiles="true">
+          <itemPath>../../../Microchip/USB/usb_device_local.h</itemPath>
+        </logicalFolder>
         <itemPath>../../../Microchip/HardwareProfile.h</itemPath>
-      <logicalFolder name="Include" displayName="Include" projectFiles="true">
-        <itemPath>../../../Microchip/Include/Compiler.h</itemPath>
-        <itemPath>../../../Microchip/Include/GenericTypeDefs.h</itemPath>
-      <logicalFolder name="MDD-File-System" displayName="MDD-File-System" projectFiles="true">
-        <itemPath>../../../Microchip/Include/MDD-File-System/FSDefs.h</itemPath>
-        <itemPath>../../../Microchip/Include/MDD-File-System/FSIO.h</itemPath>
-        <itemPath>../../../Microchip/Include/MDD-File-System/SD-SPI.h</itemPath>
-      </logicalFolder>
-      <logicalFolder name="USB" displayName="USB" projectFiles="true">
-        <itemPath>../../../Microchip/Include/USB/usb.h</itemPath>
-        <itemPath>../../../Microchip/Include/USB/usb_ch9.h</itemPath>
-        <itemPath>../../../Microchip/Include/USB/usb_common.h</itemPath>
-        <itemPath>../../../Microchip/Include/USB/usb_device.h</itemPath>
-        <itemPath>../../../Microchip/Include/USB/usb_function_cdc.h</itemPath>
-        <itemPath>../../../Microchip/Include/USB/usb_function_msd.h</itemPath>
-        <itemPath>../../../Microchip/Include/USB/usb_hal.h</itemPath>
-        <itemPath>../../../Microchip/Include/USB/usb_hal_dspic33E.h</itemPath>
-      </logicalFolder>
-      </logicalFolder>
         <itemPath>../../../Microchip/NetConfig.h</itemPath>
         <itemPath>../../../Microchip/Sockets.h</itemPath>
-      <logicalFolder name="USB" displayName="USB" projectFiles="true">
-        <itemPath>../../../Microchip/USB/usb_device_local.h</itemPath>
-      </logicalFolder>
         <itemPath>../../../Microchip/usb_cdc.h</itemPath>
         <itemPath>../../../Microchip/usb_config.h</itemPath>
       </logicalFolder>
-</logicalFolder>
-    <logicalFolder name="LinkerScript" displayName="Linker Files"
-    projectFiles="true"></logicalFolder>
-    <logicalFolder name="SourceFiles" displayName="Source Files"
-    projectFiles="true">      <logicalFolder name="Tools/LedTest" displayName="Tools/LedTest" projectFiles="true">
-        <itemPath>../../../Tools/LedTest/io_test.c</itemPath>
-        <itemPath>../../../Tools/LedTest/io_test_auav3.c</itemPath>
-        <itemPath>../../../Tools/LedTest/io_test_udb4.c</itemPath>
-        <itemPath>../../../Tools/LedTest/io_test_udb5.c</itemPath>
-        <itemPath>../../../Tools/LedTest/main.c</itemPath>
+      <logicalFolder name="Tools/LedTest/Config"
+                     displayName="Tools/LedTest/Config"
+                     projectFiles="true">
+        <itemPath>../../../Tools/LedTest/Config/FSconfig.h</itemPath>
+        <itemPath>../../../Tools/LedTest/Config/magnetometerOptions.h</itemPath>
+        <itemPath>../../../Tools/LedTest/Config/nv_memory_options.h</itemPath>
+        <itemPath>../../../Tools/LedTest/Config/options.h</itemPath>
+        <itemPath>../../../Tools/LedTest/Config/osd_config.h</itemPath>
+        <itemPath>../../../Tools/LedTest/Config/ports_config.h</itemPath>
+      </logicalFolder>
+    </logicalFolder>
+    <logicalFolder name="LinkerScript"
+                   displayName="Linker Files"
+                   projectFiles="true">
+    </logicalFolder>
+    <logicalFolder name="SourceFiles"
+                   displayName="Source Files"
+                   projectFiles="true">
+      <logicalFolder name="libFlashFS" displayName="libFlashFS" projectFiles="true">
+        <itemPath>../../../libFlashFS/AT45D.c</itemPath>
+        <itemPath>../../../libFlashFS/AT45D_DMA.c</itemPath>
+        <itemPath>../../../libFlashFS/AT45D_FS.c</itemPath>
+        <itemPath>../../../libFlashFS/EEPROM.c</itemPath>
+        <itemPath>../../../libFlashFS/EEPROM_FS.c</itemPath>
+        <itemPath>../../../libFlashFS/filesys.c</itemPath>
+        <itemPath>../../../libFlashFS/MDD_AT45D.c</itemPath>
+        <itemPath>../../../libFlashFS/MDD_EEPROM.c</itemPath>
+        <itemPath>../../../libFlashFS/usb.c</itemPath>
+        <itemPath>../../../libFlashFS/usb_cdc.c</itemPath>
+        <itemPath>../../../libFlashFS/usb_descriptors.c</itemPath>
+        <itemPath>../../../libFlashFS/usb_msd.c</itemPath>
       </logicalFolder>
       <logicalFolder name="libUDB" displayName="libUDB" projectFiles="true">
         <itemPath>../../../libUDB/24LC256.c</itemPath>
@@ -141,21 +146,9 @@
         <itemPath>../../../libUDB/uart.c</itemPath>
         <itemPath>../../../libUDB/write.c</itemPath>
       </logicalFolder>
-      <logicalFolder name="libFlashFS" displayName="libFlashFS" projectFiles="true">
-        <itemPath>../../../libFlashFS/AT45D.c</itemPath>
-        <itemPath>../../../libFlashFS/AT45D_DMA.c</itemPath>
-        <itemPath>../../../libFlashFS/AT45D_FS.c</itemPath>
-        <itemPath>../../../libFlashFS/EEPROM.c</itemPath>
-        <itemPath>../../../libFlashFS/EEPROM_FS.c</itemPath>
-        <itemPath>../../../libFlashFS/filesys.c</itemPath>
-        <itemPath>../../../libFlashFS/MDD_AT45D.c</itemPath>
-        <itemPath>../../../libFlashFS/MDD_EEPROM.c</itemPath>
-        <itemPath>../../../libFlashFS/usb.c</itemPath>
-        <itemPath>../../../libFlashFS/usb_cdc.c</itemPath>
-        <itemPath>../../../libFlashFS/usb_descriptors.c</itemPath>
-        <itemPath>../../../libFlashFS/usb_msd.c</itemPath>
-      </logicalFolder>
-      <logicalFolder name="libVectorMatrix" displayName="libVectorMatrix" projectFiles="true">
+      <logicalFolder name="libVectorMatrix"
+                     displayName="libVectorMatrix"
+                     projectFiles="true">
         <itemPath>../../../libVectorMatrix/madd.s</itemPath>
         <itemPath>../../../libVectorMatrix/mmul.s</itemPath>
         <itemPath>../../../libVectorMatrix/mscl.s</itemPath>
@@ -176,24 +169,40 @@
         <itemPath>../../../libVectorMatrix/vzpad.s</itemPath>
       </logicalFolder>
       <logicalFolder name="Microchip" displayName="Microchip" projectFiles="true">
-      <logicalFolder name="MDD-File-System" displayName="MDD-File-System" projectFiles="true">
-        <itemPath>../../../Microchip/MDD-File-System/FSIO.c</itemPath>
-        <itemPath>../../../Microchip/MDD-File-System/SD-SPI.c</itemPath>
+        <logicalFolder name="MDD-File-System"
+                       displayName="MDD-File-System"
+                       projectFiles="true">
+          <itemPath>../../../Microchip/MDD-File-System/FSIO.c</itemPath>
+          <itemPath>../../../Microchip/MDD-File-System/SD-SPI.c</itemPath>
+        </logicalFolder>
+        <logicalFolder name="USB" displayName="USB" projectFiles="true">
+          <logicalFolder name="CDC-Device-Driver"
+                         displayName="CDC-Device-Driver"
+                         projectFiles="true">
+            <itemPath>../../../Microchip/USB/CDC-Device-Driver/usb_function_cdc.c</itemPath>
+          </logicalFolder>
+          <logicalFolder name="MSD-Device-Driver"
+                         displayName="MSD-Device-Driver"
+                         projectFiles="true">
+            <itemPath>../../../Microchip/USB/MSD-Device-Driver/usb_function_msd.c</itemPath>
+          </logicalFolder>
+          <itemPath>../../../Microchip/USB/usb_device.c</itemPath>
+          <itemPath>../../../Microchip/USB/usb_hal_dspic33e.c</itemPath>
+        </logicalFolder>
       </logicalFolder>
-      <logicalFolder name="USB" displayName="USB" projectFiles="true">
-      <logicalFolder name="CDC-Device-Driver" displayName="CDC-Device-Driver" projectFiles="true">
-        <itemPath>../../../Microchip/USB/CDC-Device-Driver/usb_function_cdc.c</itemPath>
+      <logicalFolder name="Tools/LedTest"
+                     displayName="Tools/LedTest"
+                     projectFiles="true">
+        <itemPath>../../../Tools/LedTest/io_test.c</itemPath>
+        <itemPath>../../../Tools/LedTest/io_test_auav3.c</itemPath>
+        <itemPath>../../../Tools/LedTest/io_test_udb4.c</itemPath>
+        <itemPath>../../../Tools/LedTest/io_test_udb5.c</itemPath>
+        <itemPath>../../../Tools/LedTest/main.c</itemPath>
       </logicalFolder>
-      <logicalFolder name="MSD-Device-Driver" displayName="MSD-Device-Driver" projectFiles="true">
-        <itemPath>../../../Microchip/USB/MSD-Device-Driver/usb_function_msd.c</itemPath>
-      </logicalFolder>
-        <itemPath>../../../Microchip/USB/usb_device.c</itemPath>
-        <itemPath>../../../Microchip/USB/usb_hal_dspic33e.c</itemPath>
-      </logicalFolder>
-      </logicalFolder>
-</logicalFolder>
+    </logicalFolder>
     <logicalFolder name="ExternalFiles"
-    displayName="Important Files" projectFiles="false">
+                   displayName="Important Files"
+                   projectFiles="false">
       <itemPath>Makefile</itemPath>
     </logicalFolder>
   </logicalFolder>
@@ -214,149 +223,254 @@
         <targetPluginBoard></targetPluginBoard>
         <platformTool>PICkit3PlatformTool</platformTool>
         <languageToolchain>XC16</languageToolchain>
-        <languageToolchainVersion>1.10</languageToolchainVersion>
-        <platform>3</platform>
+        <languageToolchainVersion>1.26</languageToolchainVersion>
+        <platform>4</platform>
       </toolsSet>
       <compileType>
         <linkerTool>
-          <linkerLibItems></linkerLibItems>
+          <linkerLibItems>
+          </linkerLibItems>
         </linkerTool>
+        <archiverTool>
+        </archiverTool>
         <loading>
-          <useAlternateLoadableFile>
-          false</useAlternateLoadableFile>
+          <useAlternateLoadableFile>false</useAlternateLoadableFile>
+          <parseOnProdLoad>false</parseOnProdLoad>
           <alternateLoadableFile></alternateLoadableFile>
         </loading>
       </compileType>
       <makeCustomizationType>
-        <makeCustomizationPreStepEnabled>
-        false</makeCustomizationPreStepEnabled>
+        <makeCustomizationPreStepEnabled>false</makeCustomizationPreStepEnabled>
         <makeCustomizationPreStep></makeCustomizationPreStep>
-        <makeCustomizationPostStepEnabled>
-        false</makeCustomizationPostStepEnabled>
+        <makeCustomizationPostStepEnabled>false</makeCustomizationPostStepEnabled>
         <makeCustomizationPostStep></makeCustomizationPostStep>
-        <makeCustomizationPutChecksumInUserID>
-        false</makeCustomizationPutChecksumInUserID>
-        <makeCustomizationEnableLongLines>
-        false</makeCustomizationEnableLongLines>
-        <makeCustomizationNormalizeHexFile>
-        false</makeCustomizationNormalizeHexFile>
+        <makeCustomizationPutChecksumInUserID>false</makeCustomizationPutChecksumInUserID>
+        <makeCustomizationEnableLongLines>false</makeCustomizationEnableLongLines>
+        <makeCustomizationNormalizeHexFile>false</makeCustomizationNormalizeHexFile>
       </makeCustomizationType>
       <C30>
-        <property key="code-model" value="large-code" />
-        <property key="const-model" value="default" />
-        <property key="data-model" value="large-data" />
-        <property key="enable-all-warnings" value="true" />
-        <property key="enable-ansi-std" value="false" />
-        <property key="enable-ansi-warnings" value="false" />
-        <property key="enable-fatal-warnings" value="false" />
-        <property key="enable-large-arrays" value="false" />
-        <property key="enable-omit-frame-pointer" value="false" />
-        <property key="enable-procedural-abstraction"
-        value="false" />
-        <property key="enable-short-double" value="false" />
-        <property key="enable-symbols" value="true" />
-        <property key="enable-unroll-loops" value="false" />
+        <property key="code-model" value="large-code"/>
+        <property key="const-model" value="default"/>
+        <property key="data-model" value="large-data"/>
+        <property key="disable-instruction-scheduling" value="false"/>
+        <property key="enable-all-warnings" value="true"/>
+        <property key="enable-ansi-std" value="false"/>
+        <property key="enable-ansi-warnings" value="false"/>
+        <property key="enable-fatal-warnings" value="false"/>
+        <property key="enable-large-arrays" value="false"/>
+        <property key="enable-omit-frame-pointer" value="false"/>
+        <property key="enable-procedural-abstraction" value="false"/>
+        <property key="enable-short-double" value="false"/>
+        <property key="enable-symbols" value="true"/>
+        <property key="enable-unroll-loops" value="false"/>
         <property key="extra-include-directories"
-        value="../../../Tools/LedTest/Config;../../../;../../../Microchip;../../../Microchip/Include;../../../libVectorMatrix" />
-        <property key="isolate-each-function" value="false" />
-        <property key="keep-inline" value="false" />
-        <property key="oXC16gcc-align-arr" value="false" />
-        <property key="oXC16gcc-cnsts-mauxflash" value="false" />
-        <property key="oXC16gcc-data-sects" value="false" />
-        <property key="oXC16gcc-errata" value="" />
-        <property key="oXC16gcc-fillupper" value="" />
-        <property key="oXC16gcc-large-aggregate" value="false" />
-        <property key="oXC16gcc-mauxflash" value="false" />
-        <property key="oXC16gcc-mpa-lvl" value="" />
-        <property key="oXC16gcc-name-text-sec" value="" />
-        <property key="oXC16gcc-near-chars" value="false" />
-        <property key="oXC16gcc-no-isr-warn" value="false" />
-        <property key="oXC16gcc-sfr-warn" value="false" />
-        <property key="oXC16gcc-smar-io-lvl" value="1" />
-        <property key="oXC16gcc-smart-io-fmt" value="" />
-        <property key="optimization-level" value="0" />
-        <property key="post-instruction-scheduling"
-        value="default" />
-        <property key="pre-instruction-scheduling"
-        value="default" />
-        <property key="preprocessor-macros"
-        value="AUAV3" />
-        <property key="scalar-model" value="default" />
-        <property key="use-cci" value="false" />
+                  value="../../../Tools/LedTest/Config;../../../;../../../Microchip;../../../Microchip/Include;../../../libVectorMatrix"/>
+        <property key="isolate-each-function" value="false"/>
+        <property key="keep-inline" value="false"/>
+        <property key="oXC16gcc-align-arr" value="false"/>
+        <property key="oXC16gcc-cnsts-mauxflash" value="false"/>
+        <property key="oXC16gcc-data-sects" value="false"/>
+        <property key="oXC16gcc-errata" value=""/>
+        <property key="oXC16gcc-fillupper" value=""/>
+        <property key="oXC16gcc-large-aggregate" value="false"/>
+        <property key="oXC16gcc-mauxflash" value="false"/>
+        <property key="oXC16gcc-mpa-lvl" value=""/>
+        <property key="oXC16gcc-name-text-sec" value=""/>
+        <property key="oXC16gcc-near-chars" value="false"/>
+        <property key="oXC16gcc-no-isr-warn" value="false"/>
+        <property key="oXC16gcc-sfr-warn" value="false"/>
+        <property key="oXC16gcc-smar-io-lvl" value="1"/>
+        <property key="oXC16gcc-smart-io-fmt" value=""/>
+        <property key="optimization-level" value="0"/>
+        <property key="post-instruction-scheduling" value="default"/>
+        <property key="pre-instruction-scheduling" value="default"/>
+        <property key="preprocessor-macros" value="AUAV3"/>
+        <property key="scalar-model" value="default"/>
+        <property key="use-cci" value="false"/>
+        <property key="use-iar" value="false"/>
       </C30>
+      <C30-AR>
+        <property key="additional-options-chop-files" value="false"/>
+      </C30-AR>
       <C30-AS>
-        <property key="assembler-symbols" value="PSV_ERRATA=1" />
-        <property key="expand-macros" value="false" />
+        <property key="assembler-symbols" value="PSV_ERRATA=1"/>
+        <property key="expand-macros" value="false"/>
         <property key="extra-include-directories-for-assembler"
-        value="../../../libVectorMatrix" />
-        <property key="extra-include-directories-for-preprocessor"
-        value="" />
-        <property key="false-conditionals" value="false" />
-        <property key="keep-locals" value="false" />
-        <property key="list-assembly" value="false" />
-        <property key="list-section-info" value="false" />
-        <property key="list-source" value="false" />
-        <property key="list-symbols" value="false" />
-        <property key="oXC16asm-extra-opts" value="" />
-        <property key="oXC16asm-list-to-file" value="false" />
-        <property key="omit-debug-dirs" value="false" />
-        <property key="omit-forms" value="false" />
-        <property key="preprocessor-macros" value="" />
-        <property key="relax" value="false" />
-        <property key="warning-level" value="emit-warnings" />
-        <appendMe value="-g" />
+                  value="../../../libVectorMatrix"/>
+        <property key="extra-include-directories-for-preprocessor" value=""/>
+        <property key="false-conditionals" value="false"/>
+        <property key="keep-locals" value="false"/>
+        <property key="list-assembly" value="false"/>
+        <property key="list-section-info" value="false"/>
+        <property key="list-source" value="false"/>
+        <property key="list-symbols" value="false"/>
+        <property key="oXC16asm-extra-opts" value=""/>
+        <property key="oXC16asm-list-to-file" value="false"/>
+        <property key="omit-debug-dirs" value="false"/>
+        <property key="omit-forms" value="false"/>
+        <property key="preprocessor-macros" value=""/>
+        <property key="relax" value="false"/>
+        <property key="warning-level" value="emit-warnings"/>
+        <appendMe value="-g"/>
       </C30-AS>
       <C30-LD>
-        <property key="additional-options-use-response-files"
-        value="false" />
-        <property key="boot-eeprom" value="no_eeprom" />
-        <property key="boot-flash" value="no_flash" />
-        <property key="boot-ram" value="no_ram" />
-        <property key="boot-write-protect"
-        value="no_write_protect" />
-        <property key="enable-check-sections" value="false" />
-        <property key="enable-data-init" value="true" />
-        <property key="enable-default-isr" value="true" />
-        <property key="enable-handles" value="true" />
-        <property key="enable-pack-data" value="true" />
-        <property key="extra-lib-directories" value="" />
-        <property key="general-code-protect"
-        value="no_code_protect" />
-        <property key="general-write-protect"
-        value="no_write_protect" />
-        <property key="generate-cross-reference-file"
-        value="false" />
-        <property key="heap-size" value="256" />
-        <property key="input-libraries" value="" />
-        <property key="linker-symbols" value="" />
-        <property key="map-file"
-        value="&quot;${DISTDIR}/LedTest-AUAV3.X.${IMAGE_TYPE}.map&quot;" />
-        <property key="oXC16ld-extra-opts" value="" />
-        <property key="oXC16ld-fill-upper" value="0" />
-        <property key="oXC16ld-force-link" value="false" />
-        <property key="oXC16ld-no-smart-io" value="false" />
-        <property key="oXC16ld-nostdlib" value="false" />
-        <property key="oXC16ld-stackguard" value="16" />
-        <property key="preprocessor-macros" value="" />
-        <property key="remove-unused-sections" value="false" />
-        <property key="report-memory-usage" value="false" />
-        <property key="secure-eeprom" value="no_eeprom" />
-        <property key="secure-flash" value="no_flash" />
-        <property key="secure-ram" value="no_ram" />
-        <property key="secure-write-protect"
-        value="no_write_protect" />
-        <property key="stack-size" value="16" />
-        <property key="symbol-stripping" value="" />
-        <property key="trace-symbols" value="" />
-        <property key="warn-section-align" value="false" />
+        <property key="additional-options-use-response-files" value="false"/>
+        <property key="boot-eeprom" value="no_eeprom"/>
+        <property key="boot-flash" value="no_flash"/>
+        <property key="boot-ram" value="no_ram"/>
+        <property key="boot-write-protect" value="no_write_protect"/>
+        <property key="enable-check-sections" value="false"/>
+        <property key="enable-data-init" value="true"/>
+        <property key="enable-default-isr" value="true"/>
+        <property key="enable-handles" value="true"/>
+        <property key="enable-pack-data" value="true"/>
+        <property key="extra-lib-directories" value=""/>
+        <property key="fill-flash-options-addr" value=""/>
+        <property key="fill-flash-options-const" value=""/>
+        <property key="fill-flash-options-how" value="0"/>
+        <property key="fill-flash-options-inc-const" value="1"/>
+        <property key="fill-flash-options-increment" value=""/>
+        <property key="fill-flash-options-seq" value=""/>
+        <property key="fill-flash-options-what" value="0"/>
+        <property key="general-code-protect" value="no_code_protect"/>
+        <property key="general-write-protect" value="no_write_protect"/>
+        <property key="generate-cross-reference-file" value="false"/>
+        <property key="heap-size" value="256"/>
+        <property key="input-libraries" value=""/>
+        <property key="linker-stack" value="true"/>
+        <property key="linker-symbols" value=""/>
+        <property key="map-file" value="&quot;${DISTDIR}/LedTest-AUAV3.X.${IMAGE_TYPE}.map&quot;"/>
+        <property key="oXC16ld-extra-opts" value=""/>
+        <property key="oXC16ld-fill-upper" value="0"/>
+        <property key="oXC16ld-force-link" value="false"/>
+        <property key="oXC16ld-no-smart-io" value="false"/>
+        <property key="oXC16ld-nostdlib" value="false"/>
+        <property key="oXC16ld-stackguard" value="16"/>
+        <property key="preprocessor-macros" value=""/>
+        <property key="remove-unused-sections" value="false"/>
+        <property key="report-memory-usage" value="false"/>
+        <property key="secure-eeprom" value="no_eeprom"/>
+        <property key="secure-flash" value="no_flash"/>
+        <property key="secure-ram" value="no_ram"/>
+        <property key="secure-write-protect" value="no_write_protect"/>
+        <property key="stack-size" value="16"/>
+        <property key="symbol-stripping" value=""/>
+        <property key="trace-symbols" value=""/>
+        <property key="warn-section-align" value="false"/>
       </C30-LD>
       <C30Global>
-        <property key="fast-math" value="false" />
-        <property key="generic-16-bit" value="false" />
-        <property key="legacy-libc" value="true" />
-        <property key="oXC16glb-macros" value="" />
-        <property key="output-file-format" value="elf" />
+        <property key="common-include-directories" value=""/>
+        <property key="dual-boot-partition" value="0"/>
+        <property key="fast-math" value="false"/>
+        <property key="generic-16-bit" value="false"/>
+        <property key="legacy-libc" value="true"/>
+        <property key="oXC16glb-macros" value=""/>
+        <property key="output-file-format" value="elf"/>
+        <property key="relaxed-math" value="false"/>
+        <property key="save-temps" value="false"/>
       </C30Global>
+      <PICkit3PlatformTool>
+        <property key="ADC 1" value="true"/>
+        <property key="ADC 2" value="true"/>
+        <property key="AutoSelectMemRanges" value="auto"/>
+        <property key="COMPARATOR" value="true"/>
+        <property key="CRC" value="true"/>
+        <property key="DCI" value="true"/>
+        <property key="Freeze All Other Peripherals" value="true"/>
+        <property key="I2C1" value="true"/>
+        <property key="I2C2" value="true"/>
+        <property key="INPUT CAPTURE 1" value="true"/>
+        <property key="INPUT CAPTURE 10" value="true"/>
+        <property key="INPUT CAPTURE 11" value="true"/>
+        <property key="INPUT CAPTURE 12" value="true"/>
+        <property key="INPUT CAPTURE 13" value="true"/>
+        <property key="INPUT CAPTURE 14" value="true"/>
+        <property key="INPUT CAPTURE 15" value="true"/>
+        <property key="INPUT CAPTURE 16" value="true"/>
+        <property key="INPUT CAPTURE 2" value="true"/>
+        <property key="INPUT CAPTURE 3" value="true"/>
+        <property key="INPUT CAPTURE 4" value="true"/>
+        <property key="INPUT CAPTURE 5" value="true"/>
+        <property key="INPUT CAPTURE 6" value="true"/>
+        <property key="INPUT CAPTURE 7" value="true"/>
+        <property key="INPUT CAPTURE 8" value="true"/>
+        <property key="INPUT CAPTURE 9" value="true"/>
+        <property key="OUTPUT COMPARE 1" value="true"/>
+        <property key="OUTPUT COMPARE 10" value="true"/>
+        <property key="OUTPUT COMPARE 11" value="true"/>
+        <property key="OUTPUT COMPARE 12" value="true"/>
+        <property key="OUTPUT COMPARE 13" value="true"/>
+        <property key="OUTPUT COMPARE 14" value="true"/>
+        <property key="OUTPUT COMPARE 15" value="true"/>
+        <property key="OUTPUT COMPARE 16" value="true"/>
+        <property key="OUTPUT COMPARE 2" value="true"/>
+        <property key="OUTPUT COMPARE 3" value="true"/>
+        <property key="OUTPUT COMPARE 4" value="true"/>
+        <property key="OUTPUT COMPARE 5" value="true"/>
+        <property key="OUTPUT COMPARE 6" value="true"/>
+        <property key="OUTPUT COMPARE 7" value="true"/>
+        <property key="OUTPUT COMPARE 8" value="true"/>
+        <property key="OUTPUT COMPARE 9" value="true"/>
+        <property key="PARALLEL MASTER/SLAVE PORT" value="true"/>
+        <property key="PWM" value="true"/>
+        <property key="REAL TIME CLOCK AND CALENDAR" value="true"/>
+        <property key="SPI 1" value="true"/>
+        <property key="SPI 2" value="true"/>
+        <property key="SPI 3" value="true"/>
+        <property key="SPI 4" value="true"/>
+        <property key="SecureSegment.SegmentProgramming" value="FullChipProgramming"/>
+        <property key="TIMER1" value="true"/>
+        <property key="TIMER2" value="true"/>
+        <property key="TIMER3" value="true"/>
+        <property key="TIMER4" value="true"/>
+        <property key="TIMER5" value="true"/>
+        <property key="TIMER6" value="true"/>
+        <property key="TIMER7" value="true"/>
+        <property key="TIMER8" value="true"/>
+        <property key="TIMER9" value="true"/>
+        <property key="ToolFirmwareFilePath"
+                  value="Press to browse for a specific firmware version"/>
+        <property key="ToolFirmwareOption.UseLatestFirmware" value="true"/>
+        <property key="UART 1" value="true"/>
+        <property key="UART 2" value="true"/>
+        <property key="UART 3" value="true"/>
+        <property key="UART 4" value="true"/>
+        <property key="USB" value="true"/>
+        <property key="hwtoolclock.frcindebug" value="false"/>
+        <property key="memories.aux" value="false"/>
+        <property key="memories.bootflash" value="true"/>
+        <property key="memories.configurationmemory" value="true"/>
+        <property key="memories.configurationmemory2" value="true"/>
+        <property key="memories.dataflash" value="true"/>
+        <property key="memories.eeprom" value="true"/>
+        <property key="memories.flashdata" value="true"/>
+        <property key="memories.id" value="true"/>
+        <property key="memories.programmemory" value="true"/>
+        <property key="memories.programmemory.end" value="0x557ff"/>
+        <property key="memories.programmemory.partition2" value="true"/>
+        <property key="memories.programmemory.partition2.end"
+                  value="${memories.programmemory.partition2.end.value}"/>
+        <property key="memories.programmemory.partition2.start"
+                  value="${memories.programmemory.partition2.start.value}"/>
+        <property key="memories.programmemory.start" value="0x0"/>
+        <property key="poweroptions.powerenable" value="false"/>
+        <property key="programmertogo.imagename" value=""/>
+        <property key="programoptions.donoteraseauxmem" value="false"/>
+        <property key="programoptions.eraseb4program" value="true"/>
+        <property key="programoptions.pgmspeed" value="2"/>
+        <property key="programoptions.preservedataflash" value="false"/>
+        <property key="programoptions.preserveeeprom" value="false"/>
+        <property key="programoptions.preserveprogramrange" value="false"/>
+        <property key="programoptions.preserveprogramrange.end" value="0x557ff"/>
+        <property key="programoptions.preserveprogramrange.start" value="0x0"/>
+        <property key="programoptions.preserveuserid" value="false"/>
+        <property key="programoptions.programcalmem" value="false"/>
+        <property key="programoptions.programuserotp" value="false"/>
+        <property key="programoptions.testmodeentrymethod" value="VDDFirst"/>
+        <property key="programoptions.usehighvoltageonmclr" value="false"/>
+        <property key="programoptions.uselvpprogramming" value="false"/>
+        <property key="voltagevalue" value="3.25"/>
+      </PICkit3PlatformTool>
     </conf>
   </confs>
 </configurationDescriptor>

--- a/Tools/LedTest/LedTest-udb4.X/nbproject/configurations.xml
+++ b/Tools/LedTest/LedTest-udb4.X/nbproject/configurations.xml
@@ -8,7 +8,6 @@
         <itemPath>../../../libFlashFS/AT45D.h</itemPath>
         <itemPath>../../../libFlashFS/EEPROM.h</itemPath>
         <itemPath>../../../libFlashFS/filesys.h</itemPath>
-        <itemPath>../../../libFlashFS/FSconfig.h</itemPath>
         <itemPath>../../../libFlashFS/MDD_AT45D.h</itemPath>
         <itemPath>../../../libFlashFS/MDD_EEPROM.h</itemPath>
       </logicalFolder>
@@ -81,14 +80,6 @@
         <itemPath>../../../Microchip/Sockets.h</itemPath>
         <itemPath>../../../Microchip/usb_cdc.h</itemPath>
         <itemPath>../../../Microchip/usb_config.h</itemPath>
-      </logicalFolder>
-      <logicalFolder name="Tools/LedTest"
-                     displayName="Tools/LedTest"
-                     projectFiles="true">
-        <logicalFolder name="Config" displayName="Config" projectFiles="true">
-        </logicalFolder>
-        <itemPath>../../../Tools/LedTest/nv_memory_options.h</itemPath>
-        <itemPath>../../../Tools/LedTest/options.h</itemPath>
       </logicalFolder>
       <logicalFolder name="Tools/LedTest/Config"
                      displayName="Tools/LedTest/Config"
@@ -232,8 +223,8 @@
         <targetPluginBoard></targetPluginBoard>
         <platformTool>PICkit3PlatformTool</platformTool>
         <languageToolchain>XC16</languageToolchain>
-        <languageToolchainVersion>1.10</languageToolchainVersion>
-        <platform>3</platform>
+        <languageToolchainVersion>1.26</languageToolchainVersion>
+        <platform>4</platform>
       </toolsSet>
       <compileType>
         <linkerTool>
@@ -261,6 +252,7 @@
         <property key="code-model" value="large-code"/>
         <property key="const-model" value="default"/>
         <property key="data-model" value="large-data"/>
+        <property key="disable-instruction-scheduling" value="false"/>
         <property key="enable-all-warnings" value="true"/>
         <property key="enable-ansi-std" value="false"/>
         <property key="enable-ansi-warnings" value="false"/>
@@ -295,8 +287,10 @@
         <property key="preprocessor-macros" value="UDB4"/>
         <property key="scalar-model" value="default"/>
         <property key="use-cci" value="false"/>
+        <property key="use-iar" value="false"/>
       </C30>
       <C30-AR>
+        <property key="additional-options-chop-files" value="false"/>
       </C30-AR>
       <C30-AS>
         <property key="assembler-symbols" value="PSV_ERRATA=1"/>
@@ -331,11 +325,19 @@
         <property key="enable-handles" value="true"/>
         <property key="enable-pack-data" value="true"/>
         <property key="extra-lib-directories" value=""/>
+        <property key="fill-flash-options-addr" value=""/>
+        <property key="fill-flash-options-const" value=""/>
+        <property key="fill-flash-options-how" value="0"/>
+        <property key="fill-flash-options-inc-const" value="1"/>
+        <property key="fill-flash-options-increment" value=""/>
+        <property key="fill-flash-options-seq" value=""/>
+        <property key="fill-flash-options-what" value="0"/>
         <property key="general-code-protect" value="no_code_protect"/>
         <property key="general-write-protect" value="no_write_protect"/>
         <property key="generate-cross-reference-file" value="false"/>
         <property key="heap-size" value="256"/>
         <property key="input-libraries" value=""/>
+        <property key="linker-stack" value="true"/>
         <property key="linker-symbols" value=""/>
         <property key="map-file" value="&quot;${DISTDIR}/LedTest-UDB4.X.${IMAGE_TYPE}.map&quot;"/>
         <property key="oXC16ld-extra-opts" value=""/>
@@ -357,13 +359,91 @@
         <property key="warn-section-align" value="false"/>
       </C30-LD>
       <C30Global>
+        <property key="common-include-directories" value=""/>
+        <property key="dual-boot-partition" value="0"/>
         <property key="fast-math" value="false"/>
         <property key="generic-16-bit" value="false"/>
         <property key="legacy-libc" value="true"/>
         <property key="oXC16glb-macros" value=""/>
         <property key="output-file-format" value="elf"/>
+        <property key="relaxed-math" value="false"/>
+        <property key="save-temps" value="false"/>
       </C30Global>
       <PICkit3PlatformTool>
+        <property key="ADC 1" value="true"/>
+        <property key="ADC 2" value="true"/>
+        <property key="AutoSelectMemRanges" value="auto"/>
+        <property key="DCI" value="true"/>
+        <property key="Freeze All Other Peripherals" value="true"/>
+        <property key="I2C1" value="true"/>
+        <property key="I2C2" value="true"/>
+        <property key="INPUT CAPTURE 1" value="true"/>
+        <property key="INPUT CAPTURE 2" value="true"/>
+        <property key="INPUT CAPTURE 3" value="true"/>
+        <property key="INPUT CAPTURE 4" value="true"/>
+        <property key="INPUT CAPTURE 5" value="true"/>
+        <property key="INPUT CAPTURE 6" value="true"/>
+        <property key="INPUT CAPTURE 7" value="true"/>
+        <property key="INPUT CAPTURE 8" value="true"/>
+        <property key="OUTPUT COMPARE 1" value="true"/>
+        <property key="OUTPUT COMPARE 2" value="true"/>
+        <property key="OUTPUT COMPARE 3" value="true"/>
+        <property key="OUTPUT COMPARE 4" value="true"/>
+        <property key="OUTPUT COMPARE 5" value="true"/>
+        <property key="OUTPUT COMPARE 6" value="true"/>
+        <property key="OUTPUT COMPARE 7" value="true"/>
+        <property key="OUTPUT COMPARE 8" value="true"/>
+        <property key="SPI 1" value="true"/>
+        <property key="SPI 2" value="true"/>
+        <property key="SecureSegment.SegmentProgramming" value="FullChipProgramming"/>
+        <property key="TIMER1" value="true"/>
+        <property key="TIMER2" value="true"/>
+        <property key="TIMER3" value="true"/>
+        <property key="TIMER4" value="true"/>
+        <property key="TIMER5" value="true"/>
+        <property key="TIMER6" value="true"/>
+        <property key="TIMER7" value="true"/>
+        <property key="TIMER8" value="true"/>
+        <property key="TIMER9" value="true"/>
+        <property key="ToolFirmwareFilePath"
+                  value="Press to browse for a specific firmware version"/>
+        <property key="ToolFirmwareOption.UseLatestFirmware" value="true"/>
+        <property key="UART 1" value="true"/>
+        <property key="UART 2" value="true"/>
+        <property key="hwtoolclock.frcindebug" value="false"/>
+        <property key="memories.aux" value="false"/>
+        <property key="memories.bootflash" value="true"/>
+        <property key="memories.configurationmemory" value="true"/>
+        <property key="memories.configurationmemory2" value="true"/>
+        <property key="memories.dataflash" value="true"/>
+        <property key="memories.eeprom" value="true"/>
+        <property key="memories.flashdata" value="true"/>
+        <property key="memories.id" value="true"/>
+        <property key="memories.programmemory" value="true"/>
+        <property key="memories.programmemory.end" value="0x2abff"/>
+        <property key="memories.programmemory.partition2" value="true"/>
+        <property key="memories.programmemory.partition2.end"
+                  value="${memories.programmemory.partition2.end.value}"/>
+        <property key="memories.programmemory.partition2.start"
+                  value="${memories.programmemory.partition2.start.value}"/>
+        <property key="memories.programmemory.start" value="0x0"/>
+        <property key="poweroptions.powerenable" value="false"/>
+        <property key="programmertogo.imagename" value=""/>
+        <property key="programoptions.donoteraseauxmem" value="false"/>
+        <property key="programoptions.eraseb4program" value="true"/>
+        <property key="programoptions.pgmspeed" value="2"/>
+        <property key="programoptions.preservedataflash" value="false"/>
+        <property key="programoptions.preserveeeprom" value="false"/>
+        <property key="programoptions.preserveprogramrange" value="false"/>
+        <property key="programoptions.preserveprogramrange.end" value="0x2abff"/>
+        <property key="programoptions.preserveprogramrange.start" value="0x0"/>
+        <property key="programoptions.preserveuserid" value="false"/>
+        <property key="programoptions.programcalmem" value="false"/>
+        <property key="programoptions.programuserotp" value="false"/>
+        <property key="programoptions.testmodeentrymethod" value="VDDFirst"/>
+        <property key="programoptions.usehighvoltageonmclr" value="false"/>
+        <property key="programoptions.uselvpprogramming" value="false"/>
+        <property key="voltagevalue" value="3.25"/>
       </PICkit3PlatformTool>
     </conf>
   </confs>

--- a/Tools/LedTest/LedTest-udb5.X/nbproject/configurations.xml
+++ b/Tools/LedTest/LedTest-udb5.X/nbproject/configurations.xml
@@ -8,7 +8,6 @@
         <itemPath>../../../libFlashFS/AT45D.h</itemPath>
         <itemPath>../../../libFlashFS/EEPROM.h</itemPath>
         <itemPath>../../../libFlashFS/filesys.h</itemPath>
-        <itemPath>../../../libFlashFS/FSconfig.h</itemPath>
         <itemPath>../../../libFlashFS/MDD_AT45D.h</itemPath>
         <itemPath>../../../libFlashFS/MDD_EEPROM.h</itemPath>
       </logicalFolder>
@@ -81,14 +80,6 @@
         <itemPath>../../../Microchip/Sockets.h</itemPath>
         <itemPath>../../../Microchip/usb_cdc.h</itemPath>
         <itemPath>../../../Microchip/usb_config.h</itemPath>
-      </logicalFolder>
-      <logicalFolder name="Tools/LedTest"
-                     displayName="Tools/LedTest"
-                     projectFiles="true">
-        <logicalFolder name="Config" displayName="Config" projectFiles="true">
-        </logicalFolder>
-        <itemPath>../../../Tools/LedTest/nv_memory_options.h</itemPath>
-        <itemPath>../../../Tools/LedTest/options.h</itemPath>
       </logicalFolder>
       <logicalFolder name="Tools/LedTest/Config"
                      displayName="Tools/LedTest/Config"
@@ -232,7 +223,7 @@
         <targetPluginBoard></targetPluginBoard>
         <platformTool>PICkit3PlatformTool</platformTool>
         <languageToolchain>XC16</languageToolchain>
-        <languageToolchainVersion>1.10</languageToolchainVersion>
+        <languageToolchainVersion>1.26</languageToolchainVersion>
         <platform>3</platform>
       </toolsSet>
       <compileType>


### PR DESCRIPTION
for MatrixPilot, RollPitchYaw and LEDTest for UDB4, UDB5, and AUAV3.

XC16 version 1.26 (the latest) is now the default compiler. This removes Extended Data warning for the AUAV3 builds. The new version of 1.26 now warns that some of our clock configuration code is deprecated.