### PR TITLE
I2C2 improvements to use mag and barometer together

### DIFF
--- a/libDCM/libDCM.c
+++ b/libDCM/libDCM.c
@@ -82,59 +82,68 @@ static boolean gps_run_init_step(uint16_t count)
 	return false;
 }
 
-#if (USE_BAROMETER_ALTITUDE == 1)
 
-// We want to be reading both the magnetometer and the barometer at 4Hz
-// The magnetometer driver returns a new result via the callback on each call
-// The barometer driver needs to be called several times to get a single 
-//  result set via the callback. Also on first invocation the barometer driver
-//  reads calibration data, and hence requires one extra call
+// We want to be returning reading from both the magnetometer and the barometer at 4Hz.
+// However each device may need to be called many times before a reading is returned.
+// The code below ensures that a given sensor is called repeatedly until it reaches
+// a state where the other device can be called safely over the same I2C2 bus, even if 
+// the first device has not yet returned a complete set of sensor data.
+// For example, at startup the barometer needs 12 calls before returning pressure.
+// But in normal operation it will need 6 calls.
+// By contrast in normal operations the magnetometer only needs one call, once it is calibrated.
 
-void get_data_from_I2C_sensors(void)
+void get_data_from_I2C_sensors(void) // Expected to be called at 40Hz
 {
-	static int toggle = 0;
-	static int counter = 0;
-
-	if (toggle) {
-		if (counter++ > 0) {
-//#if (MAG_YAW_DRIFT == 1 && HILSIM != 1)
-#if (MAG_YAW_DRIFT == 1)
-//			printf("rxMag %u\r\n", udb_heartbeat_counter);
-			rxMagnetometer(mag_drift_callback);
-#endif
-			counter = 0;
-			toggle = 0;
-		}
-	} else {
-		rxBarometer(udb_barometer_callback);
-		if (counter++ > 6) {
-			counter = 0;
-			toggle = 1;
+	static uint8_t barometer_needs_servicing = BAROMETER_SERVICE_CAN_PAUSE;
+	static uint8_t magnetometer_needs_servicing = MAGNETOMETER_SERVICE_CAN_PAUSE;
+	static uint8_t counter_40Hz = 0;
+	
+	// Split a 1 second interval (40 calls) into 8 interleaved segments using the following logic
+	if ((counter_40Hz == 0) || (counter_40Hz == 10) || (counter_40Hz == 20) || ( counter_40Hz == 30))
+	{
+#if (USE_BAROMETER_ALTITUDE == 1 && HILSIM != 1)
+		barometer_needs_servicing = rxBarometer(udb_barometer_callback);
+#endif // (USE_BAROMETER_ALTITUDE == 1 && HILSIM != 1)
+	}
+	else if // Allow a total of 6 consecutive calls to the barometer to return pressure
+		(((counter_40Hz >= 1) && (counter_40Hz <= 5))
+		|| ((counter_40Hz >= 11) && (counter_40Hz <= 15))
+		|| ((counter_40Hz >= 21) && (counter_40Hz <= 25))
+		|| ((counter_40Hz >= 31) && (counter_40Hz <= 35)))
+	{
+		if (barometer_needs_servicing)
+		{
+#if (USE_BAROMETER_ALTITUDE == 1 && HILSIM != 1)
+			barometer_needs_servicing = rxBarometer(udb_barometer_callback);
+#endif // (USE_BAROMETER_ALTITUDE == 1 && HILSIM != 1)
 		}
 	}
+	else if ((counter_40Hz == 6) || (counter_40Hz == 16) || (counter_40Hz == 26) || ( counter_40Hz == 36))
+	{
+#if (MAG_YAW_DRIFT == 1 && HILSIM != 1)
+		magnetometer_needs_servicing = rxMagnetometer(mag_drift_callback);
+#endif // (MAG_YAW_DRIFT == 1 && HILSIM != 1)
+	}
+	else // Should be my_modulo at 7,8,9  17,18,19   27,28,29  37,38,39 : a total of 4 consequtive calls to mag.
+	{
+		if (magnetometer_needs_servicing)
+		{
+#if (MAG_YAW_DRIFT == 1 && HILSIM != 1)
+			magnetometer_needs_servicing = rxMagnetometer(mag_drift_callback);
+#endif  // (MAG_YAW_DRIFT == 1 && HILSIM != 1)
+		}	   
+	}
+	counter_40Hz++;
+	if (counter_40Hz >= 40) counter_40Hz = 0;
 }
-#endif // USE_BAROMETER_ALTITUDE
 
 // Called at HEARTBEAT_HZ
 void udb_heartbeat_callback(void)
 {
-#if (USE_BAROMETER_ALTITUDE == 1)
 	if (udb_pulse_counter % (HEARTBEAT_HZ / 40) == 0)
 	{
 		get_data_from_I2C_sensors(); // TODO: this should always be be called at 40Hz
 	}
-#else
-//#if (MAG_YAW_DRIFT == 1 && HILSIM != 1)
-#if (MAG_YAW_DRIFT == 1)
-	// This is a simple counter to do stuff at 4hz
-//	if (udb_heartbeat_counter % 10 == 0)
-	if (udb_pulse_counter % (HEARTBEAT_HZ / 4) == 0)
-	{
-		rxMagnetometer(mag_drift_callback);
-	}
-#endif
-#endif // USE_BAROMETER_ALTITUDE
-
 //  when we move the IMU step to the MPU call back, to run at 200 Hz, remove this
 	if (dcm_flags._.calib_finished)
 	{
@@ -142,14 +151,6 @@ void udb_heartbeat_callback(void)
 	}
 
 	dcm_heartbeat_callback();    // this was called dcm_servo_callback_prepare_outputs();
-
-//	if (!dcm_flags._.init_finished)
-//	{
-//		if (udb_heartbeat_counter % (HEARTBEAT_HZ / 40) == 0)
-//		{
-//			dcm_run_init_step(udb_heartbeat_counter / (HEARTBEAT_HZ / 40));
-//		}
-//	}
 
 	if (udb_pulse_counter % (HEARTBEAT_HZ / 40) == 0)
 	{

--- a/libDCM/libDCM.c
+++ b/libDCM/libDCM.c
@@ -90,7 +90,7 @@ static boolean gps_run_init_step(uint16_t count)
 //  result set via the callback. Also on first invocation the barometer driver
 //  reads calibration data, and hence requires one extra call
 
-void do_I2C_stuff(void)
+void get_data_from_I2C_sensors(void)
 {
 	static int toggle = 0;
 	static int counter = 0;
@@ -121,7 +121,7 @@ void udb_heartbeat_callback(void)
 #if (USE_BAROMETER_ALTITUDE == 1)
 	if (udb_pulse_counter % (HEARTBEAT_HZ / 40) == 0)
 	{
-		do_I2C_stuff(); // TODO: this should always be be called at 40Hz
+		get_data_from_I2C_sensors(); // TODO: this should always be be called at 40Hz
 	}
 #else
 //#if (MAG_YAW_DRIFT == 1 && HILSIM != 1)

--- a/libDCM/libDCM.c
+++ b/libDCM/libDCM.c
@@ -88,8 +88,8 @@ static boolean gps_run_init_step(uint16_t count)
 // The code below ensures that a given sensor is called repeatedly until it reaches
 // a state where the other device can be called safely over the same I2C2 bus, even if 
 // the first device has not yet returned a complete set of sensor data.
-// For example, at startup the barometer needs 12 calls before returning pressure.
-// But in normal operation it will need 6 calls.
+// For example, at startup the barometer could need 9 calls before returning pressure.
+// But in normal operation it will need 5 calls.
 // By contrast in normal operations the magnetometer only needs one call, once it is calibrated.
 
 void get_data_from_I2C_sensors(void) // Expected to be called at 40Hz
@@ -124,7 +124,7 @@ void get_data_from_I2C_sensors(void) // Expected to be called at 40Hz
 		magnetometer_needs_servicing = rxMagnetometer(mag_drift_callback);
 #endif // (MAG_YAW_DRIFT == 1 && HILSIM != 1)
 	}
-	else // Should be my_modulo at 7,8,9  17,18,19   27,28,29  37,38,39 : a total of 4 consequtive calls to mag.
+	else // Should be my_modulo at 7,8,9  17,18,19   27,28,29  37,38,39 : a total of 4 consecutively calls to mag.
 	{
 		if (magnetometer_needs_servicing)
 		{

--- a/libUDB/I2C2.c
+++ b/libUDB/I2C2.c
@@ -37,11 +37,8 @@
 #define _I2C2EN         I2C2CONbits.I2CEN
 
 // Calculate the BRGvalue automatically
-//#define I2C1FSCL 400000 // Bus speed measured in Hz
-//#define I2C1BRGVAL ((FREQOSC/(CLK_PHASES *I2C1FSCL))-(FREQOSC/(CLK_PHASES * 10000000)))-1
-#define I2C_CLOCK_RATE 200000LL  //Hz
+#define I2C_CLOCK_RATE 200000LL  //I2C Bus speed in Hz
 #define I2C2BRGVAL  (((FCY / I2C_CLOCK_RATE)-(FCY / 1111111)) - 1)
-//#define I2C2BRGVAL 60 // 200 Khz
 #define I2C2_NORMAL (((I2C2CON & 0b0000000000011111) == 0) && ((I2C2STAT & 0b0100010011000001) == 0))
 
 static void I2C2_Init(void);
@@ -73,12 +70,10 @@ struct I2C_xfer {
 	const uint8_t* cmd;
 	uint16_t cmd_len;
 	uint8_t* data;
-//	uint16_t data_len;
 	uint16_t tx_data_len;
 	uint16_t rx_data_len;
 	I2C_callbackFunc callback;
 	uint16_t mode;
-//
 	uint16_t index;
 	void (*state)(void);
 };

--- a/libUDB/I2C2.c
+++ b/libUDB/I2C2.c
@@ -24,6 +24,7 @@
 #include "I2C.h"
 #include "NV_memory.h"
 #include "events.h"
+#include "oscillator.h"
 
 #define USE_I2C_SECOND_PORT_DRIVER 1
 
@@ -38,7 +39,9 @@
 // Calculate the BRGvalue automatically
 //#define I2C1FSCL 400000 // Bus speed measured in Hz
 //#define I2C1BRGVAL ((FREQOSC/(CLK_PHASES *I2C1FSCL))-(FREQOSC/(CLK_PHASES * 10000000)))-1
-#define I2C2BRGVAL 60 // 200 Khz
+#define I2C_CLOCK_RATE 200000LL  //Hz
+#define I2C2BRGVAL  (((FCY / I2C_CLOCK_RATE)-(FCY / 1111111)) - 1)
+//#define I2C2BRGVAL 60 // 200 Khz
 #define I2C2_NORMAL (((I2C2CON & 0b0000000000011111) == 0) && ((I2C2STAT & 0b0100010011000001) == 0))
 
 static void I2C2_Init(void);

--- a/libUDB/barometer.c
+++ b/libUDB/barometer.c
@@ -118,14 +118,13 @@ uint8_t rxBarometer(barometer_callback_funcptr callback)  // service the baromet
 			I2C_Read(BMP085_ADDRESS, bmp085read_barCalib, 1, bc.buf, 22, &ReadBarCalib_callback, I2C_MODE_WRITE_ADDR_READ);
 			return(BAROMETER_SERVICE_CAN_PAUSE);
 		case 4:
-			barCalibPause = 2;  // probably not required
 			I2C_Write(BMP085_ADDRESS, bmp085write_index, 1, bmp085read_barTemp, 1, NULL);
 			return(BAROMETER_NEEDS_SERVICING);
 		case 5:
 			I2C_Read(BMP085_ADDRESS, bmp085read_barData, 1, barData, 2, &ReadBarTemp_callback, I2C_MODE_WRITE_ADDR_READ);
 			return(BAROMETER_SERVICE_CAN_PAUSE);
 		case 6:
-			barCalibPause = 2;  // probably not required
+			barCalibPause = 1;  // With OSS of 3, BMP180 needs 25.5 milliseconds to get the 3 oversamples 
 			I2C_Write(BMP085_ADDRESS, bmp085write_index, 1, bmp085read_barPres, 1, NULL);
 			return(BAROMETER_NEEDS_SERVICING);
 		case 7:

--- a/libUDB/barometer.c
+++ b/libUDB/barometer.c
@@ -90,7 +90,7 @@ void ReadBarCalib_callback(boolean I2CtrxOK);
 
 barometer_callback_funcptr barometer_callback = NULL;
 
-void rxBarometer(barometer_callback_funcptr callback)  // service the barometer
+uint8_t rxBarometer(barometer_callback_funcptr callback)  // service the barometer
 {
 	barometer_callback = callback;
 
@@ -98,7 +98,7 @@ void rxBarometer(barometer_callback_funcptr callback)  // service the barometer
 	{
 		barMessage = 0;         // start over again
 		I2C_Reset();            // reset the I2C
-		return;
+		return(BAROMETER_NEEDS_SERVICING);
 	}
 
 	if (barCalibPause == 0)
@@ -111,34 +111,35 @@ void rxBarometer(barometer_callback_funcptr callback)  // service the barometer
 		switch (barMessage)
 		{ 
 		case 1:
-			break;
-		case 2:
-			break;
+			return(BAROMETER_NEEDS_SERVICING);
+		case 2:	
+			return(BAROMETER_NEEDS_SERVICING);
 		case 3:
 			I2C_Read(BMP085_ADDRESS, bmp085read_barCalib, 1, bc.buf, 22, &ReadBarCalib_callback, I2C_MODE_WRITE_ADDR_READ);
-			break;
+			return(BAROMETER_SERVICE_CAN_PAUSE);
 		case 4:
 			barCalibPause = 2;  // probably not required
 			I2C_Write(BMP085_ADDRESS, bmp085write_index, 1, bmp085read_barTemp, 1, NULL);
-			break;
+			return(BAROMETER_NEEDS_SERVICING);
 		case 5:
 			I2C_Read(BMP085_ADDRESS, bmp085read_barData, 1, barData, 2, &ReadBarTemp_callback, I2C_MODE_WRITE_ADDR_READ);
-			break;
+			return(BAROMETER_SERVICE_CAN_PAUSE);
 		case 6:
 			barCalibPause = 2;  // probably not required
 			I2C_Write(BMP085_ADDRESS, bmp085write_index, 1, bmp085read_barPres, 1, NULL);
-			break;
+			return(BAROMETER_NEEDS_SERVICING);
 		case 7:
 			I2C_Read(BMP085_ADDRESS, bmp085read_barData, 1, barData, 3, &ReadBarPres_callback, I2C_MODE_WRITE_ADDR_READ);
-			break;
+			return(BAROMETER_SERVICE_CAN_PAUSE);
 		default:
 			barMessage = 0;
-			break;
+			return(BAROMETER_SERVICE_CAN_PAUSE);
 		}
 	}
 	else
 	{
 		barCalibPause--;
+		return(BAROMETER_NEEDS_SERVICING);
 	}
 }
 

--- a/libUDB/barometer.h
+++ b/libUDB/barometer.h
@@ -22,10 +22,14 @@
 #ifndef BAROMETER_H
 #define BAROMETER_H
 
+enum BAROMETER_SERVICE_STATE {
+  BAROMETER_SERVICE_CAN_PAUSE = 0,
+  BAROMETER_NEEDS_SERVICING
+};
 
 typedef void (*barometer_callback_funcptr)(long pressure, int temperature, char status);
 
-void rxBarometer(barometer_callback_funcptr);  // service the barometer
+uint8_t rxBarometer(barometer_callback_funcptr);  // service the barometer
 
 
 #endif // BAROMETER_H

--- a/libUDB/magnetometer.c
+++ b/libUDB/magnetometer.c
@@ -65,22 +65,22 @@ static magnetometer_callback_funcptr magnetometer_callback = NULL;
 #error Undefined magnetometer I2C bus
 #endif
 
-// local (static) variables
-static uint8_t hmc5883read_index[]  = { 0x03 }; // Address of the first register to read
-static uint8_t hmc5883write_index[] = { 0x00 }; // Address of the first register to read
 
-static uint8_t enableMagRead[]        = { 0x10 , 0x20 , 0x00 }; // Continous measurament
-static uint8_t enableMagCalibration[] = { 0x11 , 0x20 , 0x01 }; // Positive bias (Self Test) and single measurament
-static uint8_t resetMagnetometer[]    = { 0x10 , 0x20 , 0x02 }; // Idle mode (Reset??)
 
 #if (HILSIM == 1)
 uint8_t magreg[6];              // magnetometer read-write buffer
 #else
 static uint8_t magreg[6];       // magnetometer read-write buffer
-#endif
 
+static uint8_t hmc5883read_index[]  = { 0x03 }; // Address of the first register to read
+static uint8_t hmc5883write_index[] = { 0x00 }; // Address of the first register to read
+
+static uint8_t enableMagRead[]        = { 0x10 , 0x20 , 0x00 }; // Continuous measurement
+static uint8_t enableMagCalibration[] = { 0x11 , 0x20 , 0x01 }; // Positive bias (Self Test) and single measurement
+static uint8_t resetMagnetometer[]    = { 0x10 , 0x20 , 0x02 }; // Idle mode (Reset??)
 static int16_t mrindex;         // index into the read write buffer 
 static int16_t magCalibPause = 0;
+#endif
 
 int16_t I2messages = 0;
 
@@ -88,7 +88,7 @@ int16_t I2messages = 0;
 static void I2C_callback(boolean I2CtrxOK);
 
 
-void rxMagnetometer(magnetometer_callback_funcptr callback)     // service the magnetometer
+uint8_t rxMagnetometer(magnetometer_callback_funcptr callback)     // service the magnetometer
 {
 	magnetometer_callback = callback;
 
@@ -109,7 +109,7 @@ void rxMagnetometer(magnetometer_callback_funcptr callback)     // service the m
 	{
 		magMessage = 0;         // start over again
 		I2C_Reset();            // reset the I2C
-		return;
+		return(MAGNETOMETER_NEEDS_SERVICING);
 	}
 
 	mrindex = 0;
@@ -125,36 +125,38 @@ void rxMagnetometer(magnetometer_callback_funcptr callback)     // service the m
 		{ 
 		case 1:     // read the magnetometer in case it is still sending data, so as to NACK it
 			I2C_Read(HMC5883_COMMAND, hmc5883read_index, 1, magreg, 6, &I2C_callback, I2C_MODE_WRITE_ADDR_READ); 
-			break;
-		case 2:     // put magnetomter into the power up defaults on a reset
+			return(MAGNETOMETER_SERVICE_CAN_PAUSE);
+		case 2:     // put magnetometer into the power up defaults on a reset
 			I2C_Write(HMC5883_COMMAND, hmc5883write_index, 1, resetMagnetometer, 3, NULL);
-			break;
+			return(MAGNETOMETER_NEEDS_SERVICING);
 		case 3:     // clear out any data that is still there
 			I2C_Read(HMC5883_COMMAND, hmc5883read_index, 1, magreg, 6, &I2C_callback, I2C_MODE_WRITE_ADDR_READ);
-			break;
+			return(MAGNETOMETER_SERVICE_CAN_PAUSE);
 		case 4:     // enable the calibration process
 			magCalibPause = 2;
 			I2C_Write(HMC5883_COMMAND, hmc5883write_index, 1, enableMagCalibration, 3, NULL);
-			break;
+			return(MAGNETOMETER_NEEDS_SERVICING);
 		case 5:     // read the calibration data
 			I2C_Read(HMC5883_COMMAND, hmc5883read_index, 1, magreg, 6, &I2C_callback, I2C_MODE_WRITE_ADDR_READ);
-			break;
+			return(MAGNETOMETER_SERVICE_CAN_PAUSE);
 		case 6:     // enable normal continuous readings
 			I2C_Write(HMC5883_COMMAND, hmc5883write_index, 1, enableMagRead, 3, NULL);
-			break;
+			return(MAGNETOMETER_NEEDS_SERVICING);
 		case 7:     // read the magnetometer data
 			I2C_Read(HMC5883_COMMAND, hmc5883read_index, 1, magreg, 6, &I2C_callback, I2C_MODE_WRITE_ADDR_READ);
-			break;
+			return(MAGNETOMETER_SERVICE_CAN_PAUSE);
 		default:
 			magMessage = 0;
-			break;
+			return(MAGNETOMETER_SERVICE_CAN_PAUSE);
 		}
 	}
 	else
 	{
 		magCalibPause--;
+		return(MAGNETOMETER_NEEDS_SERVICING);
 	}
 #endif  // (HILSIM != 1)
+return(MAGNETOMETER_SERVICE_CAN_PAUSE);	
 }
 
 // this is the callback function for when the I2C transaction is complete

--- a/libUDB/magnetometer.c
+++ b/libUDB/magnetometer.c
@@ -212,11 +212,4 @@ void HILSIM_MagData(magnetometer_callback_funcptr callback)
 	I2C_callback(true); // run the magnetometer computations
 }
 
-//#else
-//
-//void rxMagnetometer(magnetometer_callback_funcptr callback)
-//{
-//	magnetometer_callback = callback;
-//}
-//
 #endif // MAG_YAW_DRIFT

--- a/libUDB/magnetometer.c
+++ b/libUDB/magnetometer.c
@@ -36,13 +36,6 @@ int16_t magFieldRaw[3];
 int16_t magMessage = 0;                         // message type
 
 #if (MAG_YAW_DRIFT == 1)
-//#if (MAG_YAW_DRIFT == 1 && HILSIM != 1)
-
-// TODO: select magnetometer type, set MAGNETICDECLINATION,
-// and select orientation of the magnetometer, and remove the next 3 lines.
-#if (HILSIM != 1)
-#warning "Check magnetometer options."
-#endif
 
 static magnetometer_callback_funcptr magnetometer_callback = NULL;
 

--- a/libUDB/magnetometer.h
+++ b/libUDB/magnetometer.h
@@ -33,8 +33,13 @@ extern int16_t I2messages;
 
 typedef void (*magnetometer_callback_funcptr)(void);
 
-void rxMagnetometer(magnetometer_callback_funcptr); // service the magnetometer
+uint8_t rxMagnetometer(magnetometer_callback_funcptr); // service the magnetometer
 void HILSIM_MagData(magnetometer_callback_funcptr);
+
+enum MAGNETOMETER_SERVICE_STATE {
+    MAGNETOMETER_SERVICE_CAN_PAUSE = 0, 
+    MAGNETOMETER_NEEDS_SERVICING  
+};
 
 
 #endif // MAGNETOMETER_H


### PR DESCRIPTION
The goal is to allow the Barometer and Magnetometer to reliably work together while sharing the same I2C2 bus (2 wires).

Once calibrated the Magnetometer state machine can return new data from the sensor with one call. But the Barometer state machine expects 6 calls to return the temperature and pressure. We intend to retrieve useful sensor data from each device bat 4Hz. 

It is not possible to just toggle calls between each device, as sometimes, it is essential that one device is called up to 6 times consecutively, for each of the next 40Hz frames. Rob had a good go at this, but I have really taken his ideas further.  I have modified the rxBarometer() and rxMagnetometer() routines so that they return a state as to whether they needs servicing imminently again. If they do, then they will be called again on the next 1/40th of a second pulse. However, the barometer is limited in doing this for a maximum of 6 repeated calls, and the magnetometer can repeat for a maximum of 4 times, which fit's it's own needs on the I2C bus. 

I am posting this Pull Request early for comments, so that I don't go too far down the route of testing, if I then need to make significant changes to this. Testing may take a while; I shall probably needs to now get the latest Salae Logic Analyser which incorporates a form of oscilloscope as well as logic analysis; When joining several I2C devices together with wiring, it will be important to check that the capacitance of the wires, along with the pull resistors are all working correctly.  This will not be so important when all the devices are on one board. e.g. on the AUAV3, or the board that Leo has found.

I note that we run our I2C2 devices at 200K Hz which is an unusual speed. The spec is usually for 100K Hz, and then there is a variant specification for 400K Hz. I have left the speed at 200K as it has been working for us so far.

Best wishes, Pete