### PR TITLE
Add desiredHeight to SERIAL_UDB_EXTRA telemetry,

### DIFF
--- a/MatrixPilot/telemetry.c
+++ b/MatrixPilot/telemetry.c
@@ -29,6 +29,7 @@
 #include "cameraCntrl.h"
 #include "flightplan.h"
 #include "flightplan_waypoints.h"
+#include "altitudeCntrl.h"
 #if (USE_TELELOG == 1)
 #include "telemetry_log.h"
 #endif
@@ -751,7 +752,8 @@ void telemetry_output_8hz(void)
 					battery_current._.W1, battery_mAh_used._.W1);
 #else
 					(int16_t)0, (int16_t)0);                    
-#endif                            
+#endif
+					serial_output("DH%i:",desiredHeight);
 #if (RECORD_FREE_STACK_SPACE == 1)
 					extern uint16_t maxstack;
 					serial_output("stk%d:", (int16_t)(4096-maxstack));

--- a/Tools/flight_analyzer/flan.pyw
+++ b/Tools/flight_analyzer/flan.pyw
@@ -2281,7 +2281,7 @@ def write_csv(options,log_book):
     print >> f_csv, "Pitch,Roll,Heading, COG, SOG, CPU, SVS, VDOP, HDOP,",
     print >> f_csv, "Est AirSpd,Est X Wind,Est Y Wind,Est Z Wind,IN1,IN2,IN3,IN4,",
     print >> f_csv, "IN5,IN6,IN7,IN8,OUT1,OUT2,OUT3,OUT4,",
-    print >> f_csv, "OUT5,OUT6,OUT7,OUT8,LEX,LEY,LEZ,IMU X,IMU Y,IMU Z,MAG W,MAG N,MAG Z,",
+    print >> f_csv, "OUT5,OUT6,OUT7,OUT8,LEX,LEY,LEZ,IMU X,IMU Y,IMU Z,Desired Height,MAG W,MAG N,MAG Z,",
     print >> f_csv, "Waypoint X,WaypointY,WaypointZ,IMUvelocityX,IMUvelocityY,IMUvelocityZ,",
     print >> f_csv, "Flags Dec,Flags Hex,Sonar Dst,ALT_SONAR, Aero X, Aero Y, Aero Z, AoI,Wing Load, AoA Pitch,",
     print >> f_csv, "Volts,Amps,mAh"
@@ -2377,7 +2377,7 @@ def write_csv(options,log_book):
               entry.pwm_output[1], "," , entry.pwm_output[2], "," , entry.pwm_output[3], "," , entry.pwm_output[4], "," , \
               entry.pwm_output[5], "," , entry.pwm_output[6], "," , entry.pwm_output[7], "," , entry.pwm_output[8], "," , \
               entry.lex, "," , entry.ley , "," , entry.lez, ",", \
-              entry.IMUlocationx_W1, ",", entry.IMUlocationy_W1, ",", entry.IMUlocationz_W1, "," , \
+              entry.IMUlocationx_W1, ",", entry.IMUlocationy_W1, ",", entry.IMUlocationz_W1, "," , entry.desired_height, ",",\
               int(entry.earth_mag_vec_E), "," , int(entry.earth_mag_vec_N), "," , int(entry.earth_mag_vec_Z), "," , \
               entry.inline_waypoint_x, ",", entry.inline_waypoint_y, ",", entry.inline_waypoint_z, ",", \
               entry.IMUvelocityx, ",", entry.IMUvelocityy, ",", entry.IMUvelocityz, ",", \

--- a/Tools/flight_analyzer/matrixpilot_lib.py
+++ b/Tools/flight_analyzer/matrixpilot_lib.py
@@ -261,6 +261,7 @@ class base_telemetry :
         self.battery_voltage = 0
         self.battery_ampage = 0
         self.battery_amphours = 0
+        self.desired_height = 0
        
 
 class mavlink_telemetry(base_telemetry):
@@ -1254,6 +1255,15 @@ class ascii_telemetry(base_telemetry):
                     self.battery_amphours  = float(match.group(1))
                 except:
                     print "Corrupt battery_amphours value in line", line_no
+                    return "Error"
+            else :
+                pass
+            match = re.match(".*:DH([-0-9]*?):",line) # desiredHeight of plane
+            if match :
+                try:
+                    self.desired_height  = int(match.group(1))
+                except:
+                    print "Corrupt desired_height (DH:) in line", line_no
                     return "Error"
             else :
                 pass


### PR DESCRIPTION
 and add desired height to csv file produced by flight analyzer (flan.pyw).

This feature will allow Leo to display the setpoint of commanded altitude from the throttle channel, on the overlay of his video using Dashware.  I also enclose a sample graph from libreOffice showing the relationship between IMU Z altitude and desiredHeight from a flight today.

![desired_height](https://cloud.githubusercontent.com/assets/542066/18808756/d6911f06-8262-11e6-8c4e-d0cf0043e91d.png)

I am wary of adding data to the SERIAL_UDB_EXTRA F2: format statement, as on older cards, the time to store data on the memory card can allow the OpenLog buffer to overrun (no flow control). So I'm open to suggestions whether we go ahead with this change. It works on my OpenLog at 57600 baud.