### PR TITLE
Add MAG_STATIC_OFFSETS to RollPitchYaw, FlashOSD, LedTest and  Cessna Projects

### DIFF
--- a/Config/Cessna/options_magnetometer.h
+++ b/Config/Cessna/options_magnetometer.h
@@ -62,7 +62,17 @@
 //#define MAG_FLIPPED
 //#define MAG_DIRECT
 
+// Uncomment the following line for using Static Magnetometer Offsets.
+// You will need to manually calibrate your plane's offsets in advance.
+// Set SERIAL_OUTPUT_FORMAT to  SERIAL_MAG_CALIBRATE to obtain calibration measurements.
+// Turn the plane through all dimensions X,Y,Z  (imagine you are painting a 3D globe by rotating the plane).
+// Inspect the last line of the telemetry file that you have created for the following static offsets,
+// and set them below.
+#define MAG_STATIC_OFFSETS
 
+#define MAG_STATIC_OFFSET_X       0
+#define MAG_STATIC_OFFSET_Y       0
+#define MAG_STATIC_OFFSET_Z       0
 
 // ************************************************************************
 // *** Users should not need to change anything below here ****************

--- a/RollPitchYaw/Config/options_magnetometer.h
+++ b/RollPitchYaw/Config/options_magnetometer.h
@@ -68,7 +68,17 @@
 //#define MAG_FLIPPED
 //#define MAG_DIRECT
 
+// Uncomment the following line for using Static Magnetometer Offsets.
+// You will need to manually calibrate your plane's offsets in advance.
+// Set SERIAL_OUTPUT_FORMAT to  SERIAL_MAG_CALIBRATE to obtain calibration measurements.
+// Turn the plane through all dimensions X,Y,Z  (imagine you are painting a 3D globe by rotating the plane).
+// Inspect the last line of the telemetry file that you have created for the following static offsets,
+// and set them below.
+#define MAG_STATIC_OFFSETS
 
+#define MAG_STATIC_OFFSET_X       0
+#define MAG_STATIC_OFFSET_Y       0
+#define MAG_STATIC_OFFSET_Z       0
 
 // ************************************************************************
 // *** Users should not need to change anything below here ****************

--- a/Tools/FlashOSD/Config/options_magnetometer.h
+++ b/Tools/FlashOSD/Config/options_magnetometer.h
@@ -68,7 +68,17 @@
 //#define MAG_FLIPPED
 //#define MAG_DIRECT
 
+// Uncomment the following line for using Static Magnetometer Offsets.
+// You will need to manually calibrate your plane's offsets in advance.
+// Set SERIAL_OUTPUT_FORMAT to  SERIAL_MAG_CALIBRATE to obtain calibration measurements.
+// Turn the plane through all dimensions X,Y,Z  (imagine you are painting a 3D globe by rotating the plane).
+// Inspect the last line of the telemetry file that you have created for the following static offsets,
+// and set them below.
+#define MAG_STATIC_OFFSETS
 
+#define MAG_STATIC_OFFSET_X       0
+#define MAG_STATIC_OFFSET_Y       0
+#define MAG_STATIC_OFFSET_Z       0
 
 // ************************************************************************
 // *** Users should not need to change anything below here ****************

--- a/Tools/LedTest/Config/options_magnetometer.h
+++ b/Tools/LedTest/Config/options_magnetometer.h
@@ -68,7 +68,17 @@
 //#define MAG_FLIPPED
 //#define MAG_DIRECT
 
+// Uncomment the following line for using Static Magnetometer Offsets.
+// You will need to manually calibrate your plane's offsets in advance.
+// Set SERIAL_OUTPUT_FORMAT to  SERIAL_MAG_CALIBRATE to obtain calibration measurements.
+// Turn the plane through all dimensions X,Y,Z  (imagine you are painting a 3D globe by rotating the plane).
+// Inspect the last line of the telemetry file that you have created for the following static offsets,
+// and set them below.
+#define MAG_STATIC_OFFSETS
 
+#define MAG_STATIC_OFFSET_X       0
+#define MAG_STATIC_OFFSET_Y       0
+#define MAG_STATIC_OFFSET_Z       0
 
 // ************************************************************************
 // *** Users should not need to change anything below here ****************

--- a/Tools/MatrixPilot-SIL/SIL-udb.c
+++ b/Tools/MatrixPilot-SIL/SIL-udb.c
@@ -457,7 +457,7 @@ boolean handleUDBSockets(void)
 
 static magnetometer_callback_funcptr magnetometer_callback = NULL;
 
-void rxMagnetometer(magnetometer_callback_funcptr callback)
+uint8_t rxMagnetometer(magnetometer_callback_funcptr callback)
 {
 	magnetometer_callback = callback;
 }


### PR DESCRIPTION
This PR updates the options_magnetometer.h file of non MatrixPilot Projects (e.g. RollPitchYaw etc) with MAG_STATIC_OFFSETS. They will fail to compile in MatrixPilot_5_0_1. Apologies.  I will have to bump the new release with this PR to MatrixPilot_5_0_2 and let uavdevboard group know. If anyone notices anything else of high priority that needs fixing please let me know.

Thanks to Robert for spotting the issue in the build log files. The Travis build system will need fixing so that it actually reports this type of error correctly back up to the main page.