### PR TITLE
Fix build all sh script to return "pass" or "fail" of session to Travis 

### DIFF
--- a/build-all.sh
+++ b/build-all.sh
@@ -1,68 +1,122 @@
 #!/bin/bash
+command_failed=false
 
 git config --get remote.origin.url && git symbolic-ref --short HEAD
 
 mkdir -p _build
 cd _build
-
+ 
 mkdir -p XPlane; cd XPlane
-make -j 8 -f ../../makefile TARGET_NAME=XPlane DEVICE=HIL
+#if ! make -j 8 -f ../../makefile TARGET_NAME=XPlane DEVICE=HIL
+#	then
+#	command_failed=true
+#fi
 cd ..
-
+ 
 mkdir -p MatrixPilot; cd MatrixPilot
+
 mkdir -p SIL; cd SIL
-make -j 8 -f ../../../makefile TARGET_NAME=MPSIM DEVICE=SIL CONFIG=Cessna DEFS=CONSOLE_UART=0
-
+#if ! make -j 8 -f ../../../makefile TARGET_NAME=MPSIM DEVICE=SIL CONFIG=Cessna DEFS=CONSOLE_UART=0 
+#	then
+#	command_failed=true
+#fi
 cd ..; mkdir -p AUAV3; cd AUAV3
-make -j 8 -f ../../../makefile TARGET_NAME=MatrixPilot DEVICE=UDB5 CONFIG=Cessna
-
+if ! make -j 8 -f ../../../makefile TARGET_NAME=MatrixPilot DEVICE=UDB5 CONFIG=Cessna
+	then
+	command_failed=true
+fi
+ 
 cd ..; mkdir -p Grobularis; cd Grobularis
-make -j 8 -f ../../../makefile TARGET_NAME=MatrixPilot DEVICE=UDB5 CONFIG=Grobularis
-
+if ! make -j 8 -f ../../../makefile TARGET_NAME=MatrixPilot DEVICE=UDB5 CONFIG=Grobularis
+	then
+	command_failed=true
+fi
 cd ..; mkdir -p E_Glider; cd E_Glider
-make -j 8 -f ../../../makefile TARGET_NAME=MatrixPilot DEVICE=AUAV3 CONFIG=E_Glider
-
+if ! make -j 8 -f ../../../makefile TARGET_NAME=MatrixPilot DEVICE=AUAV3 CONFIG=E_Glider
+	then
+	command_failed=true
+fi 
 cd ..; mkdir -p UDB5; cd UDB5
-make -j 8 -f ../../../makefile TARGET_NAME=MatrixPilot DEVICE=UDB5 DEFS='USE_OSD=OSD_REMZIBI HILSIM=1'
+if ! make -j 8 -f ../../../makefile TARGET_NAME=MatrixPilot DEVICE=UDB5 DEFS='USE_OSD=OSD_REMZIBI HILSIM=1' 
+	then
+	command_failed=true 
+fi
 cd ..; mkdir -p UDB5_UDB_EXTRA; cd UDB5_UDB_EXTRA
-make -j 8 -f ../../../makefile TARGET_NAME=MatrixPilot DEVICE=UDB5 DEFS='SERIAL_OUTPUT_FORMAT=SERIAL_UDB_EXTRA MAG_YAW_DRIFT=1 HMC5883L MAG_FORWARDS USE_BAROMETER_ALTITUDE=1'
+if ! make -j 8 -f ../../../makefile TARGET_NAME=MatrixPilot DEVICE=UDB5 DEFS='SERIAL_OUTPUT_FORMAT=SERIAL_UDB_EXTRA MAG_YAW_DRIFT=1 HMC5883L MAG_FORWARDS USE_BAROMETER_ALTITUDE=1'
+	then
+	command_failed=true
+fi
 cd ..; mkdir -p UDB5_LOGO; cd UDB5_LOGO
-make -j 8 -f ../../../makefile TARGET_NAME=MatrixPilot DEVICE=UDB5 DEFS='FLIGHT_PLAN_TYPE=FP_LOGO NORADIO=1 USE_CAMERA_STABILIZATION=1'
+if ! make -j 8 -f ../../../makefile TARGET_NAME=MatrixPilot DEVICE=UDB5 DEFS='FLIGHT_PLAN_TYPE=FP_LOGO NORADIO=1 USE_CAMERA_STABILIZATION=1'
+	then
+	command_failed=true
+fi
 cd ..; mkdir -p UDB4; cd UDB4
-make -j 8 -f ../../../makefile TARGET_NAME=MatrixPilot DEVICE=UDB4 DEFS='USE_OSD=OSD_MINIM AIRFRAME_TYPE=AIRFRAME_GLIDER GAINS_VARIABLE=1 ALTITUDE_GAINS_VARIABLE=1'
+if ! make -j 8 -f ../../../makefile TARGET_NAME=MatrixPilot DEVICE=UDB4 DEFS='USE_OSD=OSD_MINIM AIRFRAME_TYPE=AIRFRAME_GLIDER GAINS_VARIABLE=1 ALTITUDE_GAINS_VARIABLE=1'
+	then
+	command_failed=true
+fi
 cd ..; mkdir -p UDB4_NV; cd UDB4_NV
-make -j 8 -f ../../../makefile TARGET_NAME=MatrixPilot DEVICE=UDB4 DEFS='USE_NV_MEMORY=1 USE_I2C1_DRIVER=1 SERIAL_OUTPUT_FORMAT=SERIAL_MAVLINK'
+if ! make -j 8 -f ../../../makefile TARGET_NAME=MatrixPilot DEVICE=UDB4 DEFS='USE_NV_MEMORY=1 USE_I2C1_DRIVER=1 SERIAL_OUTPUT_FORMAT=SERIAL_MAVLINK'
+	then
+	command_failed=true
+fi
 cd ../..
-
-#exit 0
-
+ 
 mkdir -p RollPitchYaw; cd RollPitchYaw
 mkdir -p AUAV3; cd AUAV3
-make -j 8 -f ../../../makefile TARGET_NAME=RollPitchYaw DEVICE=AUAV3
+if ! make -j 8 -f ../../../makefile TARGET_NAME=RollPitchYaw DEVICE=AUAV3
+	then
+	command_failed=true
+fi
 cd ..; mkdir -p UDB5; cd UDB5
-make -j 8 -f ../../../makefile TARGET_NAME=RollPitchYaw DEVICE=UDB5
+if ! make -j 8 -f ../../../makefile TARGET_NAME=RollPitchYaw DEVICE=UDB5
+	then
+	command_failed=true
+fi
 cd ..; mkdir -p UDB4; cd UDB4
-make -j 8 -f ../../../makefile TARGET_NAME=RollPitchYaw DEVICE=UDB4
+if ! make -j 8 -f ../../../makefile TARGET_NAME=RollPitchYaw DEVICE=UDB4
+	then
+	command_failed=true
+fi
 cd ../..
-
+ 
 mkdir -p LedTest; cd LedTest
 mkdir -p AUAV3; cd AUAV3
-make -j 8 -f ../../../makefile TARGET_NAME=LedTest DEVICE=AUAV3
+if ! make -j 8 -f ../../../makefile TARGET_NAME=LedTest DEVICE=AUAV3
+	then
+	command_failed=true
+fi
 cd ..; mkdir -p UDB5; cd UDB5
-make -j 8 -f ../../../makefile TARGET_NAME=LedTest DEVICE=UDB5
+if ! make -j 8 -f ../../../makefile TARGET_NAME=LedTest DEVICE=UDB5
+	then
+	command_failed=true
+fi
 cd ..; mkdir -p UDB4; cd UDB4
-make -j 8 -f ../../../makefile TARGET_NAME=LedTest DEVICE=UDB4
+if ! make -j 8 -f ../../../makefile TARGET_NAME=LedTest DEVICE=UDB4
+	then
+	command_failed=true
+fi
 cd ../..
-
+ 
 mkdir -p FlashOSD; cd FlashOSD
 mkdir -p AUAV3; cd AUAV3
-make -j 8 -f ../../../makefile TARGET_NAME=FlashOSD DEVICE=AUAV3
+if ! make -j 8 -f ../../../makefile TARGET_NAME=FlashOSD DEVICE=AUAV3
+	then
+	command_failed=true
+fi
 cd ..; mkdir -p UDB5; cd UDB5
-make -j 8 -f ../../../makefile TARGET_NAME=FlashOSD DEVICE=UDB5
+if ! make -j 8 -f ../../../makefile TARGET_NAME=FlashOSD DEVICE=UDB5
+	then
+	command_failed=true
+fi
 cd ..; mkdir -p UDB4; cd UDB4
-make -j 8 -f ../../../makefile TARGET_NAME=FlashOSD DEVICE=UDB4 DEFS=USE_OSD_SPI=1
+if ! make -j 8 -f ../../../makefile TARGET_NAME=FlashOSD DEVICE=UDB4 DEFS=USE_OSD_SPI=1
+	then
+	command_failed=true
+fi
 cd ../..
-
+ 
 cd ..
 echo
 echo "The following output files now exist:"
@@ -74,3 +128,12 @@ find _build | grep px4
 echo 
 echo "$0" complete.
 echo
+
+if [ $command_failed == "true" ]
+then
+	echo "***** One of the make commands has failed *****"
+	exit 1
+else
+	echo "All make commands have completed successfully."
+	exit 0
+fi


### PR DESCRIPTION
At the moment, if the script build-all.sh has an error in the make of one of it's many configuration scenarios, it will report the error in the log, but Travis will still believe that the entire session ran smoothly.

I have edited the script, so that any one single failure will result in a Fail being returned to the caller of build-all.sh (Travis). I have tested it outside of Travis.

At the moment, the SIL configuration and one of the other configuration are commented out, as they are failing anyway. I will look at how to fix the up, and then put in a separate Pull Requests for those fixes. 

I did look at make a subroutine called "try()" which would keep track of whether a given command line had been successful. However I ran into the difficulties of borne shell evaluation of quotes with the DEFS='xxx yyy'  syntax being passed all the way to the Make subsystem correctly. I spent half a day on that, before returning to live with multiple if statements through out the code for now.