### PR TITLE
Fix high speed baud rate (1 megabit) telemetry bug

### DIFF
--- a/MatrixPilot/telemetry.c
+++ b/MatrixPilot/telemetry.c
@@ -449,8 +449,10 @@ static void serial_output(const char* format, ...)
 
 	if (remaining > 1)
 	{
+		udb_serial_stop_sending_data();
 		int16_t wrote = vsnprintf((char*)(&serial_buffer[start_index]), (size_t)remaining, format, arglist);
 		end_index = start_index + wrote;
+		udb_serial_start_sending_data();
 	}
 
 	if (sb_index == 0)

--- a/libUDB/serialIO.c
+++ b/libUDB/serialIO.c
@@ -39,6 +39,8 @@
 static int16_callback_fptr_t gps_callback_get_byte_to_send_fptr = NULL;
 static callback_uint8_fptr_t gps_callback_received_byte_fptr = NULL;
 
+static boolean udb_serial_stop_sending_flag = 0;
+
 void udb_init_GPS(int16_callback_fptr_t tx_fptr, callback_uint8_fptr_t rx_fptr)
 {
 	gps_callback_get_byte_to_send_fptr = tx_fptr;
@@ -221,7 +223,13 @@ boolean udb_serial_check_rate(int32_t rate)
 
 void udb_serial_start_sending_data(void)
 {
+	 udb_serial_stop_sending_flag = false;
 	_U2TXIF = 1; // fire the tx interrupt
+}
+
+void udb_serial_stop_sending_data(void)
+{
+	udb_serial_stop_sending_flag  = true; 
 }
 
 void __attribute__((__interrupt__, __no_auto_psv__)) _U2TXInterrupt(void)
@@ -233,7 +241,7 @@ void __attribute__((__interrupt__, __no_auto_psv__)) _U2TXInterrupt(void)
 
 //	int16_t txchar = udb_serial_callback_get_byte_to_send();
 	int16_t txchar = -1;
-	if (serial_callback_get_byte_to_send)
+	if (serial_callback_get_byte_to_send && ! udb_serial_stop_sending_flag)
 	{
 		txchar = serial_callback_get_byte_to_send();
 	}

--- a/libUDB/serialIO.h
+++ b/libUDB/serialIO.h
@@ -27,6 +27,7 @@ void udb_init_GPS(int16_callback_fptr_t tx_fptr, callback_uint8_fptr_t rx_fptr);
 void udb_gps_set_rate(int32_t rate);
 boolean udb_gps_check_rate(int32_t rate);
 void udb_gps_start_sending_data(void);
+void udb_serial_stop_sending_data(void);
 
 // Implement this callback to tell the UDB what byte is next to send on the GPS.
 // Return -1 to stop sending data.


### PR DESCRIPTION
This is a potential fix to the telemetry bug #108  seen when using 1 Megabaud rates from MatrixPilot and using SERIAL_UDB_EXTRA.