### PR TITLE
A refactoring of radioIn failsafe for easier code review. No functional changes.

### DIFF
--- a/libUDB/heartbeat.c
+++ b/libUDB/heartbeat.c
@@ -140,7 +140,7 @@ static void heartbeat_pulse(void)
 	// Noise pulses are counted when they are detected, and reset once a second
 	if (udb_pulse_counter % (HEARTBEAT_HZ/1) == 1)
 	{
-		radioIn_failsafe_reset();
+		radioIn_bad_pulse_count_reset();
 	}
 #endif // NORADIO
 

--- a/libUDB/radioIn.h
+++ b/libUDB/radioIn.h
@@ -28,6 +28,6 @@ void udb_servo_record_trims(void);
 // called from heartbeat pulse at 20Hz
 void radioIn_failsafe_check(void);
 // called from heartbeat pulse at 1Hz
-void radioIn_failsafe_reset(void);
+void radioIn_bad_pulse_count_reset(void);
 
 void udb_callback_radio_did_turn_off(void); // callback


### PR DESCRIPTION
In approving Bill's recent change to radioIn failsafe,  I found the names of the variables and one of the routines to be confusing. So I've changed some of the names to make the code easier to read. There are no functional changes.