### PR TITLE
Simplify barometer configuration

### DIFF
--- a/Config/options.h
+++ b/Config/options.h
@@ -148,15 +148,9 @@
 // the magnetometerOptions.h file, including declination and magnetometer type.
 #define MAG_YAW_DRIFT                       0
 
-// Define BAROMETER_ALTITUDE to be 1 to use barometer for altitude correction.
+// Define USE_BAROMETER_ALTITUDE to be 1 to use barometer for altitude correction.
 // Otherwise, if set to 0 only the GPS will be used.
-// If you select this option, you also need to correctly set the LAUNCH_ALTITUDE
-// to your takeoff location altitude at the time of initialisation.
-#define BAROMETER_ALTITUDE                  0
-
-// Set your takeoff/launch/initialisation altitude in meters.
-#define LAUNCH_ALTITUDE                     300
-
+#define USE_BAROMETER_ALTITUDE              0
 
 // Racing Mode
 // Setting RACING_MODE to 1 will keep the plane at a set throttle value while in waypoint mode.

--- a/MatrixPilot/console.c
+++ b/MatrixPilot/console.c
@@ -114,11 +114,10 @@ static void cmd_adc(char* arg)
 static void cmd_barom(char* arg)
 {
 #if (SILSIM != 1 && PX4 != 1)
-	printf("Barometer temp %i, pres %u, alt %u, agl %u\r\n",
+	printf("Barometer temp %i, pres %u, alt %u\r\n",
 	       get_barometer_temperature(),
 	       (uint16_t)get_barometer_pressure(),
 	       (uint16_t)get_barometer_altitude(),
-	       (uint16_t)get_barometer_agl_altitude()
 	      );
 #endif
 }

--- a/MatrixPilot/navigate.c
+++ b/MatrixPilot/navigate.c
@@ -122,7 +122,7 @@ void dcm_callback_gps_location_updated(void)
 		// extend this code.
 		state_flags._.save_origin = 0;
 		setup_origin();
-#if (BAROMETER_ALTITUDE == 1)
+#if (USE_BAROMETER_ALTITUDE == 1)
 		altimeter_calibrate();
 #endif
 	}

--- a/libDCM/estAltitude.c
+++ b/libDCM/estAltitude.c
@@ -57,7 +57,7 @@ void altimeter_calibrate(void)
 	DPRINT("altimeter_calibrate: ground temp & pres set %i, %li\r\n", barometer_temperature_gnd, barometer_pressure_gnd);
 }
 
-#if (BAROMETER_ALTITUDE == 1)
+#if (USE_BAROMETER_ALTITUDE == 1)
 void udb_barometer_callback(long pressure, int16_t temperature, char status)
 {
 	barometer_temperature = temperature; // units of 0.1 deg C
@@ -72,7 +72,7 @@ void udb_barometer_callback(long pressure, int16_t temperature, char status)
  */
 void estAltitude(void)
 {
-#if (BAROMETER_ALTITUDE == 1)
+#if (USE_BAROMETER_ALTITUDE == 1)
 	float pressure_ambient = barometer_pressure;    // Pascals?
 	float barometer_alt;
 
@@ -94,11 +94,11 @@ void estAltitude(void)
 #endif
 		}
 	}
-#endif // BAROMETER_ALTITUDE
+#endif // USE_BAROMETER_ALTITUDE
 }
 
 /*  rough-in draft of new algorithm adaption pending verification and revision of barometer data & functions
-#if (BAROMETER_ALTITUDE == 1)
+#if (USE_BAROMETER_ALTITUDE == 1)
 	void udb_barometer_callback(long pressure, int temperature, char status)
 	{
 	#if (USE_PA_PRESSURE == 1)          // **** OPTION TO USE PRESSURE OR HOME POSITION ALTITUDE  in options.h   ****

--- a/libDCM/estLocation.c
+++ b/libDCM/estLocation.c
@@ -23,7 +23,7 @@
 #include "gpsData.h"
 #include "gpsParseCommon.h"
 #include "estLocation.h"
-#include "estAltitude.h"  //USE_PRESSURE_ALT
+#include "estAltitude.h"  //USE_BAROMETER_ALTITUDE
 #include "mathlibNAV.h"
 #include "estWind.h"
 
@@ -33,14 +33,14 @@ static void location_plane(int32_t* location)
 {
 	location[1] = ((lat_gps.WW - lat_origin.WW)/90); // in meters, range is about 20 miles
 	location[0] = long_scale((lon_gps.WW - lon_origin.WW)/90, cos_lat);
-#ifdef USE_PRESSURE_ALT
+#if (USE_BAROMETER_ALTITUDE == 1 ) 
 #warning "using pressure altitude instead of GPS altitude"
 	// division by 100 implies alt_origin is in centimeters; not documented elsewhere
 	// longword result = (longword/10 - longword)/100 : range
 	location[2] = ((get_barometer_altitude()/10) - alt_origin.WW)/100; // height in meters
 #else
 	location[2] = (alt_sl_gps.WW - alt_origin.WW)/100; // height in meters
-#endif // USE_PRESSURE_ALT
+#endif // USE_BAROMETER_ALTITUDE
 
 }
 #else // !USE_EXTENDED_NAV
@@ -52,14 +52,14 @@ static void location_plane(int16_t* location)
 	location[1] = accum_nav._.W0;
 	accum_nav.WW = long_scale((lon_gps.WW - lon_origin.WW)/90, cos_lat);
 	location[0] = accum_nav._.W0;
-#ifdef USE_PRESSURE_ALT
+#if (USE_BAROMETER_ALTITUDE == 1 ) 
 #warning "using pressure altitude instead of GPS altitude"
 	// division by 100 implies alt_origin is in centimeters; not documented elsewhere
 	// longword result = (longword/10 - longword)/100 : range
 	accum_nav.WW = ((get_barometer_altitude()/10) - alt_origin.WW)/100; // height in meters
 #else
 	accum_nav.WW = (alt_sl_gps.WW - alt_origin.WW)/100; // height in meters
-#endif // USE_PRESSURE_ALT
+#endif // USE_BAROMETER_ALTITUDE
 	location[2] = accum_nav._.W0;
 }
 #endif // USE_EXTENDED_NAV

--- a/libDCM/libDCM.c
+++ b/libDCM/libDCM.c
@@ -82,7 +82,7 @@ static boolean gps_run_init_step(uint16_t count)
 	return false;
 }
 
-#if (BAROMETER_ALTITUDE == 1)
+#if (USE_BAROMETER_ALTITUDE == 1)
 
 // We want to be reading both the magnetometer and the barometer at 4Hz
 // The magnetometer driver returns a new result via the callback on each call
@@ -113,12 +113,12 @@ void do_I2C_stuff(void)
 		}
 	}
 }
-#endif // BAROMETER_ALTITUDE
+#endif // USE_BAROMETER_ALTITUDE
 
 // Called at HEARTBEAT_HZ
 void udb_heartbeat_callback(void)
 {
-#if (BAROMETER_ALTITUDE == 1)
+#if (USE_BAROMETER_ALTITUDE == 1)
 	if (udb_heartbeat_counter % (HEARTBEAT_HZ / 40) == 0)
 	{
 		do_I2C_stuff(); // TODO: this should always be be called at 40Hz
@@ -133,7 +133,7 @@ void udb_heartbeat_callback(void)
 		rxMagnetometer(mag_drift_callback);
 	}
 #endif
-#endif // BAROMETER_ALTITUDE
+#endif // USE_BAROMETER_ALTITUDE
 
 //  when we move the IMU step to the MPU call back, to run at 200 Hz, remove this
 	if (dcm_flags._.calib_finished)

--- a/libUDB/barometer.c
+++ b/libUDB/barometer.c
@@ -23,7 +23,7 @@
 #include "I2C.h"
 #include "barometer.h"
 
-#if (BAROMETER_ALTITUDE == 1)
+#if (USE_BAROMETER_ALTITUDE == 1)
 
 #define BMP085_ADDRESS 0xEE  // I2C address of BMP085
 #define USE_BMP085_ON_I2C 2
@@ -274,4 +274,4 @@ void ReadBarPres_callback(boolean I2CtrxOK)
 	}
 }
 
-#endif // BAROMETER_ALTITUDE
+#endif // USE_BAROMETER_ALTITUDE


### PR DESCRIPTION
This aims to make configuring barometer easier. This means that enabling but not using barometric pressure is no longer possible.
rename  BAROMETER_ALTITUDE to USE_BAROMETER_ALTITUDE;
the macro BAROMETER_ALTITUDE might suggest an altitude value is configured, which is not the case
USE_BAROMETER_ALTITUDE makes clear this is a 0/1 setting.
remove #define USE_PRESSURE_ALT because it is not obvious that is should be commented out, not set 0 to inactivate.
also, a commented line would need to be added to indicate how to enable it, we don't like that.
LAUNCH_ALTITUDE is not needed anymore, because it is read from GPS automatically when the calibrations are performed (double waggle)