### PR TITLE
Fix long_scale() to ensure that bottom 2 bits of return int32_t are n…

### DIFF
--- a/libDCM/mathlibNAV.c
+++ b/libDCM/mathlibNAV.c
@@ -392,11 +392,12 @@ int32_t long_scale(int32_t arg1, int16_t arg2)
 		arg2 = -arg2;
 	}
 	product  = __builtin_muluu(arg2, arg1ww._.W1);
+	product <<= 2;
 	accum.WW = __builtin_muluu(arg2, arg1ww._.W0);
+	accum.WW <<= 2;
 	accum._.W0 = accum._.W1;
 	accum._.W1 = 0;
 	product += accum.WW;
-	product <<= 2;
 	if (sign_result > 0)
 	{
 		return product;


### PR DESCRIPTION
When investigating locationErrorEarth noise in HILSIM I noticed that GPSLocation.X (East to West) only ever increased in increments of 4 meters. For example, we were losing the changes for 1,2,3 meters which showed as zero. I tracked the issue down to a bug in long_scale() which was dropping 2 bits in it's reutrned calculations. long_scale is used in the calculation of Longitude but not for Latitude which is why I saw the issue in GPSLocation.X.

