### PR TITLE
Hilsim:- delete latency adjustment

### DIFF
--- a/libDCM/deadReckoning.c
+++ b/libDCM/deadReckoning.c
@@ -172,11 +172,7 @@ void dead_reckon(void)
 	                          + __builtin_mulss( IMUintegralAccelerationy._.W1, rmat[4])) << 2);
 	forward_ground_speed = accum._.W1 ;
 
-#if (HILSIM == 1)
-	air_speed_3DIMU = hilsim_airspeed.BB;    // use Xplane as a pitot
-#else
 	air_speed_3DIMU = vector3_mag(air_speed_x, air_speed_y, air_speed_z);
-#endif
 
 	accum.WW   = __builtin_mulsu(air_speed_x, 37877);
 	energy.WW  = __builtin_mulss(accum._.W1, accum._.W1);

--- a/libDCM/estLocation.c
+++ b/libDCM/estLocation.c
@@ -102,7 +102,7 @@ void estLocation(void)
 	// markw: what is the latency? It doesn't appear numerically or as a comment
 	// in the following code. Since this method is called at the GPS reporting rate
 	// it must be assumed to be one reporting interval?
-
+#if (HILSIM != 1)
 	if (dcm_flags._.gps_history_valid)
 	{
 		cog_delta = cog_circular - cog_previous;
@@ -120,6 +120,12 @@ void estLocation(void)
 		climb_rate_delta = 0;
 		location_deltaXY.x = location_deltaXY.y = location_deltaZ = 0;
 	}
+#else
+	cog_delta = 0;
+	sog_delta = 0;
+	climb_rate_delta = 0;
+	location_deltaXY.x = location_deltaXY.y = location_deltaZ = 0;
+#endif //#if (HILSIM != 1)
 	dcm_flags._.gps_history_valid = 1;
 	actual_dir = cog_circular + cog_delta;
 	cog_previous = cog_circular;

--- a/libDCM/estLocation.c
+++ b/libDCM/estLocation.c
@@ -152,11 +152,7 @@ void estLocation(void)
 	velocity_thru_air.x = GPSvelocity.x - estimatedWind[0];
 	velocity_thru_airz  = GPSvelocity.z - estimatedWind[2];
 
-#if (HILSIM == 1)
-	air_speed_3DGPS = hilsim_airspeed.BB; // use Xplane as a pitot
-#else
 	air_speed_3DGPS = vector3_mag(velocity_thru_air.x, velocity_thru_air.y, velocity_thru_airz);
-#endif
 
 	calculated_heading  = rect_to_polar(&velocity_thru_air);
 	// veclocity_thru_air.x becomes XY air speed as a by product of CORDIC routine in rect_to_polar()


### PR DESCRIPTION
GPS latency adjustments are best not applied during HILSIM, when there is no latency in calculating the GPS position inside of the X-Plane simulator. There is some latency in transmitting the position from X-Plane 10 via 38400 serial comms to the uavdevboard, but this is much less than with a real GPS.

This PR also re-instates the calculation of airspeed in HILSIM to be done in the same way as in a real flight.