### PR TITLE
Ensure that SUE Telemetry works correctly with a 64bit word MatrixPilot

### DIFF
--- a/MatrixPilot/MAVParams.c
+++ b/MatrixPilot/MAVParams.c
@@ -217,7 +217,7 @@ void mavlink_send_int_circular(int16_t i)
 	deg_angle._.W0 = *((int16_t*) mavlink_parameters_list[i].pparam);
 	deg_angle.WW = __builtin_mulss(deg_angle._.W0, (int16_t)(RMAX * 180.0 / 256.0));
 	deg_angle.WW >>= 5;
-	if (deg_angle._.W0 > 0x8000) deg_angle._.W1++; // Take care of the rounding error
+    deg_angle.WW += 0x8000 ; // Take care of the rounding error
 	param.param_int32 = deg_angle._.W1; // >> 6;
 	mavlink_msg_param_value_send(MAVLINK_COMM_0, mavlink_parameters_list[i].name,
 	    param.param_float, MAVLINK_TYPE_INT32_T, count_of_parameters_list, i);
@@ -231,7 +231,7 @@ void mavlink_set_int_circular(mavlink_param_union_t setting, int16_t i)
 
 	dec_angle.WW = __builtin_mulss((int16_t)setting.param_int32, (int16_t)(RMAX * (256.0 / 180.0)));
 	dec_angle.WW <<= 9;
-	if (dec_angle._.W0 > 0x8000) dec_angle.WW += 0x8000; // Take care of the rounding error
+	dec_angle.WW += 0x8000 ; // Take care of the rounding error
 	*((int16_t*)mavlink_parameters_list[i].pparam) = dec_angle._.W1;
 }
 
@@ -312,7 +312,7 @@ void mavlink_send_dcm_angle(int16_t i)
 //	deg_angle.WW = __builtin_mulss(deg_angle._.W0, 40);
 	deg_angle.WW = __builtin_mulss(deg_angle._.W0, (int16_t)(57.3 * 16.0)); //(RMAX * 180.0 / 256.0));
 	deg_angle.WW >>= 2;
-	if (deg_angle._.W0 > 0x8000) deg_angle._.W1++; // Take care of the rounding error
+	deg_angle.WW += 0x8000 ; // Take care of the rounding error
 	param.param_int32 = deg_angle._.W1; // >> 6;
 	mavlink_msg_param_value_send(MAVLINK_COMM_0, mavlink_parameters_list[i].name,
 	    param.param_float, MAVLINK_TYPE_INT32_T, count_of_parameters_list, i);
@@ -327,7 +327,7 @@ void mavlink_set_dcm_angle(mavlink_param_union_t setting, int16_t i)
 
 	dec_angle.WW = __builtin_mulss((int16_t)setting.param_int32, (RMAX * (16.0 / 57.3))); //(int16_t)(RMAX * 64 / 57.3)
 	dec_angle.WW <<= 12;
-	if (dec_angle._.W0 > 0x8000) dec_angle.WW += 0x8000; // Take care of the rounding error
+	dec_angle.WW += 0x8000 ; // Take care of the rounding error
 	*((int16_t*)mavlink_parameters_list[i].pparam) = dec_angle._.W1;
 }
 
@@ -342,7 +342,7 @@ void mavlink_send_frame_anglerate(int16_t i)
 //	deg_angle.WW = __builtin_mulss(deg_angle._.W0, 40);
 	deg_angle.WW = __builtin_mulss(deg_angle._.W0, (int16_t)(57.3 * 40.0)); //(RMAX * 180.0 / 256.0));
 	deg_angle.WW <<= 2;
-	if (deg_angle._.W0 > 0x8000) deg_angle._.W1++; // Take care of the rounding error
+	deg_angle.WW += 0x8000 ; // Take care of the rounding error
 	param.param_int32 = deg_angle._.W1; // >> 6;
 	mavlink_msg_param_value_send(MAVLINK_COMM_0, mavlink_parameters_list[i].name,
 	    param.param_float, MAVLINK_TYPE_INT32_T, count_of_parameters_list, i);
@@ -357,7 +357,7 @@ void mavlink_set_frame_anglerate(mavlink_param_union_t setting, int16_t i)
 
 	dec_angle.WW = __builtin_mulss((int16_t)setting.param_int32, (128.0 * 7.15)); //(int16_t)(RMAX * 128 / (57.3 * 40.0))
 	dec_angle.WW <<= 9;
-	if (dec_angle._.W0 > 0x8000) dec_angle.WW += 0x8000; // Take care of the rounding error
+	dec_angle.WW += 0x8000 ; // Take care of the rounding error
 	*((int16_t*)mavlink_parameters_list[i].pparam) = dec_angle._.W1;
 }
 

--- a/MatrixPilot/telemetry.c
+++ b/MatrixPilot/telemetry.c
@@ -667,19 +667,27 @@ void telemetry_output_8hz(void)
 			if (!f13_print_prepare)
 			{
 				if (toggle)
+
 				{
-					serial_output("F2:T%li:S%d%d%d:N%li:E%li:A%li:W%i:"
-					              "a%i:b%i:c%i:d%i:e%i:f%i:g%i:h%i:i%i:"
-					              "c%u:s%i:cpu%u:"
-					              "as%u:wvx%i:wvy%i:wvz%i:ma%i:mb%i:mc%i:svs%i:hd%i:",
-					    tow.WW, udb_flags._.radio_on, dcm_flags._.nav_capable, state_flags._.GPS_steering,
-					    lat_gps.WW, lon_gps.WW, alt_sl_gps.WW, waypointIndex,
-					    rmat[0], rmat[1], rmat[2],
-					    rmat[3], rmat[4], rmat[5],
-					    rmat[6], rmat[7], rmat[8],
-					    (uint16_t)cog_gps.BB, sog_gps.BB, (uint16_t)udb_cpu_load(), 
-					    air_speed_3DIMU,
-				    estimatedWind[0], estimatedWind[1], estimatedWind[2],
+#if (MP_WORDSIZE == 64)
+                    serial_output("F2:T%i:S%d%d%d:N%i:E%i:A%i:W%i:"
+                            "a%i:b%i:c%i:d%i:e%i:f%i:g%i:h%i:i%i:"
+                            "c%u:s%i:cpu%u:"
+                            "as%u:wvx%i:wvy%i:wvz%i:ma%i:mb%i:mc%i:svs%i:hd%i:",
+#else
+                    serial_output("F2:T%li:S%d%d%d:N%li:E%li:A%li:W%i:"
+                            "a%i:b%i:c%i:d%i:e%i:f%i:g%i:h%i:i%i:"
+                            "c%u:s%i:cpu%u:"
+                            "as%u:wvx%i:wvy%i:wvz%i:ma%i:mb%i:mc%i:svs%i:hd%i:",                  
+#endif
+					tow.WW, udb_flags._.radio_on, dcm_flags._.nav_capable, state_flags._.GPS_steering,
+					lat_gps.WW, lon_gps.WW, alt_sl_gps.WW, waypointIndex,
+					rmat[0], rmat[1], rmat[2],
+					rmat[3], rmat[4], rmat[5],
+					rmat[6], rmat[7], rmat[8],
+					(uint16_t)cog_gps.BB, sog_gps.BB, (uint16_t)udb_cpu_load(), 
+					air_speed_3DIMU,
+                    estimatedWind[0], estimatedWind[1], estimatedWind[2],
 #if (MAG_YAW_DRIFT == 1)
 				    magFieldEarth[0], magFieldEarth[1], magFieldEarth[2],
 #else
@@ -747,7 +755,11 @@ void telemetry_output_8hz(void)
 				{
 					f13_print_prepare = false;
 				}
-				serial_output("F13:week%i:origN%li:origE%li:origA%li:\r\n", week_no, lat_origin.WW, lon_origin.WW, alt_origin);
+#if (MP_WORDSIZE == 64)
+				serial_output("F13:week%i:origN%i:origE%i:origA%i:\r\n", week_no, lat_origin.WW, lon_origin.WW, alt_origin);
+#else
+                serial_output("F13:week%i:origN%li:origE%li:origA%li:\r\n", week_no, lat_origin.WW, lon_origin.WW, alt_origin);
+#endif
 				serial_output("F20:NUM_IN=%i:TRIM=",NUM_INPUTS);
 				for (i = 1; i <= NUM_INPUTS; i++)
 				{

--- a/MatrixPilot/telemetry_log.c
+++ b/MatrixPilot/telemetry_log.c
@@ -195,7 +195,7 @@ static void log_write(const char* str, int len)
 	if (fsp)
 	{
 		led_on(LED_BLUE);
-		if (fwrite(str, 1, len, fsp) != len)
+		if ((int)fwrite(str, 1, len, fsp) != len)
 		{
 			DPRINT("ERROR: fwrite\r\n");
 			log_close();

--- a/Tools/MatrixPilot-SIL/Makefile
+++ b/Tools/MatrixPilot-SIL/Makefile
@@ -11,22 +11,36 @@ endif
 CONFIG  ?= .
 
 ifeq ($(OS),Windows_NT)
-DEFINES  = -DWIN=1
-BINARY   = .exe
-OSOBJS   = UDBSocketWin.o
-OSLIB    = ws2_32
-RM       = del /Q /F
+    DEFINES    = -DWIN=1
+    BINARY     = .exe
+    OSOBJS     = UDBSocketWin.o
+    OSLIB      = ws2_32
+    RM         = del /Q /F
+    ARCH_FLAGS = 
+    WARN       = -Wall -Wextra -Wno-unused-parameter -Wno-unused-but-set-variable
 else
-DEFINES  = -DNIX=1
-BINARY   =
-OSOBJS   = UDBSocketUnix.o
-OSLIB    = m
-RM       = rm -rf
+    ARCH         := $(shell getconf LONG_BIT)
+    ARCH_FLAGS   := -DMP_WORDSIZE=32 -m32
+    ARCH_FLAGS   := -DMP_WORDSIZE=64 -m64
+    DEFINES  = -DNIX=1
+    BINARY   =
+    OSOBJS   = UDBSocketUnix.o
+    OSLIB    = m
+    RM       = rm -rf
+    UNAME_S := $(shell sh -c 'uname -s 2>/dev/null || echo not')
+    ifeq ($(UNAME_S),Linux)
+        DEFINES = -DAPL=0 -DIBM=0 -DLIN=1 -DNIX=1
+        WARN       = -Wall -Wextra -Wno-unused-parameter -Wno-unused-but-set-variable
+    endif
+    ifeq ($(UNAME_S),Darwin)
+        DEFINES = -DAPL=1 -DIBM=0 -DLIN=0 -DNIX=1
+        WARN       = -Wall -Wextra -Wno-unused-parameter -Wno-unused-const-variable
+    endif
 endif
 
 CC       = gcc
-WARN     = -Wall -Wextra -Wno-unused-parameter -Wno-unused-but-set-variable
-CFLAGS   = -pipe -O0 $(DEFINES) $(WARN)
+CCP	 = g++
+CFLAGS   = -pipe -O0 $(DEFINES) $(WARN) $(ARCH_FLAGS)
 INCPATH  = -I. -I../../Config/$(CONFIG) -I../../Config -I../../libUDB -I../../libDCM -I../../MatrixPilot
 LFLAGS   =
 LIBS     = -l$(OSLIB)
@@ -113,18 +127,19 @@ first: all
 	$(CC) -c $(CFLAGS) $(INCPATH) -o $@ $<
 
 %.o: %.cpp $(MP_HEADERS)
-	$(CC) -c $(CFLAGS) $(INCPATH) -o $@ $<
+	$(CCP) -c $(CFLAGS) $(INCPATH) -o $@ $<
 
 all: $(MPSIL_TARGET) $(MPCAT_TARGET)
 
 sil: $(MPSIL_TARGET)
 
 cat: $(MPCAT_TARGET)
+
 $(MPSIL_TARGET): $(MPSIL_OBJECTS)
 	$(CC) $(LFLAGS) -o $(MPSIL_TARGET) $(MPSIL_OBJECTS) $(LIBS)
 
 $(MPCAT_TARGET): $(MPCAT_OBJECTS)
-	$(CC) $(LFLAGS) -o $(MPCAT_TARGET) $(MPCAT_OBJECTS) $(LIBS)
+	$(CCP) $(LFLAGS) -o $(MPCAT_TARGET) $(MPCAT_OBJECTS) $(LIBS)
 
 clean:
 	-$(RM) $(MPSIL_OBJECTS) $(MPCAT_OBJECTS)

--- a/Tools/MatrixPilot-SIL/SILcat.cpp
+++ b/Tools/MatrixPilot-SIL/SILcat.cpp
@@ -48,7 +48,7 @@ int main(int argc, char** argv)
 {
 	UDBSocketType socketType = (!SILSIM_TELEMETRY_RUN_AS_SERVER) ? UDBSocketUDPServer : UDBSocketUDPClient;
 	uint32_t udpPort = SILSIM_TELEMETRY_PORT;
-	char *udpHost = SILSIM_TELEMETRY_HOST;
+	char *udpHost = (char *)SILSIM_TELEMETRY_HOST;
 	char *serialPort = NULL;
 	uint32_t serialBaud = 0;
 	uint8_t argPos = 0;


### PR DESCRIPTION
The main purpose of this PR is to ensure that SILSIM MatrixPilot, when compiled on a 64 bit mac or Unix machine, will store SUE telemetry correctly.  32 bit int32_t variables such as Latitude and Longitude were being printed incorrectly on 64 bit machines when the variables were negative, because the sign bit was not treated as a sign bit when they were 64 bit integers. The end result was the the Google Earth KMZ files for a demo flight in Innsbruck were flying out into space, and across russia when viewed in Google Earth. That should is now fixed.

At the same time, I have tried to remove all the compiler warnings under Ubuntu and most of the warnings under MacOS.  The PR requires further testing by myself at this stage. 

The end goal is to have SILSIM working well under Macos, Ubuntu and Windows (which will be in a separate PR).

Comments welcome.