### PR TITLE
Fix linker/loader flag in X16 toolchain makefile

### DIFF
--- a/Tools/makefiles/toolchain-XC16.mk
+++ b/Tools/makefiles/toolchain-XC16.mk
@@ -7,4 +7,4 @@ LIBS     := -legacy-libc
 TARGET_ARCH := -mcpu=$(CPU)
 AFLAGS += -Wa,-g,--defsym=PSV_ERRATA=1
 CFLAGS += -g -omf=elf -legacy-libc -msmart-io=1 -Wall -msfr-warn=off -mlarge-code -mlarge-data
-LFLAGS += -omf=elf -Wl,-script=p$(CPU).gld,--heap=256,--stack=16,--check-sections,--data-init,--pack-data,--handles,--isr,--no-gc-sections,--fill-upper=0,--stackguard=16,--no-force-link,--smart-io,-Map="$(TARGET_MAP)"
+LFLAGS += -omf=elf -Wl,--script=p$(CPU).gld,--heap=256,--stack=16,--check-sections,--data-init,--pack-data,--handles,--isr,--no-gc-sections,--fill-upper=0,--stackguard=16,--no-force-link,--smart-io,-Map="$(TARGET_MAP)"

--- a/build-all.sh
+++ b/build-all.sh
@@ -3,26 +3,32 @@
 mkdir -p build
 cd build
 
+echo
 mkdir -p SIL
 cd SIL
 make -j 8 -f ../../makefile DEVICE=SIL
 cd ..
 
+echo
 mkdir -p AUAV3
 cd AUAV3
 make -j 8 -f ../../makefile DEVICE=AUAV3 TOOLCHAIN=XC16
 cd ..
 
+echo
 mkdir -p UDB5
 cd UDB5
 make -j 8 -f ../../makefile DEVICE=UDB5 TOOLCHAIN=XC16
 cd ..
 
+echo
 mkdir -p UDB4
 cd UDB4
 make -j 8 -f ../../makefile DEVICE=UDB4 TOOLCHAIN=XC16
 cd ..
 
-find | grep *.hex
-
 cd ..
+echo
+echo "The following hex files now exist:-"
+find build | grep hex
+echo


### PR DESCRIPTION
This is a small but significant fix for the X16 compiler options when using the build-all.sh script to generate multiple  hex images for multiple target architectures (UDB4, UDB5, AUAV3 and SIL).

The script was failing to link correctly before this commit.