### PR TITLE
Fix GPS initialisation when OSD SPI bitbash used with AUAV3 or UDB5,

### DIFF
--- a/MatrixPilot/servoPrepare.c
+++ b/MatrixPilot/servoPrepare.c
@@ -83,7 +83,7 @@ void servoPrepare_init(void) // initialize the PWM
 
 static void flight_controller(void)
 {
-	if (udb_heartbeat_counter % (HEARTBEAT_HZ/40) == 0)
+	if (udb_pulse_counter % (HEARTBEAT_HZ/40) == 0)
 	{
 		flight_mode_switch_2pos_poll(); // we always want this called at 40Hz
 	
@@ -131,14 +131,14 @@ void dcm_heartbeat_callback(void)
 	{
 #if (USE_MAVLINK == 1)
 		// Poll the MAVLink subsystem at 40hz
-		if (udb_heartbeat_counter % (HEARTBEAT_HZ/40) == 0)
+		if (udb_pulse_counter % (HEARTBEAT_HZ/40) == 0)
 		{
 			mavlink_output_40hz();
 		}
 #endif // (USE_MAVLINK == 1)
 #if (SERIAL_OUTPUT_FORMAT != SERIAL_NONE)
 		// Send telemetry updates at 8hz
-		if (udb_heartbeat_counter % (HEARTBEAT_HZ/8) == 0)
+		if (udb_pulse_counter % (HEARTBEAT_HZ/8) == 0)
 		{
 // RobD			flight_state_8hz();
 			telemetry_output_8hz();
@@ -146,16 +146,16 @@ void dcm_heartbeat_callback(void)
 #endif // (SERIAL_OUTPUT_FORMAT != SERIAL_NONE)
 	}
 
-	// Poll the OSD subsystem at 8hz
-	if (udb_heartbeat_counter % (HEARTBEAT_HZ/8) == 0)
+		// Poll the OSD subsystem at 8hz
+	if (udb_pulse_counter % (HEARTBEAT_HZ/8) == 0)
 	{
 #if (USE_OSD == OSD_NATIVE)
-		mp_osd_run_step(udb_heartbeat_counter); // TODO: this was being called at HEARTBEAT_HZ (investigate) - RobD
+		mp_osd_run_step(udb_pulse_counter); // TODO: this was being called at HEARTBEAT_HZ (investigate) - RobD
 #elif (USE_OSD == OSD_REMZIBI)
-void remzibi_osd_8hz(void);
+		void remzibi_osd_8hz(void);
 		remzibi_osd_8hz();
 #elif (USE_OSD == OSD_MINIM)
-void minim_osd_8hz(void);
+		void minim_osd_8hz(void);
 		minim_osd_8hz();
 #endif // USE_OSD
 	}

--- a/MatrixPilot/states.c
+++ b/MatrixPilot/states.c
@@ -146,7 +146,6 @@ void udb_heartbeat_40hz_callback(void)
 {
 	// Determine whether a flight mode switch is commanded.
 	flight_mode_switch_check_set();
-//	if (udb_heartbeat_counter % (HEARTBEAT_HZ/2) == 0)
 	if (counter++ >= 20)    // 2Hz
 	{
 		counter = 0;

--- a/MatrixPilot/telemetry.c
+++ b/MatrixPilot/telemetry.c
@@ -551,7 +551,7 @@ void telemetry_output_8hz(void)
 	// The Ardupilot GroundStation protocol is mostly documented here:
 	//    http://diydrones.com/profiles/blogs/ardupilot-telemetry-protocol
 
-	if (udb_heartbeat_counter % 40 == 0)        // Every 8 runs (5 heartbeat counts per 8Hz)
+	if (udb_pulse_counter % 40 == 0)        // Every 8 runs (5 heartbeat counts per 8Hz)
 	{
 		serial_output("!!!LAT:%li,LON:%li,SPD:%.2f,CRT:%.2f,ALT:%li,ALH:%i,CRS:%.2f,BER:%i,WPN:%i,DST:%i,BTV:%.2f***\r\n"
 		              "+++THH:%i,RLL:%li,PCH:%li,STT:%i,***\r\n",
@@ -561,7 +561,7 @@ void telemetry_output_8hz(void)
 		    (int16_t)((udb_pwOut[THROTTLE_OUTPUT_CHANNEL] - udb_pwTrim[THROTTLE_OUTPUT_CHANNEL])/20),
 		    earth_roll, earth_pitch, mode);
 	}
-	else if (udb_heartbeat_counter % 10 == 0)   // Every 2 runs (5 heartbeat counts per 8Hz)
+	else if (udb_pulse_counter % 10 == 0)   // Every 2 runs (5 heartbeat counts per 8Hz)
 	{
 		serial_output("+++THH:%i,RLL:%li,PCH:%li,STT:%i,***\r\n",
 		    (int16_t)((udb_pwOut[THROTTLE_OUTPUT_CHANNEL] - udb_pwTrim[THROTTLE_OUTPUT_CHANNEL])/20),
@@ -587,7 +587,7 @@ void telemetry_output_8hz(void)
 	static int16_t pwOut_save[NUM_OUTPUTS + 1];
 #elif (SERIAL_OUTPUT_FORMAT == SERIAL_UDB)          // Only run through this function twice per second, by skipping all but every 4 runs through it.
 	// Saves CPU and XBee power.
-	if (udb_heartbeat_counter % 20 != 0) return;    // Every 4 runs (5 heartbeat counts per 8Hz)
+	if (udb_pulse_counter % 20 != 0) return;    // Every 4 runs (5 heartbeat counts per 8Hz)
 #endif // SERIAL_OUTPUT_FORMAT
 	switch (telemetry_counter)
 	{
@@ -852,7 +852,7 @@ void telemetry_output_8hz(void)
 
 void telemetry_output_8hz(void)
 {
-	if (udb_heartbeat_counter % 10 == 0) // Every 2 runs (5 heartbeat counts per 8Hz)
+	if (udb_pulse_counter % 10 == 0) // Every 2 runs (5 heartbeat counts per 8Hz)
 	{
 		serial_output("MagOffset: %i, %i, %i\r\n"
 		              "MagBody: %i, %i, %i\r\n"

--- a/Tools/MatrixPilot-SIL/SIL-udb.c
+++ b/Tools/MatrixPilot-SIL/SIL-udb.c
@@ -84,6 +84,7 @@ inline int gettimeofday(struct timeval* p, void* tz /* IGNORED */)
 #include "SIL-eeprom.h"
 
 uint16_t udb_heartbeat_counter;
+uint16_t udb_pulse_counter;
 
 int16_t udb_pwIn[MAX_INPUTS];   // pulse widths of radio inputs
 int16_t udb_pwTrim[MAX_INPUTS]; // initial pulse widths for trimming
@@ -160,6 +161,7 @@ void udb_init(void)
 //	}
 
 	udb_heartbeat_counter = 0;
+	udb_pulse_counter = 0;
 	udb_flags.B = 0;
 	sil_radio_on = 1;
 
@@ -251,6 +253,7 @@ void udb_run(void)
 			}
 
 			udb_heartbeat_counter++;
+			udb_pulse_counter++;
 			nextHeartbeatTime = nextHeartbeatTime + UDB_STEP_TIME;
 			if (nextHeartbeatTime > UDB_WRAP_TIME) nextHeartbeatTime -= UDB_WRAP_TIME;
 		}

--- a/libDCM/libDCM.c
+++ b/libDCM/libDCM.c
@@ -119,7 +119,7 @@ void do_I2C_stuff(void)
 void udb_heartbeat_callback(void)
 {
 #if (USE_BAROMETER_ALTITUDE == 1)
-	if (udb_heartbeat_counter % (HEARTBEAT_HZ / 40) == 0)
+	if (udb_pulse_counter % (HEARTBEAT_HZ / 40) == 0)
 	{
 		do_I2C_stuff(); // TODO: this should always be be called at 40Hz
 	}
@@ -128,7 +128,7 @@ void udb_heartbeat_callback(void)
 #if (MAG_YAW_DRIFT == 1)
 	// This is a simple counter to do stuff at 4hz
 //	if (udb_heartbeat_counter % 10 == 0)
-	if (udb_heartbeat_counter % (HEARTBEAT_HZ / 4) == 0)
+	if (udb_pulse_counter % (HEARTBEAT_HZ / 4) == 0)
 	{
 		rxMagnetometer(mag_drift_callback);
 	}
@@ -151,15 +151,15 @@ void udb_heartbeat_callback(void)
 //		}
 //	}
 
-	if (udb_heartbeat_counter % (HEARTBEAT_HZ / 40) == 0)
+	if (udb_pulse_counter % (HEARTBEAT_HZ / 40) == 0)
 	{
 		if (!dcm_flags._.calib_finished)
 		{
-			dcm_run_calib_step(udb_heartbeat_counter / (HEARTBEAT_HZ / 40));
+			dcm_run_calib_step(udb_pulse_counter / (HEARTBEAT_HZ / 40));
 		}
 		if (!dcm_flags._.init_finished)
 		{
-			dcm_flags._.init_finished = gps_run_init_step(udb_heartbeat_counter / (HEARTBEAT_HZ / 40));
+			dcm_flags._.init_finished = gps_run_init_step(udb_pulse_counter / (HEARTBEAT_HZ / 40));
 		}
 	}
 

--- a/libUDB/heartbeat.h
+++ b/libUDB/heartbeat.h
@@ -42,6 +42,7 @@
 
 // Read-only value increments with each heartbeat
 extern uint16_t udb_heartbeat_counter;
+extern uint16_t udb_pulse_counter;
 
 
 void heartbeat(void);


### PR DESCRIPTION
Split udb_heartbeat_counter and create udb_pulse_counter for low priority heartbeat.

This is a fix for issue #75 in which activating the OSD with the UDB5 using SPI bit bashing, when using the UDB5, would result in the GPS (EM506 or Ublox) not getting initialised correctly. It is expected that the issue also effected the AUAV3 because they both use a 200HZ Heartbeat, unlike the UDB4 which uses a 40HZ heartbeat.

The root cause was that udb_heartbeat_counter was incremented in a high priority interrupt (heartbeat()), but was being used in a low priority interrupt (heartbeat_pulse). If heartbeat_pulse took more than 1/200th of a second to complete, then udb_heartbeat_counter could get incremented while heartbeat_pulse() was part of the way through processing it's routines. See issue #75 for further details.

I will be flight testing it on the UDB5, with OSI bit bashing enabled, although I won't have the OSD hardware attached. Leo, it would be good if you could do a ground test of the OSD with the OSD hardware attached, and let me know the result. I think we need a full hardware test before approving this commit.

Best wishes, Pete