### PR TITLE
GNSS (Global Navigation Sattelite System) metrics

### DIFF
--- a/Config/Cessna/options.h
+++ b/Config/Cessna/options.h
@@ -74,6 +74,15 @@
 #define GPS_TYPE                            GPS_STD
 //#define DEFAULT_GPS_BAUD                    57600   // added for GPS_NMEA support
 
+////////////////////////////////////////////////////////////////////////////////
+// You can specify a level of good GNSS reception before MatrixPilot accepts "GPS ACQUIRED".
+// You can generally leaves these lines at their default values. A value of zero switches off the check.
+// The VDOP parameter is only available for Ublox GNSS devices. It is ignored for other GNSS units.
+// The metrics are not used by HILSIM or SILSIM.
+
+#define GNSS_HDOP_REQUIRED_FOR_STARTUP       20  //  Horizontal Dilution of Precision
+#define GNSS_VDOP_REQUIRED_FOR_STARTUP	     60  //  Vertical Dilution of Precision
+#define GNSS_SVS_REQUIRED_FOR_STARTUP	      6  //  Number of Sattelites in View
 
 ////////////////////////////////////////////////////////////////////////////////
 // Enable/Disable core features of this firmware

--- a/Config/CloudsFly/options.h
+++ b/Config/CloudsFly/options.h
@@ -72,6 +72,15 @@
 #define GPS_TYPE                            GPS_MTEK
 //#define DEFAULT_GPS_BAUD                    57600   // added for GPS_NMEA support
 
+////////////////////////////////////////////////////////////////////////////////
+// You can specify a level of good GNSS reception before MatrixPilot accepts "GPS ACQUIRED".
+// You can generally leaves these lines at their default values. A value of zero switches off the check.
+// The VDOP parameter is only available for Ublox GNSS devices. It is ignored for other GNSS units.
+// The metrics are not used by HILSIM or SILSIM.
+
+#define GNSS_HDOP_REQUIRED_FOR_STARTUP       20  //  Horizontal Dilution of Precision
+#define GNSS_VDOP_REQUIRED_FOR_STARTUP	     60  //  Vertical Dilution of Precision
+#define GNSS_SVS_REQUIRED_FOR_STARTUP	      6  //  Number of Sattelites in View
 
 ////////////////////////////////////////////////////////////////////////////////
 // Enable/Disable core features of this firmware

--- a/Config/E_Glider/options.h
+++ b/Config/E_Glider/options.h
@@ -74,6 +74,15 @@
 #define GPS_TYPE                            GPS_UBX_4HZ
 //#define DEFAULT_GPS_BAUD                    57600   // added for GPS_NMEA support
 
+////////////////////////////////////////////////////////////////////////////////
+// You can specify a level of good GNSS reception before MatrixPilot accepts "GPS ACQUIRED".
+// You can generally leaves these lines at their default values. A value of zero switches off the check.
+// The VDOP parameter is only available for Ublox GNSS devices. It is ignored for other GNSS units.
+// The metrics are not used by HILSIM or SILSIM.
+
+#define GNSS_HDOP_REQUIRED_FOR_STARTUP       20  //  Horizontal Dilution of Precision
+#define GNSS_VDOP_REQUIRED_FOR_STARTUP	     60  //  Vertical Dilution of Precision
+#define GNSS_SVS_REQUIRED_FOR_STARTUP	      6  //  Number of Sattelites in View
 
 ////////////////////////////////////////////////////////////////////////////////
 // Enable/Disable core features of this firmware

--- a/Config/Grobularis/options.h
+++ b/Config/Grobularis/options.h
@@ -74,6 +74,15 @@
 #define GPS_TYPE                            GPS_UBX_4HZ
 //#define DEFAULT_GPS_BAUD                    57600   // added for GPS_NMEA support
 
+////////////////////////////////////////////////////////////////////////////////
+// You can specify a level of good GNSS reception before MatrixPilot accepts "GPS ACQUIRED".
+// You can generally leaves these lines at their default values. A value of zero switches off the check.
+// The VDOP parameter is only available for Ublox GNSS devices. It is ignored for other GNSS units.
+// The metrics are not used by HILSIM or SILSIM.
+
+#define GNSS_HDOP_REQUIRED_FOR_STARTUP       20  //  Horizontal Dilution of Precision
+#define GNSS_VDOP_REQUIRED_FOR_STARTUP	     60  //  Vertical Dilution of Precision
+#define GNSS_SVS_REQUIRED_FOR_STARTUP	      6  //  Number of Sattelites in View
 
 ////////////////////////////////////////////////////////////////////////////////
 // Enable/Disable core features of this firmware

--- a/Config/options.h
+++ b/Config/options.h
@@ -78,6 +78,7 @@
 // You can specify a level of good GNSS reception before MatrixPilot accepts "GPS ACQUIRED".
 // You can generally leaves these lines at their default values. A value of zero switches off the check.
 // The VDOP parameter is only available for Ublox GNSS devices. It is ignored for other GNSS units.
+// The metrics are not used by HILSIM or SILSIM.
 
 #define GNSS_HDOP_REQUIRED_FOR_STARTUP       20  //  Horizontal Dilution of Precision
 #define GNSS_VDOP_REQUIRED_FOR_STARTUP	     60  //  Vertical Dilution of Precision

--- a/Config/options.h
+++ b/Config/options.h
@@ -74,6 +74,14 @@
 #define GPS_TYPE                            GPS_STD
 //#define DEFAULT_GPS_BAUD                    57600   // added for GPS_NMEA support
 
+////////////////////////////////////////////////////////////////////////////////
+// You can specify a level of good GNSS reception before MatrixPilot accepts "GPS ACQUIRED".
+// You can generally leaves these lines at their default values. A value of zero switches off the check.
+// The VDOP parameter is only available for Ublox GNSS devices. It is ignored for other GNSS units.
+
+#define GNSS_HDOP_REQUIRED_FOR_STARTUP       20  //  Horizontal Dilution of Precision
+#define GNSS_VDOP_REQUIRED_FOR_STARTUP	     60  //  Vertical Dilution of Precision
+#define GNSS_SVS_REQUIRED_FOR_STARTUP	      6  //  Number of Sattelites in View
 
 ////////////////////////////////////////////////////////////////////////////////
 // Enable/Disable core features of this firmware

--- a/MatrixPilot/states.c
+++ b/MatrixPilot/states.c
@@ -371,27 +371,29 @@ static void acquiringS(void)
 		if (udb_flags._.radio_on)
 #endif
 		{
-			if (standby_timer == NUM_WAGGLES+1)
-				waggle = WAGGLE_SIZE;
-			else if (standby_timer <= NUM_WAGGLES)
-				waggle = - waggle;
-			else
-				waggle = 0;
+			if (gps_check_startup_metrics())
+			{
+				if (standby_timer == NUM_WAGGLES+1)
+					waggle = WAGGLE_SIZE;
+				else if (standby_timer <= NUM_WAGGLES)
+					waggle = - waggle;
+				else
+					waggle = 0;
 
-			standby_timer--;
-			DPRINT("standby_timer %u  \r", standby_timer);
-			if (standby_timer == 6)
-			{
-				state_flags._.save_origin = 1;
-			}
-			else if (standby_timer == 2)
-			{
-				dcm_flags._.dead_reckon_enable = 1;
-			}
-			else if ((standby_timer <= 0) && 
-				gps_check_startup_metrics())
-			{
-				ent_manualS();
+				standby_timer--;
+				DPRINT("standby_timer %u  \r", standby_timer);
+				if (standby_timer == 6)
+				{
+					state_flags._.save_origin = 1;
+				}
+				else if (standby_timer == 2)
+				{
+					dcm_flags._.dead_reckon_enable = 1;
+				}
+				else if (standby_timer <= 0)
+				{
+					ent_manualS();
+				}
 			}
 		}
 		else

--- a/MatrixPilot/states.c
+++ b/MatrixPilot/states.c
@@ -388,7 +388,8 @@ static void acquiringS(void)
 			{
 				dcm_flags._.dead_reckon_enable = 1;
 			}
-			else if (standby_timer <= 0)
+			else if ((standby_timer <= 0) && 
+				gps_check_startup_metrics())
 			{
 				ent_manualS();
 			}

--- a/MatrixPilot/telemetry.c
+++ b/MatrixPilot/telemetry.c
@@ -733,7 +733,7 @@ void telemetry_output_8hz(void)
 					serial_output("stk%d:", (int16_t)(4096-maxstack));
 #endif // RECORD_FREE_STACK_SPACE
 					serial_output("\r\n");
-					serial_output("F23:G%i:\r\n",gps_parse_errors);
+					serial_output("F23:G%i:V%i:\r\n",gps_parse_errors,vdop);
 				}
 			}
 			if (state_flags._.f13_print_req == 1)

--- a/RollPitchYaw/Config/options.h
+++ b/RollPitchYaw/Config/options.h
@@ -54,6 +54,16 @@
 // Set this value to your GPS type.  (Set to GPS_STD, GPS_UBX_2HZ, GPS_UBX_4HZ, GPS_MTEK, GPS_NMEA, or GPS_NONE)
 #define GPS_TYPE                            GPS_STD
 
+///////////////////////////////////////////////////////////////////////////////
+// You can specify a level of good GNSS reception before MatrixPilot accepts "GPS ACQUIRED".
+// You can generally leaves these lines at their default values. A value of zero switches off the check.
+// The VDOP parameter is only available for Ublox GNSS devices. It is ignored for other GNSS units.
+// The metrics are not used by HILSIM or SILSIM.
+
+#define GNSS_HDOP_REQUIRED_FOR_STARTUP      200  //  Horizontal Dilution of Precision
+#define GNSS_VDOP_REQUIRED_FOR_STARTUP	    200  //  Vertical Dilution of Precision
+#define GNSS_SVS_REQUIRED_FOR_STARTUP	      4  //  Number of Sattelites in View
+
 // Note: As of MatrixPilot 3.0, Dead Reckoning and Wind Estimation are automatically enabled.
 
 // Define MAG_YAW_DRIFT to be 1 to use magnetometer for yaw drift correction.

--- a/libDCM/gpsData.c
+++ b/libDCM/gpsData.c
@@ -50,6 +50,7 @@ union longbbbb lat_origin, lon_origin, alt_origin;  // (COULD THIS BETTER BE A V
 // WRAP ALL THIS UP INTO A STRUCTURE
 volatile union longbbbb lat_gps, lon_gps, alt_sl_gps;        // latitude, longitude, altitude   (COULD THIS BETTER BE A VECTOR??)
 volatile uint8_t hdop;                                       // horizontal dilution of precision
+volatile uint8_t vdop;                                       // vertical dilution of precision
 volatile uint8_t svs;    // referenced by telemetry and OSD modules  // number of satellites
 // these are only exported for telemetry output
 volatile union intbb week_no;

--- a/libDCM/gpsParseCommon.c
+++ b/libDCM/gpsParseCommon.c
@@ -266,9 +266,5 @@ boolean gps_check_startup_metrics(void)
 	{
 		return(true);
 	}
-	else
-	{
-		return(false);
-	}
-
+	return(false);
 }

--- a/libDCM/gpsParseCommon.c
+++ b/libDCM/gpsParseCommon.c
@@ -254,7 +254,11 @@ int32_t calculate_time_of_week(int32_t time)
 
 boolean gps_check_startup_metrics(void)
 {
-	if ((hdop <= GNSS_HDOP_REQUIRED_FOR_STARTUP) && (svs  >=  GNSS_SVS_REQUIRED_FOR_STARTUP))
+	if ((hdop <= GNSS_HDOP_REQUIRED_FOR_STARTUP) && 
+#if ((GPS_TYPE == GPS_UBX_4HZ) || (GPS_TYPE == GPS_UBX_2HZ))
+		(vdop <= GNSS_VDOP_REQUIRED_FOR_STARTUP) &&
+#endif
+		(svs  >=  GNSS_SVS_REQUIRED_FOR_STARTUP))
 	{
 		return(true);
 	}

--- a/libDCM/gpsParseCommon.c
+++ b/libDCM/gpsParseCommon.c
@@ -250,3 +250,16 @@ int32_t calculate_time_of_week(int32_t time)
 	time = (((((int32_t)(h)) * 60) + m) * 60 + s) * 1000 + ms;
 	return (time + (((int32_t)day_of_week) * MS_PER_DAY));
 }
+
+boolean gps_check_startup_metrics(void)
+{
+	if ((hdop <= GNSS_HDOP_REQUIRED_FOR_STARTUP) && (svs  >=  GNSS_SVS_REQUIRED_FOR_STARTUP))
+	{
+		return(true);
+	}
+	else
+	{
+		return(false);
+	}
+
+}

--- a/libDCM/gpsParseCommon.c
+++ b/libDCM/gpsParseCommon.c
@@ -37,6 +37,7 @@ union longbbbb lat_gps_, lon_gps_;
 union longbbbb alt_sl_gps_;
 union longbbbb tow_;
 union intbb hdop_;
+union intbb vdop_;
 union longbbbb date_gps_, time_gps_;
 
 extern void (*msg_parse)(uint8_t gpschar);

--- a/libDCM/gpsParseCommon.c
+++ b/libDCM/gpsParseCommon.c
@@ -254,6 +254,10 @@ int32_t calculate_time_of_week(int32_t time)
 
 boolean gps_check_startup_metrics(void)
 {
+	
+#if (HILSIM == 1)
+	return(true);
+#endif
 	if ((hdop <= GNSS_HDOP_REQUIRED_FOR_STARTUP) && 
 #if ((GPS_TYPE == GPS_UBX_4HZ) || (GPS_TYPE == GPS_UBX_2HZ))
 		(vdop <= GNSS_VDOP_REQUIRED_FOR_STARTUP) &&

--- a/libDCM/gpsParseCommon.h
+++ b/libDCM/gpsParseCommon.h
@@ -26,6 +26,7 @@ extern volatile union intbb climb_gps;      // climb
 extern volatile union intbb hilsim_airspeed;// referenced in estWind and deadReckoning modules
 extern volatile union longbbbb tow;
 extern volatile uint8_t hdop;               // horizontal dilution of precision
+extern volatile uint8_t vdop;               // vertical  dilution of precision
 extern volatile uint8_t svs;                // number of satellites
 //extern union longbbbb as_sim_;
 extern union longbbbb xpg, ypg, zpg;        // gps x, y, z position
@@ -46,6 +47,7 @@ extern union longbbbb alt_sl_gps_;
 //extern union longbbbb cog_gps_;
 //extern union longbbbb climb_gps_;
 extern union intbb hdop_;
+extern union intbb vdop_;
 extern union longbbbb tow_;
 extern union longbbbb date_gps_;
 extern union longbbbb time_gps_;

--- a/libDCM/gpsParseCommon.h
+++ b/libDCM/gpsParseCommon.h
@@ -62,7 +62,6 @@ extern uint16_t gps_parse_errors;
 extern int16_t forward_acceleration;
 extern uint16_t air_speed_3DGPS;
 
-
 //extern void (*msg_parse)(uint8_t gpschar);
 //extern void (*gps_startup_sequence)(int16_t gpscount);
 //extern boolean (*gps_nav_valid)(void);

--- a/libDCM/gpsParseCommon.h
+++ b/libDCM/gpsParseCommon.h
@@ -95,3 +95,5 @@ boolean gps_nav_valid(void);
 void dcm_callback_gps_location_updated(void);   // Callback
 
 int16_t udb_gps_callback_get_byte_to_send(void);
+
+boolean gps_check_startup_metrics(void);

--- a/libDCM/gpsParseUBX.c
+++ b/libDCM/gpsParseUBX.c
@@ -329,7 +329,7 @@ uint8_t* const msg_DOP_parse[] = {
 	&un, &un,                                           // gDOP
 	&un, &un,                                           // pDOP
 	&un, &un,                                           // tDOP
-	&un, &un,                                           // vDOP
+	&vdop_._.B0, &vdop_._.B1,                           // vDOP
 	&hdop_._.B0, &hdop_._.B1,                           // hDOP
 	&un, &un,                                           // nDOP
 	&un, &un,                                           // eDOP
@@ -878,6 +878,7 @@ void gps_commit_data(void)
 
 	climb_gps.BB    = - climb_gps_._.W0;            // SIRF uses 2 byte climb rate, UBX provides 4 bytes
 	hdop            = (uint8_t)(hdop_.BB / 20);     // SIRF scales HDOP by 5, UBX by 10^-2
+	vdop		= (uint8_t)(vdop_.BB / 20);
 	// SIRF provides position in m, UBX provides cm
 //	xpg.WW          = xpg_.WW / 100;
 //	ypg.WW          = ypg_.WW / 100;


### PR DESCRIPTION
This PR is primarily for people that fly in places where the GNSS accuracy may be obscured by mountains and buildings. It has two features:-

- The user can specify that the "GPS Acquired" state does not occur until the following metrics are met:-
      o  HDOP exceeds a value set in options.h
      o SVS exceed as value set in options.h
      o And for the Ublox only, VDOP exceeds a value set in options.h
   The usual standby by timer is also in effect, so the GNSS device always has to settle down for a period before "GPS iacquired."
- The VDOP values are now embedded in the SERIAL_UDB_EXTRA telemetry. This will help us to measure whether VDOP is significantly effected when the plane is low down in Alpine valleys, with mountains high all around.

I have started to test the scheme, and I invite comments from anyone.

