### PR TITLE
Keep track of GNSS parse errors in the telemetry; Flan  warns users if errors are present

### DIFF
--- a/MatrixPilot/telemetry.c
+++ b/MatrixPilot/telemetry.c
@@ -677,7 +677,7 @@ void telemetry_output_8hz(void)
 					serial_output("F2:T%li:S%d%d%d:N%li:E%li:A%li:W%i:"
 					              "a%i:b%i:c%i:d%i:e%i:f%i:g%i:h%i:i%i:"
 					              "c%u:s%i:cpu%u:"
-					              "as%u:wvx%i:wvy%i:wvz%i:ma%i:mb%i:mc%i:svs%i:hd%i:",
+					              "as%u:wvx%i:wvy%i:wvz%i:ma%u:mb%u:mc%u:svs%i:hd%i:",
 					    tow.WW, udb_flags._.radio_on, dcm_flags._.nav_capable, state_flags._.GPS_steering,
 					    lat_gps.WW, lon_gps.WW, alt_sl_gps.WW, waypointIndex,
 					    rmat[0], rmat[1], rmat[2],
@@ -689,7 +689,7 @@ void telemetry_output_8hz(void)
 #if (MAG_YAW_DRIFT == 1)
 				    magFieldEarth[0], magFieldEarth[1], magFieldEarth[2],
 #else
-				    (int16_t)0, (int16_t)0, (int16_t)0,
+				    (uint16_t)0, gps_parse_errors, (uint16_t)0,
 #endif // MAG_YAW_DRIFT
 				    svs, hdop);
 

--- a/MatrixPilot/telemetry.c
+++ b/MatrixPilot/telemetry.c
@@ -677,7 +677,7 @@ void telemetry_output_8hz(void)
 					serial_output("F2:T%li:S%d%d%d:N%li:E%li:A%li:W%i:"
 					              "a%i:b%i:c%i:d%i:e%i:f%i:g%i:h%i:i%i:"
 					              "c%u:s%i:cpu%u:"
-					              "as%u:wvx%i:wvy%i:wvz%i:ma%u:mb%u:mc%u:svs%i:hd%i:",
+					              "as%u:wvx%i:wvy%i:wvz%i:ma%i:mb%i:mc%i:svs%i:hd%i:",
 					    tow.WW, udb_flags._.radio_on, dcm_flags._.nav_capable, state_flags._.GPS_steering,
 					    lat_gps.WW, lon_gps.WW, alt_sl_gps.WW, waypointIndex,
 					    rmat[0], rmat[1], rmat[2],
@@ -689,7 +689,7 @@ void telemetry_output_8hz(void)
 #if (MAG_YAW_DRIFT == 1)
 				    magFieldEarth[0], magFieldEarth[1], magFieldEarth[2],
 #else
-				    (uint16_t)0, gps_parse_errors, (uint16_t)0,
+				    (uint16_t)0, (uint16_t)0, (uint16_t)0,
 #endif // MAG_YAW_DRIFT
 				    svs, hdop);
 
@@ -739,6 +739,7 @@ void telemetry_output_8hz(void)
 					serial_output("stk%d:", (int16_t)(4096-maxstack));
 #endif // RECORD_FREE_STACK_SPACE
 					serial_output("\r\n");
+					serial_output("F23:G%i:\r\n",gps_parse_errors);
 				}
 			}
 			if (state_flags._.f13_print_req == 1)

--- a/Tools/flight_analyzer/flan.pyw
+++ b/Tools/flight_analyzer/flan.pyw
@@ -1973,6 +1973,7 @@ class flight_log_book:
         self.F20 = "Empty"
         self.F21 = "Empty"
         self.F22 = "Empty"
+        self.F23 = "Empty"
         self.ardustation_pos = "Empty"
         self.rebase_time_to_race_time = False
         self.waypoints_in_telemetry = False
@@ -2278,6 +2279,8 @@ def create_log_book(options) :
             pass # flan not yet using sensor offsets
         elif log.log_format == "F22" : # Number of Input Channels and Trim Values
             pass # flan not using sensor values measured at boot up time
+        elif log.log_format == "F23" :
+            log_book.gps_parse_errors = log.gps_parse_errors
         elif log.log_format == "ARDUSTATION+++" : # Intermediate Ardustation line
             roll = log.roll
             pitch = log.pitch
@@ -2287,7 +2290,11 @@ def create_log_book(options) :
     initial_points = 10 # no. log entries to find origin at start if no F13 format line
     
     t.close()
-
+    if log_book.gps_parse_errors > 0:
+        showinfo(title="Excessive GPS Parse Errors\n" ,
+                         message = "There appear to be gps parsing errors recorded " +
+                                    "in this telemetry file. Please review the data in your raw telemetry file " +
+                                     "and check your gps connections carefully.\n")
     if telemetry_restarts > 1 :
         showinfo(title ="Multiple Telemetry Starts in this File\n" ,      
                        message = "It appears that this telemetry has multiple\n" +

--- a/Tools/flight_analyzer/matrixpilot_lib.py
+++ b/Tools/flight_analyzer/matrixpilot_lib.py
@@ -265,6 +265,7 @@ class base_telemetry :
         self.battery_amphours = 0
         self.desired_height = 0
         self.memory_stack_free = 0
+        self.gps_parse_errors = 0
 
 class mavlink_telemetry(base_telemetry):
     """Parse a single binary mavlink message record"""
@@ -1960,16 +1961,27 @@ class ascii_telemetry(base_telemetry):
             pass  # Not using this telemetry yet
             return "F21"
 
-         #################################################################
+        #################################################################
         # Try Another format of telemetry
         match = re.match("^F22:",line) # If line starts with F22
         if match :
             pass  # Not using this telemetry yet
             return "F22"
+
+        #################################################################
+        # Try Another format of telemetry
+        match = re.match("^F23:",line) # If line starts with F23
+        if match :
+            # Parse the line for number of gps parse errors:-
+            match = re.match(".*:G([0-9]*?):",line)   # gps_parse_errors
+            if match :
+                self.gps_parse_errors  = int(match.group(1))
+            else :
+                print "Failure parsing gps_parse_errors at line", line_no
+            return "F23"       
         
         #################################################################
         # Try Another format of telemetry
-        
         
         match = re.match("^<tm>",line)
         if  match :

--- a/libDCM/gpsParseCommon.c
+++ b/libDCM/gpsParseCommon.c
@@ -44,6 +44,7 @@ extern void (*msg_parse)(uint8_t gpschar);
 static const uint8_t* gps_out_buffer = 0;
 static int16_t gps_out_buffer_length = 0;
 static int16_t gps_out_index = 0;
+uint16_t gps_parse_errors = 1;
 
 int32_t get_gps_date(void)
 {

--- a/libDCM/gpsParseCommon.c
+++ b/libDCM/gpsParseCommon.c
@@ -44,7 +44,7 @@ extern void (*msg_parse)(uint8_t gpschar);
 static const uint8_t* gps_out_buffer = 0;
 static int16_t gps_out_buffer_length = 0;
 static int16_t gps_out_index = 0;
-uint16_t gps_parse_errors = 1;
+uint16_t gps_parse_errors = 0;
 
 int32_t get_gps_date(void)
 {

--- a/libDCM/gpsParseCommon.h
+++ b/libDCM/gpsParseCommon.h
@@ -55,6 +55,7 @@ extern uint16_t air_speed_magnitudeXY;
 extern int8_t calculated_heading;           // takes into account wind velocity
 extern int16_t gps_data_age;
 extern int8_t actual_dir;
+extern uint16_t gps_parse_errors;
 
 extern int16_t forward_acceleration;
 extern uint16_t air_speed_3DGPS;

--- a/libDCM/gpsParseSTD.c
+++ b/libDCM/gpsParseSTD.c
@@ -234,6 +234,7 @@ static void msg_PL2(uint8_t gpschar)
 			}
 			else
 			{
+				gps_parse_errors++ ;
 				calculated_checksum.BB = INVALID_CHECKSUM; // bad payload length
 				msg_parse = &msg_B3;
 			}
@@ -325,6 +326,7 @@ static void msg_B0(uint8_t gpschar)
 	}
 	else
 	{
+		gps_parse_errors++;
 		msg_parse = &msg_B3; // error condition
 	}
 }

--- a/libDCM/gpsParseUBX.c
+++ b/libDCM/gpsParseUBX.c
@@ -56,6 +56,7 @@ static void msg_POSLLH(uint8_t inchar);
 static void msg_DOP(uint8_t inchar);
 static void msg_SOL(uint8_t inchar);
 static void msg_VELNED(uint8_t inchar);
+static void msg_CS0(uint8_t inchar);
 static void msg_CS1(uint8_t inchar);
 
 #if (HILSIM == 1)
@@ -796,7 +797,7 @@ static void msg_ACK_ID(uint8_t gpschar)
 	ack_id = gpschar;
 	CK_A += gpschar;
 	CK_B += CK_A;
-	msg_parse = &msg_CS1;
+	msg_parse = &msg_CS0;
 }
 
 static void msg_MSGU(uint8_t gpschar)
@@ -815,6 +816,12 @@ static void msg_MSGU(uint8_t gpschar)
 		checksum._.B1 = gpschar;
 		msg_parse = &msg_CS1;
 	}
+}
+
+static void msg_CS0(uint8_t gpschar)
+{
+	checksum._.B1 = gpschar;
+	msg_parse = &msg_CS1;
 }
 
 static void msg_CS1(uint8_t gpschar)

--- a/libDCM/gpsParseUBX.c
+++ b/libDCM/gpsParseUBX.c
@@ -565,6 +565,7 @@ static void msg_PL1(uint8_t gpschar)
 					}
 					else
 					{
+						gps_parse_errors++;
 						msg_parse = &msg_B3;    // error condition
 					}
 					break;
@@ -576,6 +577,7 @@ static void msg_PL1(uint8_t gpschar)
 					}
 					else
 					{
+						gps_parse_errors++;
 						msg_parse = &msg_B3;    // error condition
 					}
 					break;
@@ -587,6 +589,7 @@ static void msg_PL1(uint8_t gpschar)
 					}
 					else
 					{
+						gps_parse_errors++;
 						msg_parse = &msg_B3;    // error condition
 					}
 					break;
@@ -598,6 +601,7 @@ static void msg_PL1(uint8_t gpschar)
 					}
 					else
 					{
+						gps_parse_errors++;
 						msg_parse = &msg_B3;    // error condition
 					}
 					break;
@@ -838,6 +842,7 @@ static void msg_CS1(uint8_t gpschar)
 	}
 	else
 	{
+		gps_parse_errors++;
 		gps_data_age = GPS_DATA_MAX_AGE+1;  // if the checksum is wrong then the data from this packet is invalid. 
 		                                    // setting this ensures the nav routine does not try to use this data.
 	}


### PR DESCRIPTION
Bill has added code to the GNSS parsers for the EM406/506 and Ublox, to check if there are problems parsing the serial stream from the receiver units.  This then showed that The Ublox parser was having 8 errors in normal operations at startup. That turned out to be caused by the ACK / NACK messages not having proper logic for obtaining their checksum, and so that is also fixed in this PR.

A new SERIAL_UDB_EXTRA (SUE) format message F23:) is now printed after each F2 telemetry line, which contains the count of gps parse errors. The intention is that future new telemetry for SUE will be added  to the F23: message from now on, and not to the F2: message. This solves a problem with MAVLink compatibility, in that our F2: message cannot be changed in Mavlink, as it has been formerly published. Any changes to F2, would render some mavlink ground control stations as rejecting our F2 SUE over mavlink messages.

Flight Analyzer will now check for any parsing errors, and alert the user if they are found.
