### PR TITLE
Fix warning from compiler when using HILSIM from Ublox Parser.

### DIFF
--- a/libDCM/gpsParseUBX.c
+++ b/libDCM/gpsParseUBX.c
@@ -625,7 +625,7 @@ static void msg_PL1(uint8_t gpschar)
 					}
 					else
 					{
-						printf("NAV-KEYSTROKE, bad payloadlength %u != %u\r\n", payloadlength.BB, NUM_POINTERS_IN(msg_KEYSTROKE_parse));
+						printf("NAV-KEYSTROKE, bad payloadlength %i != %i\r\n", payloadlength.BB, NUM_POINTERS_IN(msg_KEYSTROKE_parse));
 						msg_parse = &msg_B3;    // error condition
 					}
 					break;


### PR DESCRIPTION
Kees,

This is a fix for #59 .

payloadlength is a signed integer in the[ ublox code file.](https://github.com/MatrixPilot/MatrixPilot/blob/master/libDCM/gpsParseUBX.c#L40)

I had to change [both variables in the printf](https://github.com/MatrixPilot/MatrixPilot/blob/master/libDCM/gpsParseUBX.c#L628) statement to remove the warning.

Best wishes, Pete

