### PR TITLE
AUAV3: Prevent intermittent non-startup of telemetry.

### DIFF
--- a/libUDB/mcu.c
+++ b/libUDB/mcu.c
@@ -59,14 +59,14 @@ _FICD(JTAGEN_OFF &
 #pragma config GSSK = OFF               // General Segment Key bits (General Segment Write Protection and Code Protection is Disabled)
 
 // FOSCSEL
-#pragma config FNOSC = PRIPLL           // Initial Oscillator Source Selection Bits (Primary Oscillator (XT, HS, EC) with PLL)
+#pragma config FNOSC = FRC              // Initial Oscillator Source Selection Bits (Internal Fast RC) )
 #pragma config IESO = OFF               // Two-speed Oscillator Start-up Enable bit (Start up with user-selected oscillator source)
 
 // FOSC
 #pragma config POSCMD = XT              // Primary Oscillator Mode Select bits (XT Crystal Oscillator Mode)
 #pragma config OSCIOFNC = OFF           // OSC2 Pin Function bit (OSC2 is clock output)
 #pragma config IOL1WAY = ON             // Peripheral pin select configuration (Allow only one reconfiguration)
-#pragma config FCKSM = CSDCMD           // Clock Switching Mode bits (Both Clock switching and Fail-safe Clock Monitor are disabled)
+#pragma config FCKSM = CSECMD           // Clock Switching Mode bits ( Clock enabled and Fail-safe Clock Monitor disabled)
 
 // FWDT
 #pragma config WDTPOST = PS32768        // Watchdog Timer Postscaler Bits (1:32,768)


### PR DESCRIPTION
About 1 to 2 times in every 10 times, the telemetry from the AUAV3 to the OpenLog was not starting. Extensive investigations showed that TX interrupt handler was firing and placing chars in the FIFO queue, but a logic analyser showed absolutely no bits were coming from the telemetry UART.

Looking for differences between the AUAV3 and other boards, I noted that the clock of the AUV3 was setup differently when using the XC16 compiler. This non startup fault of the telemetry seems to have only been noticed by myself and Kees who use the MPLAB-X XC16 compiler. The code that sets up the clock for the AUAV3 has different clock settings when using the XC16 compiler. 

I compiled master under the old MPLAB and C30 compiler, under Windows,  and in 50 tests, there were no faults in starting up the telemetry.

So, with Bill's help, I have altered the X16 compiler configuration bits to use the same setup as was being used by the C30 compiler, but using the new #pragma syntax. I compiled that up under MPLAB-X3.3 and XC16 v. 1.26. 

I have tested the startup of the AUAVA3 telemetry for 50 startups, and with this fix applied to current master, there were no faults. So I conclude that with recent changes to master over the last few days, and with this change, the Intermittent problem is solved.

I don't know  how the clocks are possibly effecting the baud rate. If I have time, I'll re-test without this commit, and check that the fault returns. This will then conclusively be the change that creates a solution to the issue.