### PR TITLE
Interrupt priority analysis

### DIFF
--- a/MatrixPilot/MatrixPilot-auav3.X/nbproject/configurations.xml
+++ b/MatrixPilot/MatrixPilot-auav3.X/nbproject/configurations.xml
@@ -6,6 +6,7 @@
                    projectFiles="true">
       <logicalFolder name="Config" displayName="Config" projectFiles="true">
         <logicalFolder name="Cessna" displayName="Cessna" projectFiles="true">
+          <itemPath>../../Config/Cessna/flightplan-waypoints.h</itemPath>
           <itemPath>../../Config/Cessna/options.h</itemPath>
           <itemPath>../../Config/Cessna/options_airspeed.h</itemPath>
           <itemPath>../../Config/Cessna/options_auav3.h</itemPath>
@@ -17,6 +18,15 @@
         </logicalFolder>
         <logicalFolder name="CloudsFly" displayName="CloudsFly" projectFiles="true">
           <itemPath>../../Config/CloudsFly/options.h</itemPath>
+        </logicalFolder>
+        <logicalFolder name="E_Glider" displayName="E_Glider" projectFiles="true">
+          <itemPath>../../Config/E_Glider/options.h</itemPath>
+          <itemPath>../../Config/E_Glider/options_airspeed.h</itemPath>
+        </logicalFolder>
+        <logicalFolder name="Grobularis" displayName="Grobularis" projectFiles="true">
+          <itemPath>../../Config/Grobularis/options.h</itemPath>
+          <itemPath>../../Config/Grobularis/options_airspeed.h</itemPath>
+          <itemPath>../../Config/Grobularis/options_mavlink.h</itemPath>
         </logicalFolder>
         <itemPath>../../Config/flightplan-logo.h</itemPath>
         <itemPath>../../Config/flightplan-waypoints.h</itemPath>
@@ -39,6 +49,7 @@
         <itemPath>../../libDCM/estYawDrift.h</itemPath>
         <itemPath>../../libDCM/gpsData.h</itemPath>
         <itemPath>../../libDCM/gpsParseCommon.h</itemPath>
+        <itemPath>../../libDCM/hilsim.h</itemPath>
         <itemPath>../../libDCM/libDCM.h</itemPath>
         <itemPath>../../libDCM/libDCM_defines.h</itemPath>
         <itemPath>../../libDCM/libDCM_internal.h</itemPath>
@@ -84,6 +95,7 @@
         <itemPath>../../libUDB/radioIn.h</itemPath>
         <itemPath>../../libUDB/serialIO.h</itemPath>
         <itemPath>../../libUDB/servoOut.h</itemPath>
+        <itemPath>../../libUDB/servoOutPins.h</itemPath>
         <itemPath>../../libUDB/sonarIn.h</itemPath>
         <itemPath>../../libUDB/uart.h</itemPath>
         <itemPath>../../libUDB/udbTypes.h</itemPath>

--- a/MatrixPilot/MatrixPilot-udb4.X/nbproject/configurations.xml
+++ b/MatrixPilot/MatrixPilot-udb4.X/nbproject/configurations.xml
@@ -6,6 +6,7 @@
                    projectFiles="true">
       <logicalFolder name="Config" displayName="Config" projectFiles="true">
         <logicalFolder name="Cessna" displayName="Cessna" projectFiles="true">
+          <itemPath>../../Config/Cessna/flightplan-waypoints.h</itemPath>
           <itemPath>../../Config/Cessna/options.h</itemPath>
           <itemPath>../../Config/Cessna/options_airspeed.h</itemPath>
           <itemPath>../../Config/Cessna/options_auav3.h</itemPath>
@@ -17,6 +18,15 @@
         </logicalFolder>
         <logicalFolder name="CloudsFly" displayName="CloudsFly" projectFiles="true">
           <itemPath>../../Config/CloudsFly/options.h</itemPath>
+        </logicalFolder>
+        <logicalFolder name="E_Glider" displayName="E_Glider" projectFiles="true">
+          <itemPath>../../Config/E_Glider/options.h</itemPath>
+          <itemPath>../../Config/E_Glider/options_airspeed.h</itemPath>
+        </logicalFolder>
+        <logicalFolder name="Grobularis" displayName="Grobularis" projectFiles="true">
+          <itemPath>../../Config/Grobularis/options.h</itemPath>
+          <itemPath>../../Config/Grobularis/options_airspeed.h</itemPath>
+          <itemPath>../../Config/Grobularis/options_mavlink.h</itemPath>
         </logicalFolder>
         <itemPath>../../Config/flightplan-logo.h</itemPath>
         <itemPath>../../Config/flightplan-waypoints.h</itemPath>
@@ -39,6 +49,7 @@
         <itemPath>../../libDCM/estYawDrift.h</itemPath>
         <itemPath>../../libDCM/gpsData.h</itemPath>
         <itemPath>../../libDCM/gpsParseCommon.h</itemPath>
+        <itemPath>../../libDCM/hilsim.h</itemPath>
         <itemPath>../../libDCM/libDCM.h</itemPath>
         <itemPath>../../libDCM/libDCM_defines.h</itemPath>
         <itemPath>../../libDCM/libDCM_internal.h</itemPath>
@@ -84,6 +95,7 @@
         <itemPath>../../libUDB/radioIn.h</itemPath>
         <itemPath>../../libUDB/serialIO.h</itemPath>
         <itemPath>../../libUDB/servoOut.h</itemPath>
+        <itemPath>../../libUDB/servoOutPins.h</itemPath>
         <itemPath>../../libUDB/sonarIn.h</itemPath>
         <itemPath>../../libUDB/uart.h</itemPath>
         <itemPath>../../libUDB/udbTypes.h</itemPath>

--- a/MatrixPilot/MatrixPilot-udb5.X/nbproject/configurations.xml
+++ b/MatrixPilot/MatrixPilot-udb5.X/nbproject/configurations.xml
@@ -6,6 +6,7 @@
                    projectFiles="true">
       <logicalFolder name="Config" displayName="Config" projectFiles="true">
         <logicalFolder name="Cessna" displayName="Cessna" projectFiles="true">
+          <itemPath>../../Config/Cessna/flightplan-waypoints.h</itemPath>
           <itemPath>../../Config/Cessna/options.h</itemPath>
           <itemPath>../../Config/Cessna/options_airspeed.h</itemPath>
           <itemPath>../../Config/Cessna/options_auav3.h</itemPath>
@@ -17,6 +18,15 @@
         </logicalFolder>
         <logicalFolder name="CloudsFly" displayName="CloudsFly" projectFiles="true">
           <itemPath>../../Config/CloudsFly/options.h</itemPath>
+        </logicalFolder>
+        <logicalFolder name="E_Glider" displayName="E_Glider" projectFiles="true">
+          <itemPath>../../Config/E_Glider/options.h</itemPath>
+          <itemPath>../../Config/E_Glider/options_airspeed.h</itemPath>
+        </logicalFolder>
+        <logicalFolder name="Grobularis" displayName="Grobularis" projectFiles="true">
+          <itemPath>../../Config/Grobularis/options.h</itemPath>
+          <itemPath>../../Config/Grobularis/options_airspeed.h</itemPath>
+          <itemPath>../../Config/Grobularis/options_mavlink.h</itemPath>
         </logicalFolder>
         <itemPath>../../Config/flightplan-logo.h</itemPath>
         <itemPath>../../Config/flightplan-waypoints.h</itemPath>
@@ -39,6 +49,7 @@
         <itemPath>../../libDCM/estYawDrift.h</itemPath>
         <itemPath>../../libDCM/gpsData.h</itemPath>
         <itemPath>../../libDCM/gpsParseCommon.h</itemPath>
+        <itemPath>../../libDCM/hilsim.h</itemPath>
         <itemPath>../../libDCM/libDCM.h</itemPath>
         <itemPath>../../libDCM/libDCM_defines.h</itemPath>
         <itemPath>../../libDCM/libDCM_internal.h</itemPath>
@@ -84,10 +95,10 @@
         <itemPath>../../libUDB/radioIn.h</itemPath>
         <itemPath>../../libUDB/serialIO.h</itemPath>
         <itemPath>../../libUDB/servoOut.h</itemPath>
+        <itemPath>../../libUDB/servoOutPins.h</itemPath>
         <itemPath>../../libUDB/sonarIn.h</itemPath>
         <itemPath>../../libUDB/uart.h</itemPath>
         <itemPath>../../libUDB/udbTypes.h</itemPath>
-        <itemPath>../../libUDB/servoOutPins.h</itemPath>
       </logicalFolder>
       <logicalFolder name="libVectorMatrix"
                      displayName="libVectorMatrix"
@@ -579,6 +590,8 @@
           <parseOnProdLoad>false</parseOnProdLoad>
           <alternateLoadableFile></alternateLoadableFile>
         </loading>
+        <subordinates>
+        </subordinates>
       </compileType>
       <makeCustomizationType>
         <makeCustomizationPreStepEnabled>false</makeCustomizationPreStepEnabled>
@@ -711,9 +724,6 @@
         <property key="relaxed-math" value="false"/>
         <property key="save-temps" value="false"/>
       </C30Global>
-      <PICkit3PlatformTool>
-        <property key="firmware.download.all" value="false"/>
-      </PICkit3PlatformTool>
     </conf>
   </confs>
 </configurationDescriptor>

--- a/MatrixPilot/MatrixPilot-udb5.X/nbproject/configurations.xml
+++ b/MatrixPilot/MatrixPilot-udb5.X/nbproject/configurations.xml
@@ -87,6 +87,7 @@
         <itemPath>../../libUDB/sonarIn.h</itemPath>
         <itemPath>../../libUDB/uart.h</itemPath>
         <itemPath>../../libUDB/udbTypes.h</itemPath>
+        <itemPath>../../libUDB/servoOutPins.h</itemPath>
       </logicalFolder>
       <logicalFolder name="libVectorMatrix"
                      displayName="libVectorMatrix"
@@ -710,6 +711,9 @@
         <property key="relaxed-math" value="false"/>
         <property key="save-temps" value="false"/>
       </C30Global>
+      <PICkit3PlatformTool>
+        <property key="firmware.download.all" value="false"/>
+      </PICkit3PlatformTool>
     </conf>
   </confs>
 </configurationDescriptor>

--- a/RollPitchYaw/RollPitchYaw-auav3.X/nbproject/configurations.xml
+++ b/RollPitchYaw/RollPitchYaw-auav3.X/nbproject/configurations.xml
@@ -13,6 +13,7 @@
         <itemPath>../../libDCM/estYawDrift.h</itemPath>
         <itemPath>../../libDCM/gpsData.h</itemPath>
         <itemPath>../../libDCM/gpsParseCommon.h</itemPath>
+        <itemPath>../../libDCM/hilsim.h</itemPath>
         <itemPath>../../libDCM/libDCM.h</itemPath>
         <itemPath>../../libDCM/libDCM_defines.h</itemPath>
         <itemPath>../../libDCM/libDCM_internal.h</itemPath>
@@ -51,6 +52,7 @@
         <itemPath>../../libUDB/radioIn.h</itemPath>
         <itemPath>../../libUDB/serialIO.h</itemPath>
         <itemPath>../../libUDB/servoOut.h</itemPath>
+        <itemPath>../../libUDB/servoOutPins.h</itemPath>
         <itemPath>../../libUDB/sonarIn.h</itemPath>
         <itemPath>../../libUDB/uart.h</itemPath>
         <itemPath>../../libUDB/udbTypes.h</itemPath>

--- a/RollPitchYaw/RollPitchYaw-udb4.X/nbproject/configurations.xml
+++ b/RollPitchYaw/RollPitchYaw-udb4.X/nbproject/configurations.xml
@@ -13,6 +13,7 @@
         <itemPath>../../libDCM/estYawDrift.h</itemPath>
         <itemPath>../../libDCM/gpsData.h</itemPath>
         <itemPath>../../libDCM/gpsParseCommon.h</itemPath>
+        <itemPath>../../libDCM/hilsim.h</itemPath>
         <itemPath>../../libDCM/libDCM.h</itemPath>
         <itemPath>../../libDCM/libDCM_defines.h</itemPath>
         <itemPath>../../libDCM/libDCM_internal.h</itemPath>
@@ -51,6 +52,7 @@
         <itemPath>../../libUDB/radioIn.h</itemPath>
         <itemPath>../../libUDB/serialIO.h</itemPath>
         <itemPath>../../libUDB/servoOut.h</itemPath>
+        <itemPath>../../libUDB/servoOutPins.h</itemPath>
         <itemPath>../../libUDB/sonarIn.h</itemPath>
         <itemPath>../../libUDB/uart.h</itemPath>
         <itemPath>../../libUDB/udbTypes.h</itemPath>

--- a/RollPitchYaw/RollPitchYaw-udb5.X/nbproject/configurations.xml
+++ b/RollPitchYaw/RollPitchYaw-udb5.X/nbproject/configurations.xml
@@ -13,6 +13,7 @@
         <itemPath>../../libDCM/estYawDrift.h</itemPath>
         <itemPath>../../libDCM/gpsData.h</itemPath>
         <itemPath>../../libDCM/gpsParseCommon.h</itemPath>
+        <itemPath>../../libDCM/hilsim.h</itemPath>
         <itemPath>../../libDCM/libDCM.h</itemPath>
         <itemPath>../../libDCM/libDCM_defines.h</itemPath>
         <itemPath>../../libDCM/libDCM_internal.h</itemPath>
@@ -51,6 +52,7 @@
         <itemPath>../../libUDB/radioIn.h</itemPath>
         <itemPath>../../libUDB/serialIO.h</itemPath>
         <itemPath>../../libUDB/servoOut.h</itemPath>
+        <itemPath>../../libUDB/servoOutPins.h</itemPath>
         <itemPath>../../libUDB/sonarIn.h</itemPath>
         <itemPath>../../libUDB/uart.h</itemPath>
         <itemPath>../../libUDB/udbTypes.h</itemPath>

--- a/Tools/FlashOSD/FlashOSD-auav3.X/nbproject/configurations.xml
+++ b/Tools/FlashOSD/FlashOSD-auav3.X/nbproject/configurations.xml
@@ -34,6 +34,7 @@
         <itemPath>../../../libUDB/radioIn.h</itemPath>
         <itemPath>../../../libUDB/serialIO.h</itemPath>
         <itemPath>../../../libUDB/servoOut.h</itemPath>
+        <itemPath>../../../libUDB/servoOutPins.h</itemPath>
         <itemPath>../../../libUDB/sonarIn.h</itemPath>
         <itemPath>../../../libUDB/uart.h</itemPath>
         <itemPath>../../../libUDB/udbTypes.h</itemPath>

--- a/Tools/FlashOSD/FlashOSD-udb4.X/nbproject/configurations.xml
+++ b/Tools/FlashOSD/FlashOSD-udb4.X/nbproject/configurations.xml
@@ -34,6 +34,7 @@
         <itemPath>../../../libUDB/radioIn.h</itemPath>
         <itemPath>../../../libUDB/serialIO.h</itemPath>
         <itemPath>../../../libUDB/servoOut.h</itemPath>
+        <itemPath>../../../libUDB/servoOutPins.h</itemPath>
         <itemPath>../../../libUDB/sonarIn.h</itemPath>
         <itemPath>../../../libUDB/uart.h</itemPath>
         <itemPath>../../../libUDB/udbTypes.h</itemPath>

--- a/Tools/FlashOSD/FlashOSD-udb5.X/nbproject/configurations.xml
+++ b/Tools/FlashOSD/FlashOSD-udb5.X/nbproject/configurations.xml
@@ -34,6 +34,7 @@
         <itemPath>../../../libUDB/radioIn.h</itemPath>
         <itemPath>../../../libUDB/serialIO.h</itemPath>
         <itemPath>../../../libUDB/servoOut.h</itemPath>
+        <itemPath>../../../libUDB/servoOutPins.h</itemPath>
         <itemPath>../../../libUDB/sonarIn.h</itemPath>
         <itemPath>../../../libUDB/uart.h</itemPath>
         <itemPath>../../../libUDB/udbTypes.h</itemPath>

--- a/Tools/LedTest/LedTest-auav3.X/nbproject/configurations.xml
+++ b/Tools/LedTest/LedTest-auav3.X/nbproject/configurations.xml
@@ -34,6 +34,7 @@
         <itemPath>../../../libUDB/radioIn.h</itemPath>
         <itemPath>../../../libUDB/serialIO.h</itemPath>
         <itemPath>../../../libUDB/servoOut.h</itemPath>
+        <itemPath>../../../libUDB/servoOutPins.h</itemPath>
         <itemPath>../../../libUDB/sonarIn.h</itemPath>
         <itemPath>../../../libUDB/uart.h</itemPath>
         <itemPath>../../../libUDB/udbTypes.h</itemPath>

--- a/Tools/LedTest/LedTest-udb4.X/nbproject/configurations.xml
+++ b/Tools/LedTest/LedTest-udb4.X/nbproject/configurations.xml
@@ -34,6 +34,7 @@
         <itemPath>../../../libUDB/radioIn.h</itemPath>
         <itemPath>../../../libUDB/serialIO.h</itemPath>
         <itemPath>../../../libUDB/servoOut.h</itemPath>
+        <itemPath>../../../libUDB/servoOutPins.h</itemPath>
         <itemPath>../../../libUDB/sonarIn.h</itemPath>
         <itemPath>../../../libUDB/uart.h</itemPath>
         <itemPath>../../../libUDB/udbTypes.h</itemPath>

--- a/Tools/LedTest/LedTest-udb5.X/nbproject/configurations.xml
+++ b/Tools/LedTest/LedTest-udb5.X/nbproject/configurations.xml
@@ -34,6 +34,7 @@
         <itemPath>../../../libUDB/radioIn.h</itemPath>
         <itemPath>../../../libUDB/serialIO.h</itemPath>
         <itemPath>../../../libUDB/servoOut.h</itemPath>
+        <itemPath>../../../libUDB/servoOutPins.h</itemPath>
         <itemPath>../../../libUDB/sonarIn.h</itemPath>
         <itemPath>../../../libUDB/uart.h</itemPath>
         <itemPath>../../../libUDB/udbTypes.h</itemPath>

--- a/libFlashFS/AT45D_DMA.c
+++ b/libFlashFS/AT45D_DMA.c
@@ -135,16 +135,19 @@ void cfgSpi2Master(void)
 void __attribute__((__interrupt__, __no_auto_psv__)) _DMA2Interrupt(void)
 {
 	indicate_loading_inter;
+	set_ipl_on_output_pin;
 	interrupt_save_set_corcon;
 
 	_DMA2IF = 0;
 
 	interrupt_restore_corcon;
+	unset_ipl_on_output_pin;
 }
 
 void __attribute__((__interrupt__, __no_auto_psv__)) _DMA1Interrupt(void)
 {
 	indicate_loading_inter;
+	set_ipl_on_output_pin;
 	interrupt_save_set_corcon;
 
 	_DMA1IF = 0;
@@ -154,6 +157,7 @@ void __attribute__((__interrupt__, __no_auto_psv__)) _DMA1Interrupt(void)
 	IsBusy = 0;
 
 	interrupt_restore_corcon;
+	unset_ipl_on_output_pin;
 }
 /*
 unsigned char GetRxByte(uint16_t i)

--- a/libUDB/I2C1.c
+++ b/libUDB/I2C1.c
@@ -101,12 +101,14 @@ static void serviceI2C1(void) // service the I2C
 void __attribute__((__interrupt__,__no_auto_psv__)) _MI2C1Interrupt(void)
 {
 	indicate_loading_inter;
+	set_ipl_on_output_pin;
 	interrupt_save_set_corcon;
 	
 	_MI2C1IF = 0;                       // clear the interrupt
 	(*I2C1_state)();                    // execute the service routine
 	
 	interrupt_restore_corcon;
+	unset_ipl_on_output_pin;
 }
 
 // Check if I2C port is available for use.

--- a/libUDB/I2C2.c
+++ b/libUDB/I2C2.c
@@ -162,12 +162,14 @@ static void serviceI2C2(void)   // service the I2C
 void __attribute__((__interrupt__,__no_auto_psv__)) _MI2C2Interrupt(void)
 {
 	indicate_loading_inter;
+	set_ipl_on_output_pin;
 	interrupt_save_set_corcon;
 
 	_MI2C2IF = 0;               // clear the interrupt
 	(*x.state)();               // execute the service routine
 
 	interrupt_restore_corcon;
+	unset_ipl_on_output_pin;
 }
 
 // Check if I2C port is available for use.

--- a/libUDB/analog2digital_auav3.c
+++ b/libUDB/analog2digital_auav3.c
@@ -207,6 +207,7 @@ ALMOST_ENOUGH_SAMPLES = 88
 void __attribute__((__interrupt__, __no_auto_psv__)) _DMA0Interrupt(void)
 {
 	indicate_loading_inter;
+	set_ipl_on_output_pin;
 	interrupt_save_set_corcon;
 
 #if (RECORD_FREE_STACK_SPACE == 1)
@@ -267,6 +268,7 @@ void __attribute__((__interrupt__, __no_auto_psv__)) _DMA0Interrupt(void)
 		}
 	}
 	interrupt_restore_corcon;
+	unset_ipl_on_output_pin;
 }
 
 #endif // BOARD_TYPE

--- a/libUDB/analog2digital_udb4.c
+++ b/libUDB/analog2digital_udb4.c
@@ -234,8 +234,9 @@ void udb_init_ADC(void)
 void __attribute__((__interrupt__,__no_auto_psv__)) _DMA0Interrupt(void)
 {
 	indicate_loading_inter;
+	set_ipl_on_output_pin;
 	interrupt_save_set_corcon;
-
+			
 #if (RECORD_FREE_STACK_SPACE == 1)
 	uint16_t stack = SP_current();
 	if (stack > maxstack)
@@ -347,6 +348,7 @@ void __attribute__((__interrupt__,__no_auto_psv__)) _DMA0Interrupt(void)
 	}
 
 	interrupt_restore_corcon;
+	unset_ipl_on_output_pin;
 }
 
 #endif // BOARD_TYPE

--- a/libUDB/analog2digital_udb5.c
+++ b/libUDB/analog2digital_udb5.c
@@ -173,6 +173,7 @@ void udb_init_ADC(void)
 void __attribute__((__interrupt__,__no_auto_psv__)) _DMA0Interrupt(void)
 {
 	indicate_loading_inter;
+	set_ipl_on_output_pin;
 	interrupt_save_set_corcon;
 
 #if (RECORD_FREE_STACK_SPACE == 1)
@@ -265,6 +266,7 @@ void __attribute__((__interrupt__,__no_auto_psv__)) _DMA0Interrupt(void)
 	}
 
 	interrupt_restore_corcon;
+	unset_ipl_on_output_pin;
 }
 
 #endif // BOARD_TYPE

--- a/libUDB/background.c
+++ b/libUDB/background.c
@@ -159,19 +159,23 @@ void udb_init_irq(void)
 void __attribute__((__interrupt__,__no_auto_psv__)) _T1Interrupt(void)
 {
 	indicate_loading_inter;
+	set_ipl_on_output_pin;
 	interrupt_save_set_corcon;
 	_T1IF = 0;              // clear the interrupt
 	heartbeat();
 	interrupt_restore_corcon;
+	unset_ipl_on_output_pin;
 }
 
 void __attribute__((__interrupt__,__no_auto_psv__)) _T5Interrupt(void)
 {
 	interrupt_save_set_corcon;
+	set_ipl_on_output_pin;
 	TMR5 = 0;               // reset the timer
 	_cpu_timer++;           // increment the load counter
 	_T5IF = 0;              // clear the interrupt
 	interrupt_restore_corcon;
+	unset_ipl_on_output_pin;
 }
 
 static background_callback callback_fptr_1 = NULL;
@@ -181,10 +185,12 @@ static background_callback callback_fptr_1 = NULL;
 void __attribute__((__interrupt__,__no_auto_psv__)) _T6Interrupt(void)
 {
 	indicate_loading_inter;
+	set_ipl_on_output_pin;
 	interrupt_save_set_corcon;
 	_T6IF = 0;              // clear the interrupt
 	if (callback_fptr_1) callback_fptr_1(); // was called pulse() or heartbeat_pulse()
 	interrupt_restore_corcon;
+	unset_ipl_on_output_pin;
 }
 
 // Trigger the low priority background processing interrupt.
@@ -203,11 +209,13 @@ static background_callback callback_fptr_2 = NULL;
 void __attribute__((__interrupt__,__no_auto_psv__)) _T7Interrupt(void)
 {
 	indicate_loading_inter;
+	set_ipl_on_output_pin;
 	interrupt_save_set_corcon;
 	_T7IF = 0;              // clear the interrupt
 	//udb_background_callback_triggered(); // replaced by function pointer callback below
 	if (callback_fptr_2) callback_fptr_2();
 	interrupt_restore_corcon;
+	unset_ipl_on_output_pin;
 }
 
 // Trigger the low priority background processing interrupt.

--- a/libUDB/events.c
+++ b/libUDB/events.c
@@ -109,6 +109,7 @@ void __attribute__((__interrupt__, __no_auto_psv__)) _EVENTL_INTERUPT(void)
 {
 	_EVENTL_TRIGGERIF = 0;      // clear the interrupt
 	indicate_loading_inter;
+	set_ipl_on_output_pin;
 	interrupt_save_set_corcon;
 
 	int16_t eventIndex;
@@ -130,12 +131,14 @@ void __attribute__((__interrupt__, __no_auto_psv__)) _EVENTL_INTERUPT(void)
 		}
 	}
 	interrupt_restore_corcon;
+	unset_ipl_on_output_pin;
 }
 
 void __attribute__((__interrupt__, __no_auto_psv__)) _EVENTM_INTERUPT(void)
 {
 	_EVENTM_TRIGGERIF = 0;      // clear the interrupt
 	indicate_loading_inter;
+	set_ipl_on_output_pin;
 	interrupt_save_set_corcon;
 
 	int16_t eventIndex;
@@ -157,5 +160,6 @@ void __attribute__((__interrupt__, __no_auto_psv__)) _EVENTM_INTERUPT(void)
 		}
 	}
 	interrupt_restore_corcon;
+	unset_ipl_on_output_pin;
 }
 

--- a/libUDB/interrupt.h
+++ b/libUDB/interrupt.h
@@ -19,7 +19,7 @@
 // along with MatrixPilot.  If not, see <http://www.gnu.org/licenses/>.
 
 
-////////////////////////////////////////////////////////////////////////////////
+//////////////////////////////////////////////////////////////////////////////// 
 // Optionally enable the new power saving idle mode of the MCU during mainloop
 #define USE_MCU_IDLE    0
 
@@ -65,18 +65,86 @@ uint16_t SP_start(void);
 uint16_t SP_limit(void);
 uint16_t SP_current(void);
 
+#define TEST_INTERRUPT_PRIORITY_TIMINGS    0
+#if (TEST_INTERRUPT_PRIORITY_TIMINGS == 1)
+// Set Interrupt Priority on associated Output Pin for timing analysis with Logic Analyzer
+// Servos should be disconnected from OUTPUT pins when using this feature
+#include "servoOutPins.h"
+#define set_ipl_on_output_pin			\
+	{					\
+		switch(SRbits.IPL)		\
+		{				\
+		    case 1:			\
+			   SERVO_OUT_PIN_1 = 1;	\
+			   break;		\
+		    case 2:			\
+			   SERVO_OUT_PIN_2 = 1;	\
+			   break;		\
+		    case 3:			\
+			   SERVO_OUT_PIN_3 = 1;	\
+			   break;		\
+		    case 4:			\
+			   SERVO_OUT_PIN_4 = 1;	\
+			   break;		\
+		    case 5:			\
+			   SERVO_OUT_PIN_5 = 1;	\
+			   break;		\
+		    case 6:			\
+			   SERVO_OUT_PIN_6 = 1;	\
+			   break;		\
+		    case 7:			\
+			   SERVO_OUT_PIN_7 = 1;	\
+			   break;		\
+		}				\
+	}
+
+#define unset_ipl_on_output_pin                 \
+	{                                       \
+		switch(SRbits.IPL)              \
+		{                               \
+		    case 1:                     \
+			   SERVO_OUT_PIN_1 = 0; \
+			   break;               \
+		    case 2:                     \
+			   SERVO_OUT_PIN_2 = 0; \
+			   break;               \
+		    case 3:                     \
+			   SERVO_OUT_PIN_3 = 0; \
+			   break;               \
+		    case 4:                     \
+			   SERVO_OUT_PIN_4 = 0; \
+			   break;               \
+		    case 5:                     \
+			   SERVO_OUT_PIN_5 = 0; \
+			   break;               \
+		    case 6:                     \
+			   SERVO_OUT_PIN_6 = 0; \
+			   break;               \
+		    case 7:                     \
+			   SERVO_OUT_PIN_7 = 0; \
+			   break;               \
+		}                               \
+	}
+#else
+
+#define set_ipl_on_output_pin	    \
+
+#define unset_ipl_on_output_pin	    \
+
+#endif 
+
 #if (USE_MCU_IDLE == 1)
 #define indicate_loading_inter {}
 #define indicate_loading_main  {}
 #else
-#define indicate_loading_inter \
-	{ \
-		T5CONbits.TON = 1; \
+#define indicate_loading_inter			\
+	{					\
+		T5CONbits.TON = 1;		\
 	}
 
-#define indicate_loading_main \
-	{ \
-		T5CONbits.TON = 0; \
+#define indicate_loading_main			\
+	{					\
+		T5CONbits.TON = 0;		\
 	}
 #endif // USE_MCU_IDLE
 

--- a/libUDB/mpu_spi.c
+++ b/libUDB/mpu_spi.c
@@ -193,6 +193,7 @@ void __attribute__((__interrupt__, __no_auto_psv__)) SPIInterrupt(void)
 
 	_SPIIF = 0;                 // clear interrupt flag as soon as possible so as to not miss any interrupts
 	indicate_loading_inter;
+	set_ipl_on_output_pin;
 	interrupt_save_set_corcon;
 	_SPIIE = 0;                 // turn off SPI interrupts
 	spibuf = SPIBUF;            // get first byte from first word
@@ -207,6 +208,7 @@ void __attribute__((__interrupt__, __no_auto_psv__)) SPIInterrupt(void)
 	MPU_SS = 1;
 	(*mpu_call_back)();
 	interrupt_restore_corcon;
+	unset_ipl_on_output_pin;
 }
 
 #else // no SPI FIFO
@@ -234,6 +236,7 @@ void __attribute__((__interrupt__, __no_auto_psv__)) SPIInterrupt(void)
 
 	_SPIIF = 0;                 // clear interrupt flag as soon as possible so as to not miss any interrupts
 	indicate_loading_inter;
+	set_ipl_on_output_pin;
 	interrupt_save_set_corcon;
 #if 1
 	if (SPI_i == 0) {
@@ -275,6 +278,7 @@ void __attribute__((__interrupt__, __no_auto_psv__)) SPIInterrupt(void)
 	SPI_high = 0xFF & spibuf;
 #endif // 0
 	interrupt_restore_corcon;
+	unset_ipl_on_output_pin;
 }
 
 #endif // (__dsPIC33E__)

--- a/libUDB/radioIn.c
+++ b/libUDB/radioIn.c
@@ -231,6 +231,7 @@ static void set_udb_pwIn(int pwm, int index)
 void __attribute__((__interrupt__,__no_auto_psv__)) _IC##x##Interrupt(void) \
 { \
 	indicate_loading_inter; \
+	set_ipl_on_output_pin; \
 	interrupt_save_set_corcon; \
 	static uint16_t rise = 0; \
 	uint16_t time = 0; \
@@ -242,6 +243,7 @@ void __attribute__((__interrupt__,__no_auto_psv__)) _IC##x##Interrupt(void) \
 	else \
 		set_udb_pwIn(time - rise, x); \
 	interrupt_restore_corcon; \
+	unset_ipl_on_output_pin; \
 }
 #define IC_HANDLER(x, y, z) _IC_HANDLER(x, y, z)
 
@@ -315,6 +317,7 @@ IC_TIME(PPM_IC, REGTOK1);
 void __attribute__((__interrupt__,__no_auto_psv__)) IC_INTERRUPT(PPM_IC)
 {
 	indicate_loading_inter;
+	set_ipl_on_output_pin;
 	interrupt_save_set_corcon;
 
 	static uint16_t rise_ppm = 0;
@@ -371,6 +374,7 @@ void __attribute__((__interrupt__,__no_auto_psv__)) IC_INTERRUPT(PPM_IC)
 #error Invalid USE_PPM_INPUT setting
 #endif // USE_PPM_INPUT
 	interrupt_restore_corcon;
+	unset_ipl_on_output_pin;
 }
 
 #endif // USE_PPM_INPUT

--- a/libUDB/serialIO.c
+++ b/libUDB/serialIO.c
@@ -110,6 +110,7 @@ void __attribute__((__interrupt__,__no_auto_psv__)) _U1TXInterrupt(void)
 {
 	_U1TXIF = 0; // clear the interrupt
 	indicate_loading_inter;
+	set_ipl_on_output_pin;
 	interrupt_save_set_corcon;
 
 	int16_t txchar = -1;
@@ -125,12 +126,14 @@ void __attribute__((__interrupt__,__no_auto_psv__)) _U1TXInterrupt(void)
 		U1TXREG = (uint8_t)txchar;
 	}
 	interrupt_restore_corcon;
+	unset_ipl_on_output_pin;
 }
 
 void __attribute__((__interrupt__, __no_auto_psv__)) _U1RXInterrupt(void)
 {
 	_U1RXIF = 0; // clear the interrupt
 	indicate_loading_inter;
+	set_ipl_on_output_pin;
 	interrupt_save_set_corcon;
 	
 	while (U1STAbits.URXDA)
@@ -146,6 +149,7 @@ void __attribute__((__interrupt__, __no_auto_psv__)) _U1RXInterrupt(void)
 	}
 	U1STAbits.OERR = 0;
 	interrupt_restore_corcon;
+	unset_ipl_on_output_pin;
 }
 
 
@@ -224,6 +228,7 @@ void __attribute__((__interrupt__, __no_auto_psv__)) _U2TXInterrupt(void)
 {
 	_U2TXIF = 0; // clear the interrupt
 	indicate_loading_inter;
+	set_ipl_on_output_pin;
 	interrupt_save_set_corcon;
 
 //	int16_t txchar = udb_serial_callback_get_byte_to_send();
@@ -237,12 +242,14 @@ void __attribute__((__interrupt__, __no_auto_psv__)) _U2TXInterrupt(void)
 		U2TXREG = (uint8_t)txchar;
 	}
 	interrupt_restore_corcon;
+	unset_ipl_on_output_pin;
 }
 
 void __attribute__((__interrupt__, __no_auto_psv__)) _U2RXInterrupt(void)
 {
 	_U2RXIF = 0; // clear the interrupt
 	indicate_loading_inter;
+	set_ipl_on_output_pin;
 	interrupt_save_set_corcon;
 
 	while (U2STAbits.URXDA)
@@ -256,4 +263,5 @@ void __attribute__((__interrupt__, __no_auto_psv__)) _U2RXInterrupt(void)
 	}
 	U2STAbits.OERR = 0;
 	interrupt_restore_corcon;
+	unset_ipl_on_output_pin;
 }

--- a/libUDB/servoOutPins.h
+++ b/libUDB/servoOutPins.h
@@ -1,0 +1,48 @@
+/* 
+ * File:   servoOutPins.h
+ * Author: phollands
+ *
+ * Created on 08 February 2017, 11:41
+ */
+
+#ifndef SERVOOUTPINS_H
+#define	SERVOOUTPINS_H
+
+#if (BOARD_TYPE == UDB4_BOARD || BOARD_TYPE == UDB5_BOARD)
+
+#define SERVO_OUT_PIN_1         _LATD0
+#define SERVO_OUT_PIN_2         _LATD1
+#define SERVO_OUT_PIN_3         _LATD2
+#define SERVO_OUT_PIN_4         _LATD3
+#define SERVO_OUT_PIN_5         _LATD4
+#define SERVO_OUT_PIN_6         _LATD5
+#define SERVO_OUT_PIN_7         _LATD6
+#define SERVO_OUT_PIN_8         _LATD7
+#define SERVO_OUT_PIN_9         _LATA4
+#define SERVO_OUT_PIN_10        _LATA1
+#define ACTION_OUT_PIN          SERVO_OUT_PIN_9
+
+#elif (BOARD_TYPE == AUAV3_BOARD)
+
+#define SERVO_OUT_PIN_1         _LATG0
+#define SERVO_OUT_PIN_2         _LATE0
+#define SERVO_OUT_PIN_3         _LATG13
+#define SERVO_OUT_PIN_4         _LATD7
+#define SERVO_OUT_PIN_5         _LATG14
+#define SERVO_OUT_PIN_6         _LATG1
+#define SERVO_OUT_PIN_7         _LATF13
+#define SERVO_OUT_PIN_8         _LATF12
+#define SERVO_OUT_PIN_9         _LATF12
+#define SERVO_OUT_PIN_10        _LATF12
+#define ACTION_OUT_PIN          SERVO_OUT_PIN_8
+
+#if (NUM_OUTPUTS > 8)
+#error "max of 8 servo outputs currently supported for AUAV3"
+#endif
+
+#else
+#error Invalid BOARD_TYPE
+#endif
+
+#endif	/* SERVOOUTPINS_H */
+

--- a/libUDB/sonarIn.c
+++ b/libUDB/sonarIn.c
@@ -85,6 +85,7 @@ void udb_init_sonar(void)
 void __attribute__((__interrupt__,__no_auto_psv__)) _IC##x##Interrupt(void) \
 { \
 	indicate_loading_inter; \
+	set_ipl_on_output_pin; \
 	interrupt_save_set_corcon; \
 	uint16_t time; \
 	_IC##x##IF = 0; \
@@ -103,6 +104,7 @@ void __attribute__((__interrupt__,__no_auto_psv__)) _IC##x##Interrupt(void) \
 		udb_flags._.sonar_updated = 1; \
 	} \
 	interrupt_restore_corcon; \
+	unset_ipl_on_output_pin;  \
 }
 #define SONAR_HANDLER(x, y) _SONAR_HANDLER(x, y)
 


### PR DESCRIPTION
For many years, I've wanted to be able to see the millisecond level interaction of the various interrupt routines in MatrixPilot. This block of code has let me view the interactions between interrupts in much greater detail.  I enclose  example screenshots below using the Salae Logic Analyser.

The first screenshot shows a 1 second overview. The GPS data is arriving at 4HZ (HILSIM UDB4). 
![screen shot 2017-01-12 at 13 15 38](https://cloud.githubusercontent.com/assets/542066/22737736/4a610996-edfc-11e6-9d67-5a440aa81faa.png)

In the second screenshot, a close up on the arrival of the 1st GPS block of data,  you can see the GPS navigation thread being interrupted by the DCM thread, so that the GPS thread does not complete until after the DCM thread has completed.

![screen shot 2017-01-12 at 13 14 21](https://cloud.githubusercontent.com/assets/542066/22737743/53f35644-edfc-11e6-9224-c60375009a47.png)

I am going to test this code in more detail before merging (especially for the AUAV3), but I would like to leave the code here in this pull request for a few days, to give the team time to make any constructive comments, before I complete final testing (and flight test of the code without this running).

Best wishes, Pete