### PR TITLE
SILSIM: Fix for FBW mode to operate correctly.

### DIFF
--- a/libUDB/builtins.h
+++ b/libUDB/builtins.h
@@ -12,11 +12,11 @@
 // Fake dspic builtin ASM calls for Non dspic devices (e.g. Arm devices))
 // Microchip dspic controllers use __builtin__ calls to engage special fast instructions in the hardware
 // This file is not included in builds for Microchip dspic devices
-#define __builtin_mulss(x,y) ((( int32_t)(x))*( int32_t)(y))
-#define __builtin_mulus(x,y) (((uint32_t)(x))*( int32_t)(y))
-#define __builtin_mulsu(x,y) ((( int32_t)(x))*(uint32_t)(y))
-#define __builtin_muluu(x,y) (((uint32_t)(x))*(uint32_t)(y))
+#define __builtin_mulss(x,y) (( int32_t)((( int16_t)(x))*( int16_t)(y)))
+#define __builtin_mulus(x,y) (( int32_t)(((uint16_t)(x))*( int16_t)(y)))
+#define __builtin_mulsu(x,y) (( int32_t)((( int16_t)(x))*(uint16_t)(y)))
+#define __builtin_muluu(x,y) ((uint32_t)(((uint16_t)(x))*(uint16_t)(y)))
 #define __builtin_divud(x,y) ((uint16_t)(((uint32_t)(x))/(uint16_t)(y)))
-#define __builtin_divsd(x,y) (( int16_t)((( int32_t)(x))/(int16_t)(y)))
+#define __builtin_divsd(x,y) (( int16_t)((( int32_t)(x))/( int16_t)(y)))
 
 #endif // _BUILTINS_H_

--- a/libUDB/builtins.h
+++ b/libUDB/builtins.h
@@ -12,11 +12,11 @@
 // Fake dspic builtin ASM calls for Non dspic devices (e.g. Arm devices))
 // Microchip dspic controllers use __builtin__ calls to engage special fast instructions in the hardware
 // This file is not included in builds for Microchip dspic devices
-#define __builtin_mulss(x,y) (( int32_t)((( int16_t)(x))*( int16_t)(y)))
-#define __builtin_mulus(x,y) (( int32_t)(((uint16_t)(x))*( int16_t)(y)))
-#define __builtin_mulsu(x,y) (( int32_t)((( int16_t)(x))*(uint16_t)(y)))
-#define __builtin_muluu(x,y) ((uint32_t)(((uint16_t)(x))*(uint16_t)(y)))
-#define __builtin_divud(x,y) ((uint16_t)(((uint32_t)(x))/(uint16_t)(y)))
-#define __builtin_divsd(x,y) (( int16_t)((( int32_t)(x))/( int16_t)(y)))
+static inline int32_t  __builtin_mulss(const  int16_t  p0, const  int16_t  p1) { return (p0 * p1);   }
+static inline int32_t  __builtin_mulus(const uint16_t  p0, const  int16_t  p1) { return (p0 * p1);   }
+static inline int32_t  __builtin_mulsu(const  int16_t  p0, const uint16_t  p1) { return (p0 * p1);   }
+static inline uint32_t __builtin_muluu(const uint16_t  p0, const uint16_t  p1) { return (p0 * p1);   }
+static inline uint16_t __builtin_divud(const uint32_t num, const uint16_t den) { return (num / den); }
+static inline int16_t  __builtin_divsd(const  int32_t num, const  int16_t den) { return (num / den); }
 
 #endif // _BUILTINS_H_


### PR DESCRIPTION
Rob, 

I changed the builtins.h file (which only is used for non dspic devices) this morning to better reflect my understanding of the size of the integers required for each of the parameters, and also the size of the returned values.  Fly By Wire Mode is now running correctly in SILSIM on my setup, with X-Plane 10, in that, on the ground, the Ailerons / Rudder no longer suddenly flip to nearly full throw on the application of "5% aileron" with the keyboard.  The J and Keys   correctly move the ailerons and rudder in fly by wire mode with this patch applied.

Please can you test this change, on your PC  and let me know if the fix works for you.

I know that casting can be tricky, and that this change needs some careful reviewing. It may well effect any other ports to non dspic processors. (e.g. ARM processors.).

Best wishes, Pete
