### PR TITLE
Fix to allow for bigger interrupt programs.

### DIFF
--- a/MatrixPilot/flightplan-logo.c
+++ b/MatrixPilot/flightplan-logo.c
@@ -466,7 +466,7 @@ void flightplan_logo_update(void)
 		}
 		else
 		{
-			if (interruptStackBase)   //if not in-progress
+			if (interruptStackBase)   //if in-progress
 			{
 				//cleanup uncompleted interrupt
 				instructionIndex = logoStack[interruptStackBase].returnInstructionIndex+1;  //support both end by main and end by END SUBROUTINE

--- a/MatrixPilot/flightplan-logo.c
+++ b/MatrixPilot/flightplan-logo.c
@@ -442,10 +442,9 @@ void flightplan_logo_update(void)
 		return;
 	}
 
-	// otherwise run the interrupt handler, if configured, and not in-progress
+	// otherwise run the interrupt handler, if configured.
 	if (interruptIndex)
-	{
-		//if not arrived
+	{	
 		if (tofinish_line >= WAYPOINT_PROXIMITY_RADIUS) // not crossed the finish line
 		{
 			if (!interruptStackBase)   //if not in-progress


### PR DESCRIPTION
Before this the number of instructions in interrupts could not exceed MAX_INSTRUCTIONS_PER_CYCLE.

Simply making MAX_INSTRUCTIONS_PER_CYCLE larger would cause 40(Hz) * x instructions per seconds

This fix: the first cycle will run the first MAX_INSTRUCTIONS_PER_CYCLE instructions,
but will continue with the next cycle to run the instructions that follow the first batch. If no CLEAR is encountered, the routine will run to its end and start over.
Interrupt routines are only run while the main program is waiting for a fly command to finish.