### PR TITLE
SILSIM: re-code for SUE telemetry to work.

### DIFF
--- a/MatrixPilot/telemetry.c
+++ b/MatrixPilot/telemetry.c
@@ -454,12 +454,6 @@ static void serial_output(const char* format, ...)
 		end_index = start_index + wrote;
 		udb_serial_start_sending_data();
 	}
-
-	if (sb_index == 0)
-	{
-		udb_serial_start_sending_data();
-	}
-
 	va_end(arglist);
 }
 #endif // USE_TELELOG

--- a/Tools/MatrixPilot-SIL/SIL-serial.c
+++ b/Tools/MatrixPilot-SIL/SIL-serial.c
@@ -95,12 +95,28 @@ void sil_telemetry_input(uint8_t* buffer, int32_t bytesRead)
 // Call this function to initiate sending data to the serial port
 void udb_serial_start_sending_data(void)
 {
+	uint8_t buffer[BUFLEN];
 	int16_t c;
 	int16_t pos = 0;
+	int16_t bytesWritten;
+	
+	if (!telemetrySocket) return;
 
 	while (pos < BUFLEN && (c = udb_serial_callback_get_byte_to_send()) != -1) {
-//		buffer[pos++] = c;
+		buffer[pos++] = c;
 	}
+	bytesWritten = UDBSocket_write(telemetrySocket, (uint8_t*)buffer, pos);
+        if (bytesWritten == -1) {
+                UDBSocket_close(telemetrySocket);
+                telemetrySocket = NULL;
+	}
+}
+
+
+void udb_serial_stop_sending_data(void)
+{
+	// No mechanism to stop sending as SILSIM not using Interrupts.
+	return;
 }
 
 void mavlink_start_sending_data(void)


### PR DESCRIPTION
This PR is primarily to allow discussion between Pete and Rob regarding the telemetry comms architecture, and getting SILSIM working.

The immediate background here is that Ric needs to test fairly complex Logo routines. One of the fastest and most reliable methods for testing Logo is with SILSIM. It is fast to compile a new change (just over 2 seconds on my machine), and X-Plane 10, can be left running during the process. So a quick change of Logo routine to testing it in flight, is just a matter of a few seconds.

So my main immediate goal is to get the SERIAL_UDB_EXTRA telemetry working in SILSIM immediately.

Beyond that, I can see that Rob has been working diligently on trying to improve and rationalise our comms architecture. 

Rob, perhaps you could review what I've done this morning (this PR), which is based on your PR that I approved into master last night; and let me know your thoughts and comments. 

Best wishes, Pete
