### PR TITLE
mathlibNAV.c: Improve rounding in rotate_2D()

### DIFF
--- a/libDCM/mathlibNAV.c
+++ b/libDCM/mathlibNAV.c
@@ -172,9 +172,9 @@ void rotate_2D(struct relative2D* xy, int8_t angle)
 
 	sinang = sine(angle);
 	cosang = cosine(angle);
-	accum.WW = ((__builtin_mulss(cosang, xy->x) - __builtin_mulss(sinang, xy->y)) << 2);
+	accum.WW = ((__builtin_mulss(cosang, xy->x) - __builtin_mulss(sinang, xy->y)) << 2) + 0x00008000;
 	newx = accum._.W1;
-	accum.WW = ((__builtin_mulss(sinang, xy->x) + __builtin_mulss(cosang, xy->y)) << 2);
+	accum.WW = ((__builtin_mulss(sinang, xy->x) + __builtin_mulss(cosang, xy->y)) << 2) + 0x00008000;
 	newy = accum._.W1;
 	xy->x = newx;
 	xy->y = newy;


### PR DESCRIPTION
An improvement to rotate_2D(). The fix ensures that rounding is effectively done between -0.49 to +0.5 rather than from 0,0 to 1.0. So this fix can remove a small bias in some calculations.