### PR TITLE
Telemetry.c tidy up

### DIFF
--- a/Config/options.h
+++ b/Config/options.h
@@ -340,8 +340,8 @@
 
 
 ////////////////////////////////////////////////////////////////////////////////
-// Serial Output Format (Can be SERIAL_NONE, SERIAL_DEBUG, SERIAL_ARDUSTATION, SERIAL_UDB,
-// SERIAL_UDB_EXTRA,SERIAL_MAVLINK, SERIAL_CAM_TRACK, SERIAL_OSD_REMZIBI, or SERIAL_UDB_MAG)
+// Serial Output Format (Can be SERIAL_NONE, SERIAL_DEBUG, SERIAL_ARDUSTATION,
+// SERIAL_UDB_EXTRA,SERIAL_MAVLINK, SERIAL_CAM_TRACK, SERIAL_OSD_REMZIBI, SERIAL_MAGNETOMETER)
 // This determines the format of the output sent out the spare serial port.
 // Note that SERIAL_OSD_REMZIBI only works with a ublox GPS.
 // SERIAL_UDB_EXTRA will add additional telemetry fields to those of SERIAL_UDB.
@@ -349,7 +349,7 @@
 // SERIAL_UDB_EXTRA may result in dropped characters if used with the XBEE wireless transmitter.
 // SERIAL_CAM_TRACK is used to output location data to a 2nd UDB, which will target its camera at this plane.
 // SERIAL_MAVLINK is a bi-directional binary format for use with QgroundControl, HKGCS or MAVProxy (Ground Control Stations.)
-// SERIAL_UDB_MAG outputs the automatically calculated offsets and raw magnetometer data.
+// SERIAL_MAGNETOMETER outputs the automatically calculated offsets and raw magnetometer data.
 // Note that SERIAL_MAVLINK defaults to using a baud rate of 57600 baud (other formats default to 19200)
 
 #define SERIAL_OUTPUT_FORMAT                SERIAL_NONE

--- a/MatrixPilot/telemetry.c
+++ b/MatrixPilot/telemetry.c
@@ -52,6 +52,7 @@
 #include "../libDCM/estAltitude.h"
 #include "../libDCM/estWind.h"
 #include "../libDCM/rmat.h"
+#include "../libDCM/mathlibNAV.h"   // Needed for SERIAL_ARDUSTATION
 #include "../libUDB/magnetometer.h" // Needed for SERIAL_MAGNETOMETER 
 #include <string.h>
 

--- a/MatrixPilot/telemetry.c
+++ b/MatrixPilot/telemetry.c
@@ -52,6 +52,7 @@
 #include "../libDCM/estAltitude.h"
 #include "../libDCM/estWind.h"
 #include "../libDCM/rmat.h"
+#include "../libUDB/magnetometer.h" // Needed for SERIAL_MAGNETOMETER 
 #include <string.h>
 
 

--- a/MatrixPilot/telemetry.c
+++ b/MatrixPilot/telemetry.c
@@ -821,12 +821,6 @@ void telemetry_output_8hz(void)
 
 #elif (SERIAL_OUTPUT_FORMAT == SERIAL_MAGNETOMETER)
 
-extern int16_t udb_magFieldBody[3];
-//extern int16_t magFieldEarth[3];
-//extern int16_t udb_magOffset[3];
-extern int16_t magGain[3];
-extern int16_t rawMagCalib[3];
-extern int16_t magMessage;
 
 #define OFFSETSHIFT 1
 
@@ -862,7 +856,8 @@ void telemetry_output_8hz(void)
 		              "Calib: %i, %i, %i\r\n"
 		              "MagMessage: %i\r\n"
 		              "TotalMsg: %i\r\n"
-		              "I2CCON: %X, I2CSTAT: %X, I2ERROR: %X\r\n"
+		              //"I2CCON: %X, I2CSTAT: %X, I2ERROR: %X\r\n" // PDH
+			      "I2CCON: %X, I2CSTAT: %X\r\n"
 		              "\r\n",
 		    udb_magOffset[0]>>OFFSETSHIFT, udb_magOffset[1]>>OFFSETSHIFT, udb_magOffset[2]>>OFFSETSHIFT,
 		    udb_magFieldBody[0], udb_magFieldBody[1], udb_magFieldBody[2],
@@ -871,7 +866,8 @@ void telemetry_output_8hz(void)
 		    rawMagCalib[0], rawMagCalib[1], rawMagCalib[2],
 		    magMessage,
 		    I2messages,
-		    I2CCONREG, I2CSTATREG, I2ERROR);
+		    //I2CCONREG, I2CSTATREG, I2ERROR); // PDH I2ERROR no where to be found.
+		    I2CCONREG, I2CSTATREG);
 	}
 }
 

--- a/libUDB/magnetometer.c
+++ b/libUDB/magnetometer.c
@@ -75,7 +75,8 @@ static uint8_t magreg[6];       // magnetometer read-write buffer
 
 static int16_t mrindex;         // index into the read write buffer 
 static int16_t magCalibPause = 0;
-static int16_t I2messages = 0;
+
+int16_t I2messages = 0;
 
 // forward declarations
 static void I2C_callback(boolean I2CtrxOK);

--- a/libUDB/magnetometer.h
+++ b/libUDB/magnetometer.h
@@ -28,7 +28,7 @@ extern int16_t udb_magOffset[];     // magnetic offset in the body frame of refe
 extern int16_t magGain[];           // magnetometer calibration gains
 extern int16_t rawMagCalib[];
 extern int16_t magFieldRaw[];
-extern int16_t magMessageb;         // message type
+extern int16_t magMessage;          // message type
 
 typedef void (*magnetometer_callback_funcptr)(void);
 

--- a/libUDB/magnetometer.h
+++ b/libUDB/magnetometer.h
@@ -29,6 +29,7 @@ extern int16_t magGain[];           // magnetometer calibration gains
 extern int16_t rawMagCalib[];
 extern int16_t magFieldRaw[];
 extern int16_t magMessage;          // message type
+extern int16_t I2messages;
 
 typedef void (*magnetometer_callback_funcptr)(void);
 


### PR DESCRIPTION
Before starting on SUE over MAVLink, I would like to tidy up telemetry.c, mainly because it is hard to read with so many #if statement to include or exclude code.

I have taken out SERIAL_UDB as I am only aware of people using SERIAL_UDB_EXTRA. 
I have taken out SERIAL_UDB_MAG, as debugging of the magnetometer is usually done with SERIAL_MAGNETOMETER. 

SERIAL_MAGNETOMTER was printing out a variable called I2ERROR. If anyone can point me to where I2ERROR is defined, I would be grateful, as I cannot currently declare it correctly, and so have temporarily commented it out. 

I have some testing to do on this, but thought I would put these ideas past you all, before I go too far, if I need to back off.

Best wishes, Pete