### PR TITLE
Refactor CRUISE_SPEED to be REFERENCE_SPEED across MatrixPilot.

### DIFF
--- a/Config/options.h
+++ b/Config/options.h
@@ -495,7 +495,7 @@
 // Parameters below are used in the computation of angle of attack and pitch trim.
 // ( INVERTED_NEUTRAL_PITCH is no longer used and should not be used.) -- Note (RobD) yes it is?
 // If these parameters are not defined, angle of attack and pitch trim will be set to zero.
-// CRUISE_SPEED                         The nominal speed in meters per second at which the parameters are defined.
+// REFERENCE_SPEED                      The nominal speed in meters per second at which the parameters are defined.
 // ANGLE_OF_ATTACK_NORMAL               Angle of attack in degrees in the body frame for normal straight and level flight at cruise speed.
 // ANGLE_OF_ATTACK_INVERTED             Angle of attack in degrees in the body frame for inverted straight and level flight at cruise speed.
 // Note: ANGLE_OF_ATTACK_INVERTED is usually negative, with typical values in the -5 to -10 degree range.
@@ -503,8 +503,7 @@
 // ELEVATOR_TRIM_INVERTED               Elevator trim in fractional servo units (-1.0 to 1.0 ) for inverted straight and level flight at cruise speed.
 // Note: ELEVATOR_TRIM_INVERTED is usually negative, with typical values in the -0.5 to -1.0 range.
 
-// The following are the values for HILSIM EasyStar2:
-#define CRUISE_SPEED                      ( 12.0 )
+#define REFERENCE_SPEED                   ( 12.0 )
 #define ANGLE_OF_ATTACK_NORMAL            ( -0.8 )
 #define ANGLE_OF_ATTACK_INVERTED          ( -7.2 )
 #define ELEVATOR_TRIM_NORMAL              ( -0.03 )

--- a/MatrixPilot/config.c
+++ b/MatrixPilot/config.c
@@ -177,7 +177,7 @@ static void load_turns(void)
 	DPRINT("turns.FeedForward = %f\r\n", turns.FeedForward);
 	turns.TurnRateNav = ini_getf(strTurns, "ratenav", TURN_RATE_NAV, strConfigFile);
 	turns.TurnRateFBW = ini_getf(strTurns, "ratefbw", TURN_RATE_FBW, strConfigFile);
-	turns.CruiseSpeed = ini_getf(strTurns, "crsespd", CRUISE_SPEED, strConfigFile);
+	turns.RefSpeed = ini_getf(strTurns, "refspd", REFERENCE_SPEED, strConfigFile);
 	turns.AngleOfAttackNormal = ini_getf(strTurns, "aoanorm", ANGLE_OF_ATTACK_NORMAL, strConfigFile);
 	turns.AngleOfAttackInverted = ini_getf(strTurns, "aoainvt", ANGLE_OF_ATTACK_INVERTED, strConfigFile);
 	turns.ElevatorTrimNormal = ini_getf(strTurns, "elenorm", ELEVATOR_TRIM_NORMAL, strConfigFile);
@@ -295,7 +295,7 @@ static void save_turns(void)
 	ini_putf(strTurns, "feedfwd", turns.FeedForward, strConfigFile);
 	ini_putf(strTurns, "ratenav", turns.TurnRateNav, strConfigFile);
 	ini_putf(strTurns, "ratefbw", turns.TurnRateFBW, strConfigFile);
-	ini_putf(strTurns, "crsespd", turns.CruiseSpeed, strConfigFile);
+	ini_putf(strTurns, "refspd", turns.RefSpeed, strConfigFile);
 	ini_putf(strTurns, "aoanorm", turns.AngleOfAttackNormal, strConfigFile);
 	ini_putf(strTurns, "aoainvt", turns.AngleOfAttackInverted, strConfigFile);
 	ini_putf(strTurns, "elenorm", turns.ElevatorTrimNormal, strConfigFile);

--- a/MatrixPilot/config.h
+++ b/MatrixPilot/config.h
@@ -131,7 +131,7 @@ struct turns_variables {
 	float FeedForward;
 	float TurnRateNav;
 	float TurnRateFBW;
-	float CruiseSpeed;
+	float RefSpeed;
 	float AngleOfAttackNormal;
 	float AngleOfAttackInverted;
 	float ElevatorTrimNormal;

--- a/MatrixPilot/helicalTurnCntrl.c
+++ b/MatrixPilot/helicalTurnCntrl.c
@@ -67,7 +67,7 @@
 #define AOA_INVERTED       ((int16_t)(turns.AngleOfAttackInverted*(RMAX/57.3)))
 #define ELEV_TRIM_NORMAL   ((int16_t)SERVORANGE*turns.ElevatorTrimNormal)
 #define ELEV_TRIM_INVERTED ((int16_t)SERVORANGE*turns.ElevatorTrimInverted)
-#define STALL_SPEED_CM_SEC ((uint16_t)turns.CruiseSpeed*50.0) // assume stall speed approximately 1/2 of cruise speed
+#define STALL_SPEED_CM_SEC ((uint16_t)turns.RefSpeed*50.0) // assume stall speed approximately 1/2 of reference speed
 
 #define AOA_OFFSET           ((int16_t)((AOA_NORMAL + AOA_INVERTED)/2)) // offset is the average of the two values
 #define AOA_SLOPE            ((int16_t)((AOA_NORMAL - AOA_INVERTED) * 4)) // multiply by 4 because base speed is 1/2 of cruise

--- a/MatrixPilot/parameter_table.c
+++ b/MatrixPilot/parameter_table.c
@@ -104,7 +104,7 @@ const mavlink_parameter mavlink_parameters_list[] = {
 
 	{"TURN_ELE_TR_NRM", {.param_float=-1.0}, {.param_float=1.0}, UDB_TYPE_FLOAT, PARAMETER_READWRITE, (void*)&turns.ElevatorTrimNormal, sizeof(turns.ElevatorTrimNormal) },
 	{"TURN_ELE_TR_INV", {.param_float=-1.0}, {.param_float=1.0}, UDB_TYPE_FLOAT, PARAMETER_READWRITE, (void*)&turns.ElevatorTrimInverted, sizeof(turns.ElevatorTrimInverted) },
-	{"TURN_CRUISE_SPD", {.param_float=0.0}, {.param_float=999.0}, UDB_TYPE_FLOAT, PARAMETER_READWRITE, (void*)&turns.CruiseSpeed, sizeof(turns.CruiseSpeed) },
+	{"TURN_CRUISE_SPD", {.param_float=0.0}, {.param_float=999.0}, UDB_TYPE_FLOAT, PARAMETER_READWRITE, (void*)&turns.RefSpeed, sizeof(turns.RefSpeed) },
 	{"TURN_AOA_NORMAL", {.param_float=-90.0}, {.param_float=90.0}, UDB_TYPE_FLOAT, PARAMETER_READWRITE, (void*)&turns.AngleOfAttackNormal, sizeof(turns.AngleOfAttackNormal) },
 	{"TURN_AOA_INV", {.param_float=-90.0}, {.param_float=90.0}, UDB_TYPE_FLOAT, PARAMETER_READWRITE, (void*)&turns.AngleOfAttackInverted, sizeof(turns.AngleOfAttackInverted) },
 	{"TURN_FEED_FWD", {.param_float=0.0}, {.param_float=100.0}, UDB_TYPE_FLOAT, PARAMETER_READWRITE, (void*)&turns.FeedForward, sizeof(turns.FeedForward) },

--- a/MatrixPilot/parameter_table2.c
+++ b/MatrixPilot/parameter_table2.c
@@ -104,7 +104,7 @@ const mavlink_parameter mavlink_parameters_list[] = {
 
 	{"TURN_ELE_TR_NRM", {-1.0}, {1.0}, UDB_TYPE_FLOAT, PARAMETER_READWRITE, (void*)&turns.ElevatorTrimNormal, sizeof(turns.ElevatorTrimNormal) },
 	{"TURN_ELE_TR_INV", {-1.0}, {1.0}, UDB_TYPE_FLOAT, PARAMETER_READWRITE, (void*)&turns.ElevatorTrimInverted, sizeof(turns.ElevatorTrimInverted) },
-	{"TURN_CRUISE_SPD", {0.0}, {999.0}, UDB_TYPE_FLOAT, PARAMETER_READWRITE, (void*)&turns.CruiseSpeed, sizeof(turns.CruiseSpeed) },
+	{"TURN_CRUISE_SPD", {0.0}, {999.0}, UDB_TYPE_FLOAT, PARAMETER_READWRITE, (void*)&turns.RefSpeed, sizeof(turns.RefSpeed) },
 	{"TURN_AOA_NORMAL", {-90.0}, {90.0}, UDB_TYPE_FLOAT, PARAMETER_READWRITE, (void*)&turns.AngleOfAttackNormal, sizeof(turns.AngleOfAttackNormal) },
 	{"TURN_AOA_INV", {-90.0}, {90.0}, UDB_TYPE_FLOAT, PARAMETER_READWRITE, (void*)&turns.AngleOfAttackInverted, sizeof(turns.AngleOfAttackInverted) },
 	{"TURN_FEED_FWD", {0.0}, {100.0}, UDB_TYPE_FLOAT, PARAMETER_READWRITE, (void*)&turns.FeedForward, sizeof(turns.FeedForward) },

--- a/MatrixPilot/telemetry.c
+++ b/MatrixPilot/telemetry.c
@@ -622,7 +622,7 @@ void telemetry_output_8hz(void)
 		case 8:
 			serial_output("F18:AOA_NRM=%5.3f:AOA_INV=%5.3f:EL_TRIM_NRM=%5.3f:EL_TRIM_INV=%5.3f:CRUISE_SPD=%5.3f:\r\n",
 			    turns.AngleOfAttackNormal, turns.AngleOfAttackInverted, turns.ElevatorTrimNormal,
-			    turns.ElevatorTrimInverted, turns.CruiseSpeed);
+			    turns.ElevatorTrimInverted, turns.RefSpeed);
 			break;
 		case 7:
 			serial_output("F19:AIL=%i,%i:ELEV=%i,%i:THROT=%i,%i:RUDD=%i,%i:\r\n",


### PR DESCRIPTION
I would prefer to use REFERENCE_SPEED in options.h as the speed at which the parameters for Angle of Attack and Trim are nominally calculated. "CRUISE_SPEED"  may be confused with some concept of the desired cruise speed. There is a DESIRED_SPEED further up the options.h file, and I want to make the link between this parameter and the Angle of Attack and Trim parameters stronger.