### PR TITLE
RSSI signal, in OSD, will blink when the signal strenght drops below a configurable value

### DIFF
--- a/MatrixPilot/mp_osd.c
+++ b/MatrixPilot/mp_osd.c
@@ -337,6 +337,7 @@ static void osd_update_values_phase_1(void)
 	int8_t dir_to_goal;
 	int16_t dist_to_goal;
 	struct relative2D curHeading;
+    static char f_OSD_RSSI_flash = 0;        // To keep track on show/hide OSD_RSSI
 
 	curHeading.x = -rmat[1];
 	curHeading.y = rmat[4];
@@ -436,8 +437,28 @@ static void osd_update_values_phase_1(void)
 #if (ANALOG_RSSI_INPUT_CHANNEL != CHANNEL_UNUSED)
 
 #if (OSD_LOC_RSSI != OSD_LOC_DISABLED)
-	osd_spi_write_location(OSD_LOC_RSSI);
-	osd_spi_write_number(rc_signal_strength, 3, 0, 0, 0, 0xB3);     // RC Receiver signal strength as 0-100%
+    osd_spi_write_location(OSD_LOC_RSSI);
+#if (OSD_FLASH_RSSI != 0)    
+    if(rc_signal_strength < OSD_FLASH_MIN_RSSI)         // If we has low RC signal strength
+    {
+        if ( f_OSD_RSSI_flash != 0 )                    // If blinking flag is 1
+        {                                               // then shows RSSI
+             osd_spi_write_number(rc_signal_strength, 3, 0, 0, 0, 0xB3);     // RC Receiver signal strength as 0-100%
+            f_OSD_RSSI_flash = 0;                       // Next time RSSI info will be erased
+        }
+        else                                            // else
+        {
+            osd_spi_erase_chars(3);                     // erase RSSI info 
+            f_OSD_RSSI_flash = 1;                       // Next time RSSI info will be showed
+        }
+    }
+    else
+    {
+        osd_spi_write_number(rc_signal_strength, 3, 0, 0, 0, 0xB3);     // RC Receiver signal strength as 0-100%
+    }
+#else
+        osd_spi_write_number(rc_signal_strength, 3, 0, 0, 0, 0xB3);     // RC Receiver signal strength as 0-100%
+#endif 
 #endif
 
 #endif

--- a/MatrixPilot/osd_layout.h
+++ b/MatrixPilot/osd_layout.h
@@ -42,6 +42,9 @@
 #define OSD_FLASH_GPS                   0   // Flash GPS SVS on LOW SVS
 #define OSD_FLASH_MIN_SVS               4   // GPS SVS info will flash for SVS less than this
 
+#define OSD_FLASH_RSSI                  0   // Blink RSSI on LOW RSSI
+#define OSD_FLASH_MIN_RSSI              10  // RSSI info will blink for RSSI less than this percent
+
 // OSD Element Locations
 // Set each one to OSD_LOC_DISABLED or OSD_LOC(row, col) from (0, 0) to (12, 29) for NTSC or up to (15, 29) for PAL.
 


### PR DESCRIPTION
Just a blinking alarm on low RSSI in the native OSD
[Video for the new feature](https://youtu.be/rVJ379R7bZ0)