### PR TITLE
Test of the divider sample_count before calling the __buitin_divsd

### DIFF
--- a/libUDB/analog2digital_udb5.c
+++ b/libUDB/analog2digital_udb5.c
@@ -246,7 +246,8 @@ void __attribute__((__interrupt__,__no_auto_psv__)) _DMA0Interrupt(void)
 
 	// When there is a chance that data will be read soon,
 	// have the new average values ready.
-	if (sample_count > ALMOST_ENOUGH_SAMPLES)
+    //Modif gfm#1 to avoid an eventual divide by zero exception : add test sample_count>0
+	if ((sample_count > ALMOST_ENOUGH_SAMPLES) && (sample_count>0))
 	{
 		udb_vcc.value = __builtin_divsd(udb_vcc.sum, sample_count);
 		udb_5v.value  = __builtin_divsd(udb_5v.sum,  sample_count);


### PR DESCRIPTION
To avoid an eventual divide by zero exception already encountered on
UDB5