### PR TITLE
refactor gplane[] into two: gplane[] and gravity_vector_plane[]

### DIFF
--- a/libDCM/rmat.c
+++ b/libDCM/rmat.c
@@ -196,9 +196,6 @@ static inline void read_accel(void)
 {
 #if (HILSIM == 1)
 	HILSIM_set_gplane(gplane);
-//	gplane[0] = g_a_x_sim.BB;
-//	gplane[1] = g_a_y_sim.BB;
-//	gplane[2] = g_a_z_sim.BB;
 #else
 	gplane[0] = XACCEL_VALUE;
 	gplane[1] = YACCEL_VALUE;

--- a/libDCM/rmat.h
+++ b/libDCM/rmat.h
@@ -47,7 +47,6 @@ extern fractional rmat[];                   //  gyro rotation vector:
 extern fractional omegaAccum[];             //  accumulator for computing adjusted omega:
 extern fractional omegagyro[];
 extern fractional accelEarth[];             //  acceleration, as measured in GPS earth coordinate system
-//extern fractional gplane[];
 extern int16_t aero_force[];
 extern fractional dirOverGndHGPS[];         //  horizontal velocity over ground, as measured by GPS (Vz = 0 )
 extern fractional dirOverGndHrmat[];        //  horizontal direction over ground, as indicated by Rmatrix


### PR DESCRIPTION
gplane[] has had two meaning in the code, depending on the timing of when you view it in the DCM thread of activity. The 1st meaning was to be the  (gravity - acceleration) in the body frame (the plane's frame). This 1st meaning was used as the basis of measurement for DeadReckoning. Later in the code, the gplane variable is re-used for a second meaning,  to find the gravity vector. This made for some confusing reading for new users to the code. So I've refactored the 2nd meaning have a new variable called gravity_vector_plane[].