### PR TITLE
UDB_Logo_Editor: Fix calculation of angles when using atan2().

### DIFF
--- a/Tools/UDB_Logo_Editor/udb_logo_editor.html
+++ b/Tools/UDB_Logo_Editor/udb_logo_editor.html
@@ -172,8 +172,10 @@
 		var relPlaneAnglePt = absoluteToRelative(planeAnglePoint);
 		var dx = relPlaneAnglePt.we-relPlanePt.we;
 		var dy = relPlaneAnglePt.sn-relPlanePt.sn;
-		var angle = Math.atan2(dy, dx);
-		planeAngle = 90 - (angle * 180/Math.PI);
+		var angle = 90 - (Math.atan2(dy, dx) * 180 / Math.PI);
+		if (angle < 0)
+			angle = angle + 360;
+		planeAngle = angle;
     }
 
     function savePlanePoint(){
@@ -874,14 +876,22 @@ the overlay itself.
 			case "ANGLE_TO_GOAL":
 				return angle_between_points(logoLastLocationX, logoLastLocationY, logoLocationX, logoLocationY);
 			case "REL_ANGLE_TO_HOME":
-				var a = angle_between_points(0, 0, logoLocationX, logoLocationY);
-				a = (a - logoPlaneAngle + 360) % 360;
-				if (a > 180) a = a-360;
+				var homeAngle = angle_between_points(0, 0, logoLocationX, logoLocationY);
+				a =  logoPlaneAngle - homeAngle
+				a = 180 - a
+				if (a <= 180) 
+					a = a + 360;
+				if (a >=  180)
+				a = a - 360;
 				return a;
 			case "REL_ANGLE_TO_GOAL":
-				var a = angle_between_points(logoLastLocationX, logoLastLocationY, logoLocationX, logoLocationY);
-				a = (a - logoPlaneAngle + 360) % 360;
-				if (a > 180) a = a-360;
+				var goalAngle  = angle_between_points(logoLastLocationX, logoLastLocationY, logoLocationX, logoLocationY);
+				a = logoPlaneAngle - goalAngle;
+				a = 180 - a
+				if (a <= 180) 
+					a = a + 360;
+				if (a >=  180)
+				a = a - 360;
 				return a;
 			case "GROUND_SPEED":
 				return 10;
@@ -949,6 +959,8 @@ the overlay itself.
 		var dx = x2-x1;
 		var dy = y2-y1;
 		var a = 90 - Math.atan2(dy,dx) * 360/(Math.PI * 2);
+		if (a < 0)
+			a = a + 360;
 		return a;
 	}
 	


### PR DESCRIPTION
I am going to ask Ric, to test this change. The returned angles were previously negative for headings between 270 degrees and due North. They are now positive values between zero and 360 degrees.

I have tested the following snippet which was previously faulty but now works correctly in the edtor:-

PEN_UP
    USE_CURRENT_POSITION
    IF_LT(ANGLE_TO_HOME, 180)
        WEST(200)
    ELSE
        EAST(200)
    END

The following also works correctly:-

IF_GT(REL_ANGLE_TO_HOME, 0)
	WEST(300)
ELSE
	EAST(300)
END

As shown in these two screenshots where the angle of the plane relative to the origin varies just slightly from just 0 degrees to just above 0 degrees.

![screen shot 2017-09-05 at 14 38 43](https://user-images.githubusercontent.com/542066/30063982-532fea74-9248-11e7-82a9-7e0dfde5c583.png)

![screen shot 2017-09-05 at 14 38 55](https://user-images.githubusercontent.com/542066/30063988-59bb58e2-9248-11e7-8b60-e21a52274443.png)
