### PR TITLE
Static mag offsets2

### DIFF
--- a/Config/options.h
+++ b/Config/options.h
@@ -358,6 +358,7 @@
 // SERIAL_CAM_TRACK is used to output location data to a 2nd UDB, which will target its camera at this plane.
 // SERIAL_MAVLINK is a bi-directional binary format for use with QgroundControl, HKGCS or MAVProxy (Ground Control Stations.)
 // SERIAL_MAGNETOMETER outputs the automatically calculated offsets and raw magnetometer data.
+// SERIAL_MAG_CALIBRATE is used to calculate  magnetometer offsets for a static non changing calibration. 
 // Note that SERIAL_MAVLINK defaults to using a baud rate of 57600 baud (other formats default to 19200)
 
 #ifndef SERIAL_OUTPUT_FORMAT

--- a/Config/options_magnetometer.h
+++ b/Config/options_magnetometer.h
@@ -62,7 +62,17 @@
 //#define MAG_FLIPPED
 //#define MAG_DIRECT
 
+// Uncomment the following line for using Static Magnetometer Offsets. 
+// You will need to manually calibrate your plane's offsets in advance.
+// Set SERIAL_OUTPUT_FORMAT to  SERIAL_MAG_CALIBRATE to obtain calibration measurements.
+// Turn the plane through all dimensions X,Y,Z  (imagine you are painting a 3D globe by rotating the plane).
+// Inspect the last line of the telemetry file that you have created for the following static offsets,
+// and set them below.
+#define MAG_STATIC_OFFSETS
 
+#define MAG_STATIC_OFFSET_X       0
+#define MAG_STATIC_OFFSET_Y       0
+#define MAG_STATIC_OFFSET_Z       0
 
 // ************************************************************************
 // *** Users should not need to change anything below here ****************

--- a/MatrixPilot/defines.h
+++ b/MatrixPilot/defines.h
@@ -86,16 +86,17 @@ void save_altitudeCntrlVariable(void);
 #define FP_LOGO                     2
 
 // TELEMETRY_OUTPUT_FORMAT options
-#define SERIAL_NONE         0    // No serial data is sent
-#define SERIAL_DEBUG        1    // UAV Dev Board debug info
-#define SERIAL_ARDUSTATION  2    // Compatible with ArduStation
-#define SERIAL_UDB          3    // Pete's efficient UAV Dev Board format
-#define SERIAL_OSD_REMZIBI  4    // Output data formatted to use as input to a Remzibi OSD (only works with GPS_UBX)
-#define SERIAL_OSD_IF       5    // Output data formatted to use as input to a IF OSD (only works with GPS_UBX)
-#define SERIAL_MAGNETOMETER 6    // Debugging the magnetometer
-#define SERIAL_UDB_EXTRA    7    // Extra Telemetry beyond that provided by SERIAL_UDB for higher bandwidth connections
-#define SERIAL_CAM_TRACK    8    // Output Location in a format usable by a 2nd UDB to target its camera at this plane
-#define SERIAL_MAVLINK      9    // The Micro Air Vehicle Link protocol from the PixHawk Project
+#define SERIAL_NONE           0     // No serial data is sent
+#define SERIAL_DEBUG          1     // UAV Dev Board debug info
+#define SERIAL_ARDUSTATION    2     // Compatible with ArduStation
+#define SERIAL_UDB            3     // Legacy protocol. Superceded by SERIAL_UDB_EXTRA
+#define SERIAL_OSD_REMZIBI    4     // Output data formatted to use as input to a Remzibi OSD (only works with GPS_UBX)
+#define SERIAL_OSD_IF         5     // Output data formatted to use as input to a IF OSD (only works with GPS_UBX)
+#define SERIAL_MAGNETOMETER   6     // Debugging the magnetometer
+#define SERIAL_UDB_EXTRA      7     // Extra Telemetry beyond that provided by SERIAL_UDB for higher bandwidth connections
+#define SERIAL_CAM_TRACK      8     // Output Location in a format usable by a 2nd UDB to target its camera at this plane
+#define SERIAL_MAVLINK        9     // The Micro Air Vehicle Link protocol from the PixHawk Project
+#define SERIAL_MAG_CALIBRATE 10     // Used to calibrate and report static magnetometer offsets
 
 
 #include "gain_variables.h"

--- a/MatrixPilot/telemetry.c
+++ b/MatrixPilot/telemetry.c
@@ -791,7 +791,7 @@ extern int16_t I2ERROR;
 extern int16_t I2messages;
 extern int16_t I2interrupts;
 
-#if (BOARD_TYPE == UDB4_BOARD || BOARD_TYPE == UDB5_BOARD)
+#if (BOARD_TYPE == UDB4_BOARD || BOARD_TYPE == UDB5_BOARD || BOARD_TYPE == AUAV3_BOARD )
 #define I2CCONREG I2C2CON
 #define I2CSTATREG I2C2STAT
 #else
@@ -810,19 +810,23 @@ void telemetry_output_8hz(void)
 
 void telemetry_output_8hz(void)
 {
-	if (udb_pulse_counter % 10 == 0) // Every 2 runs (5 heartbeat counts per 8Hz)
+	if (udb_pulse_counter % (HEARTBEAT_HZ / 4) == 0) 
 	{
-		serial_output("MagOffset: %i, %i, %i\r\n"
-		              "MagBody: %i, %i, %i\r\n"
-		              "MagEarth: %i, %i, %i\r\n"
-		              "MagGain: %i, %i, %i\r\n"
-		              "Calib: %i, %i, %i\r\n"
-		              "MagMessage: %i\r\n"
-		              "TotalMsg: %i\r\n"
-		              //"I2CCON: %X, I2CSTAT: %X, I2ERROR: %X\r\n" // PDH
-			      "I2CCON: %X, I2CSTAT: %X\r\n"
+		serial_output(" MagOffset,%i,%i,%i,"
+		              " MagBody,%i,%i,%i,"
+		              " MagEarth,%i,%i,%i,"
+		              " MagGain,%i,%i,%i,"
+		              " Calib,%i,%i,%i,"
+		              " MagMessage,%i,"
+		              " TotalMsg,%i,"
+			      " I2CCON,0x%X, I2CSTAT,0x%X"
 		              "\r\n",
+#ifdef MAG_STATIC_OFFSETS
+		    
+		    udb_staticMagOffset[0], udb_staticMagOffset[1], udb_staticMagOffset[2],
+#else
 		    udb_magOffset[0]>>OFFSETSHIFT, udb_magOffset[1]>>OFFSETSHIFT, udb_magOffset[2]>>OFFSETSHIFT,
+#endif
 		    udb_magFieldBody[0], udb_magFieldBody[1], udb_magFieldBody[2],
 		    magFieldEarth[0], magFieldEarth[1], magFieldEarth[2],
 		    magGain[0], magGain[1], magGain[2],
@@ -833,6 +837,54 @@ void telemetry_output_8hz(void)
 		    I2CCONREG, I2CSTATREG);
 	}
 }
+
+#elif (SERIAL_OUTPUT_FORMAT == SERIAL_MAG_CALIBRATE)
+
+static int16_t mag_x_axis_max = 0;
+static int16_t mag_x_axis_min = 0;
+static int16_t mag_y_axis_max = 0;
+static int16_t mag_y_axis_min = 0;
+static int16_t mag_z_axis_max = 0;
+static int16_t mag_z_axis_min = 0;
+static boolean first_time_through = true;
+
+
+void telemetry_output_8hz(void)
+{
+	if (udb_pulse_counter % (HEARTBEAT_HZ / 4) == 0) 
+	{
+		if (first_time_through)
+		{
+			first_time_through = false;
+			mag_x_axis_max = (udb_magFieldBody[0] + (udb_staticMagOffset[0]));
+			mag_x_axis_min = (udb_magFieldBody[0] + (udb_staticMagOffset[0]));
+			 mag_y_axis_max = (udb_magFieldBody[1] +(udb_staticMagOffset[1]));
+			mag_y_axis_min = (udb_magFieldBody[1] + (udb_staticMagOffset[1]));
+			mag_z_axis_max = (udb_magFieldBody[2] + (udb_staticMagOffset[2]));
+			mag_z_axis_min = (udb_magFieldBody[2] + (udb_staticMagOffset[2]));
+		}
+		else
+		{
+			if (mag_x_axis_max > (udb_magFieldBody[0] + (udb_staticMagOffset[0]))) { mag_x_axis_max = (udb_magFieldBody[0] + (udb_staticMagOffset[0])); }
+			if (mag_x_axis_min < (udb_magFieldBody[0] + (udb_staticMagOffset[0]))) { mag_x_axis_min = (udb_magFieldBody[0] + (udb_staticMagOffset[0])); }
+			if (mag_y_axis_max > (udb_magFieldBody[1] + (udb_staticMagOffset[1]))) { mag_y_axis_max = (udb_magFieldBody[1] + (udb_staticMagOffset[1])); }
+			if (mag_y_axis_min < (udb_magFieldBody[1] + (udb_staticMagOffset[1]))) { mag_y_axis_min = (udb_magFieldBody[1] + (udb_staticMagOffset[1])); }
+			if (mag_z_axis_max > (udb_magFieldBody[2] + (udb_staticMagOffset[2]))) { mag_z_axis_max = (udb_magFieldBody[2] + (udb_staticMagOffset[2])); }
+			if (mag_z_axis_min < (udb_magFieldBody[2] + (udb_staticMagOffset[2]))) { mag_z_axis_min = (udb_magFieldBody[2] + (udb_staticMagOffset[2])); }
+		}
+		serial_output("Mag X,%i, Mag Y,%i, Mag Z,%i, Offset X,%i, Offset Y,%i, Offset Z,%i\r\n",
+		// We add in the udb_static_MagOffset in case user is re-calibrating and has left an old one defined.
+		udb_magFieldBody[0] + (udb_staticMagOffset[0]),
+		udb_magFieldBody[1] + (udb_staticMagOffset[1]),
+		udb_magFieldBody[2] + (udb_staticMagOffset[2]),
+		(mag_x_axis_max + mag_x_axis_min)  / 2,
+		(mag_y_axis_max + mag_y_axis_min)  / 2,
+		(mag_z_axis_max + mag_z_axis_min)  / 2
+		);
+		
+	}
+}
+
 
 #elif (SERIAL_OUTPUT_FORMAT == SERIAL_CAM_TRACK)
 

--- a/libUDB/magnetometer.c
+++ b/libUDB/magnetometer.c
@@ -29,7 +29,7 @@
 int16_t udb_magFieldBody[3];                    // magnetic field in the body frame of reference 
 int16_t udb_magOffset[3] = { 0 , 0 , 0 };       // magnetic offset in the body frame of reference
 // To use static offsets, Change the variable name udb_magOffset to udb_staticMagOffset on lines 169, 170, 171
-int16_t udb_staticMagOffset[3] = { 0 , 0 , 0 }; // Enter the static magnetic offset in the body frame of reference here.
+int16_t udb_staticMagOffset[3] = { MAG_STATIC_OFFSET_X , MAG_STATIC_OFFSET_Y , MAG_STATIC_OFFSET_Z }; 
 int16_t magGain[3] = { RMAX , RMAX , RMAX };    // magnetometer calibration gains
 int16_t rawMagCalib[3] = { 0 , 0 , 0 };
 int16_t magFieldRaw[3];
@@ -168,10 +168,15 @@ static void I2C_callback(boolean I2CtrxOK)
 		}
 		if (magMessage == 7)
 		{
-			udb_magFieldBody[0] = MAG_X_SIGN((__builtin_mulsu((magFieldRaw[MAG_X_AXIS]), magGain[MAG_X_AXIS]))>>14) - (udb_magOffset[0]>>1); // To use static offsets, Change udb_magOffset to udb_staticMagOffset
-			udb_magFieldBody[1] = MAG_Y_SIGN((__builtin_mulsu((magFieldRaw[MAG_Y_AXIS]), magGain[MAG_Y_AXIS]))>>14) - (udb_magOffset[1]>>1); // To use static offsets, Change udb_magOffset to udb_staticMagOffset
-			udb_magFieldBody[2] = MAG_Z_SIGN((__builtin_mulsu((magFieldRaw[MAG_Z_AXIS]), magGain[MAG_Z_AXIS]))>>14) - (udb_magOffset[2]>>1); // To use static offsets, Change udb_magOffset to udb_staticMagOffset
-
+#ifdef MAG_STATIC_OFFSETS
+			udb_magFieldBody[0] = MAG_X_SIGN((__builtin_mulsu((magFieldRaw[MAG_X_AXIS]), magGain[MAG_X_AXIS]))>>14) - (udb_staticMagOffset[0]); 
+			udb_magFieldBody[1] = MAG_Y_SIGN((__builtin_mulsu((magFieldRaw[MAG_Y_AXIS]), magGain[MAG_Y_AXIS]))>>14) - (udb_staticMagOffset[1]);
+			udb_magFieldBody[2] = MAG_Z_SIGN((__builtin_mulsu((magFieldRaw[MAG_Z_AXIS]), magGain[MAG_Z_AXIS]))>>14) - (udb_staticMagOffset[2]);		
+#else
+			udb_magFieldBody[0] = MAG_X_SIGN((__builtin_mulsu((magFieldRaw[MAG_X_AXIS]), magGain[MAG_X_AXIS]))>>14) - (udb_magOffset[0]>>1);
+			udb_magFieldBody[1] = MAG_Y_SIGN((__builtin_mulsu((magFieldRaw[MAG_Y_AXIS]), magGain[MAG_Y_AXIS]))>>14) - (udb_magOffset[1]>>1);
+			udb_magFieldBody[2] = MAG_Z_SIGN((__builtin_mulsu((magFieldRaw[MAG_Z_AXIS]), magGain[MAG_Z_AXIS]))>>14) - (udb_magOffset[2]>>1);
+#endif	
 			if ((abs(udb_magFieldBody[0]) < MAGNETICMAXIMUM) &&
 			    (abs(udb_magFieldBody[1]) < MAGNETICMAXIMUM) &&
 			    (abs(udb_magFieldBody[2]) < MAGNETICMAXIMUM))

--- a/libUDB/magnetometer.h
+++ b/libUDB/magnetometer.h
@@ -25,6 +25,7 @@
 
 extern int16_t udb_magFieldBody[];  // magnetic field in the body frame of reference 
 extern int16_t udb_magOffset[];     // magnetic offset in the body frame of reference
+extern int16_t udb_staticMagOffset[];     // magnetic static offsets in the body frame of reference
 extern int16_t magGain[];           // magnetometer calibration gains
 extern int16_t rawMagCalib[];
 extern int16_t magFieldRaw[];


### PR DESCRIPTION
In order to test the AUAV3 with both barometer and magnetometer running on the I2C bus, I needed to get the HMC5883L running correctly.  I did this eventually by setting up static offsets, and switching off the automatic calibration of offsets in the magnetometer. My hypothesis is that the HMC5883L has larger offsets than the original HMC5843 which Bill used when developing automatic calibration, and so it is either too slow or does not work on the HMC5883L. I tidied up some of the code for Static Offsets, and have added a new printout feature (SERIAL_MAG_CALIBRATE) for measuring the offsets in the telemetry. After carefully running that facility, and creating graphs in the corresponding csv file, I now have a pretty good round and centred sphere of measurements from the HMC5883L.  Ground testing in the garden, and plots in Google Earth, show this to be working much better now. The earth rotated magnetic vector is probably still moving at between +/- 10 degrees depending on roll and pitch (including inverted flight), but that is OK for now. (I think it could be improved still further with careful calibrations).

So I intend to put rebase base this set of  commits onto the previous set of commits #126 , and run a flight test when the weather allows using the AUAV3 barometer BMP180 and HMC5883L magnetometer together.

For reference my AUAV3 HMC5883L magnetometer offsets were:-
```
#define MAG_STATIC_OFFSET_X       70
#define MAG_STATIC_OFFSET_Y      132
#define MAG_STATIC_OFFSET_Z       -3
```

I show below the plots of measurements of turning my test board around in circles in each axis:-

![screen shot 2017-02-26 at 23 05 39](https://cloud.githubusercontent.com/assets/542066/23344662/367ef642-fc78-11e6-9af8-9f8eab376e9a.png)


Best wishes, Pete
