### PR TITLE
Replace MIPS by FCY to compute ADC_CLK.

### DIFF
--- a/libUDB/analog2digital_udb5.c
+++ b/libUDB/analog2digital_udb5.c
@@ -90,7 +90,7 @@ uint16_t maxstack = 0;
 #endif
 
 // TAD is 1/ADC_CLK
-#define ADC_CLK (MIPS / (ADCLK_DIV_N_MINUS_1 + 1))
+#define ADC_CLK (FCY / (ADCLK_DIV_N_MINUS_1 + 1))
 
 // At FCY=40MHz, ADC_CLK=625KHz
 // At FCY=40MHz, ADC_RATE = 25 KHz


### PR DESCRIPTION
N.B. ADC_CLK formula is correct for udb4 and auav3 analog2digital_xxx files.