### PR TITLE
Flight control telemetry

### DIFF
--- a/Config/options.h
+++ b/Config/options.h
@@ -794,6 +794,19 @@
 #define ID_LEAD_PILOT                       "Not Defined"
 #define ID_DIY_DRONES_URL                   "http://www.diydrones.com"
 
+///////////////////////////////////////////////////////////////////////////////////
+// Aid to Flight Analysis of Delta Wing Aircraft. This is an optional setting which
+// allows for minimizing drag of the aircraft from commanded elevator drag (in the elevons).
+// Flight Analyzer can help you track how much elevon is being used to keep the craft in level flight,
+// and let you decide whether to move the balance point of the flying wing forward or backwards.
+// You can set and record the Trim settings for no elevon deflection in relation trailing edger of the main wings.
+// Set the following three lines to allow Flight Analyzer (flan.pyw) compute the amount
+// of up elevon (in UDB units) being used to keep a nose heavy aircraft flying level.
+// Trim the elevons to be in line with the trailing edge, run up MatrixPilot with SERIAL_UDB_EXTRA,
+// and note the values of the relevant channels (e.g. AILERON_OUTPUT_CHANNEL and ELEVATOR_OUTPUT_CHANNEL) in UDB PWM units.
+#define FLIGHT_ANALYZER_TO_USE_NEUTUAL_DEFLECTION_VALUES    1     //Set to 1 to enable and set to 0 to disable this option
+#define AILERON_OUTPUT_CHANNEL_NEUTRAL_DEFLECTION           3000  
+#define ELEVATOR_OUTPUT_CHANNEL_NEUTRAL_DEFLECTION          3000
 
 ////////////////////////////////////////////////////////////////////////////////
 // The following define is used to enable vertical initialization for VTOL

--- a/MatrixPilot/helicalTurnCntrl.c
+++ b/MatrixPilot/helicalTurnCntrl.c
@@ -87,6 +87,7 @@
 int16_t tiltError[3];
 int16_t desiredRotationRateRadians[3];
 int16_t rotationRateError[3];
+int16_t desiredTurnRateRadians;
 //int16_t angleOfAttack;
 
 static int16_t estimatedLift;
@@ -203,7 +204,6 @@ void helicalTurnCntrl(void)
 	int16_t rtlkick;
 	int16_t desiredPitch;
 	int16_t steeringInput;
-	int16_t desiredTurnRateRadians;
 	int16_t desiredTiltVector[3];
 	int16_t desiredRotationRateGyro[3];
 	uint16_t airSpeed;

--- a/MatrixPilot/helicalTurnCntrl.h
+++ b/MatrixPilot/helicalTurnCntrl.h
@@ -22,6 +22,7 @@
 extern int16_t tiltError[3];
 extern int16_t desiredRotationRateRadians[3];
 extern int16_t rotationRateError[3];
+extern int16_t desiredTurnRateRadians;
 //extern int16_t angleOfAttack;
 
 void helicalTurnCntrl(void);

--- a/MatrixPilot/telemetry.c
+++ b/MatrixPilot/telemetry.c
@@ -30,6 +30,8 @@
 #include "flightplan.h"
 #include "flightplan_waypoints.h"
 #include "altitudeCntrl.h"
+#include "helicalTurnCntrl.h"
+#include "servoPrepare.h"
 #if (USE_TELELOG == 1)
 #include "telemetry_log.h"
 #endif
@@ -118,7 +120,7 @@ static uint8_t fp_checksum;
 static void (*sio_parse)(uint8_t inchar) = &sio_newMsg;
 
 
-#define SERIAL_BUFFER_SIZE 256
+#define SERIAL_BUFFER_SIZE 500
 static char serial_buffer[SERIAL_BUFFER_SIZE+1];
 static int16_t sb_index = 0;
 static int16_t end_index = 0;
@@ -474,11 +476,11 @@ int16_t udb_serial_callback_get_byte_to_send(void)
 	return -1;
 }
 
-static int16_t telemetry_counter = 13;
+static int16_t telemetry_counter = 14;
 
 void telemetry_restart(void)
 {
-	telemetry_counter = 13;
+	telemetry_counter = 14;
 }
 
 #if (SERIAL_OUTPUT_FORMAT == SERIAL_DEBUG)
@@ -581,31 +583,36 @@ void telemetry_output_8hz(void)
 	
 	switch (telemetry_counter)
 	{
-		case 13:
+		case 14:
 			serial_output("F22:Sensors=%i,%i,%i,%i,%i,%i\r\n",
 				UDB_XACCEL.value, UDB_YACCEL.value,
 				UDB_ZACCEL.value + (Z_GRAVITY_SIGN ((int16_t)(2*GRAVITY))),
 				udb_xrate.value, udb_yrate.value, udb_zrate.value);
 			break;
-		case 12: 
+		case 13: 
 			serial_output("F21:Offsets=%i,%i,%i,%i,%i,%i\r\n",
 				UDB_XACCEL.offset, UDB_YACCEL.offset, UDB_ZACCEL.offset,
 				udb_xrate.offset, udb_yrate.offset, udb_zrate.offset);
 			break;
-		case 11:
+		case 12:
 			serial_output("F15:IDA=");
 			serial_output(ID_VEHICLE_MODEL_NAME);
 			serial_output(":IDB=");
 			serial_output(ID_VEHICLE_REGISTRATION);
 			serial_output(":\r\n");
 			break;
-		case 10:
+		case 11:
 			serial_output("F16:IDC=");
 			serial_output(ID_LEAD_PILOT);
 			serial_output(":IDD=");
 			serial_output(ID_DIY_DRONES_URL);
 			serial_output(":\r\n");
 			break;
+#if ((FLIGHT_ANALYZER_TO_USE_NEUTUAL_DEFLECTION_VALUES == 1) && (AIRFRAME_TYPE == AIRFRAME_DELTA))
+        case 10:
+            serial_output("F24:AIL=%i:ELEV=%i:\r\n",AILERON_OUTPUT_CHANNEL_NEUTRAL_DEFLECTION,ELEVATOR_OUTPUT_CHANNEL_NEUTRAL_DEFLECTION);
+			break;
+#endif
 		case 9:
 			serial_output("F17:FD_FWD=%5.3f:TR_NAV=%5.3f:TR_FBW=%5.3f:\r\n",
 			    turns.FeedForward, turns.TurnRateNav, turns.TurnRateFBW);
@@ -741,7 +748,12 @@ void telemetry_output_8hz(void)
 					serial_output("stk%d:", (int16_t)(4096-maxstack));
 #endif // RECORD_FREE_STACK_SPACE
 					serial_output("\r\n");
-					serial_output("F23:G%i:V%i:\r\n",gps_parse_errors,vdop);
+					serial_output("F23:G%i:V%i:RE%d,%d,%d:TE%d,%d,%d:DR%d,%d,%d:OM%d,%d,%d:DT%d:EL%d:\r\n",            \
+                            gps_parse_errors,vdop,                                                                     \
+                            rotationRateError[0],rotationRateError[1],rotationRateError[2],                            \
+                            tiltError[0],tiltError[1],tiltError[2],                                                    \
+                            desiredRotationRateRadians[0],desiredRotationRateRadians[1],desiredRotationRateRadians[2], \
+                            omegaAccum[0],omegaAccum[1],omegaAccum[2],desiredTurnRateRadians,elevatorLoadingTrim);
 				}
 			}
 			if (state_flags._.f13_print_req == 1)

--- a/MatrixPilot/telemetry.c
+++ b/MatrixPilot/telemetry.c
@@ -476,11 +476,11 @@ int16_t udb_serial_callback_get_byte_to_send(void)
 	return -1;
 }
 
-static int16_t telemetry_counter = 14;
+static int16_t telemetry_counter = 15;
 
 void telemetry_restart(void)
 {
-	telemetry_counter = 14;
+	telemetry_counter = 15;
 }
 
 #if (SERIAL_OUTPUT_FORMAT == SERIAL_DEBUG)
@@ -583,50 +583,54 @@ void telemetry_output_8hz(void)
 	
 	switch (telemetry_counter)
 	{
-		case 14:
+		case 15:
 			serial_output("F22:Sensors=%i,%i,%i,%i,%i,%i\r\n",
 				UDB_XACCEL.value, UDB_YACCEL.value,
 				UDB_ZACCEL.value + (Z_GRAVITY_SIGN ((int16_t)(2*GRAVITY))),
 				udb_xrate.value, udb_yrate.value, udb_zrate.value);
 			break;
-		case 13: 
+		case 14: 
 			serial_output("F21:Offsets=%i,%i,%i,%i,%i,%i\r\n",
 				UDB_XACCEL.offset, UDB_YACCEL.offset, UDB_ZACCEL.offset,
 				udb_xrate.offset, udb_yrate.offset, udb_zrate.offset);
 			break;
-		case 12:
+		case 13:
 			serial_output("F15:IDA=");
 			serial_output(ID_VEHICLE_MODEL_NAME);
 			serial_output(":IDB=");
 			serial_output(ID_VEHICLE_REGISTRATION);
 			serial_output(":\r\n");
 			break;
-		case 11:
+		case 12:
 			serial_output("F16:IDC=");
 			serial_output(ID_LEAD_PILOT);
 			serial_output(":IDD=");
 			serial_output(ID_DIY_DRONES_URL);
 			serial_output(":\r\n");
 			break;
-        case 10:
+        case 11:
 #if ((FLIGHT_ANALYZER_TO_USE_NEUTUAL_DEFLECTION_VALUES == 1) && (AIRFRAME_TYPE == AIRFRAME_DELTA))
             serial_output("F24:AIL=%i:ELEV=%i:\r\n",AILERON_OUTPUT_CHANNEL_NEUTRAL_DEFLECTION,ELEVATOR_OUTPUT_CHANNEL_NEUTRAL_DEFLECTION);
 #endif
             break;
-		case 9:
+		case 10:
 			serial_output("F17:FD_FWD=%5.3f:TR_NAV=%5.3f:TR_FBW=%5.3f:\r\n",
 			    turns.FeedForward, turns.TurnRateNav, turns.TurnRateFBW);
 			break;
-		case 8:
+		case 9:
 			serial_output("F18:AOA_NRM=%5.3f:AOA_INV=%5.3f:EL_TRIM_NRM=%5.3f:EL_TRIM_INV=%5.3f:CRUISE_SPD=%5.3f:\r\n",
 			    turns.AngleOfAttackNormal, turns.AngleOfAttackInverted, turns.ElevatorTrimNormal,
 			    turns.ElevatorTrimInverted, turns.RefSpeed);
 			break;
-		case 7:
-			serial_output("F19:AIL=%i,%i:ELEV=%i,%i:THROT=%i,%i:RUDD=%i,%i:\r\n",
-			    AILERON_OUTPUT_CHANNEL, AILERON_CHANNEL_REVERSED, ELEVATOR_OUTPUT_CHANNEL,ELEVATOR_CHANNEL_REVERSED,
-			    THROTTLE_OUTPUT_CHANNEL, THROTTLE_CHANNEL_REVERSED, RUDDER_OUTPUT_CHANNEL,RUDDER_CHANNEL_REVERSED );
+		case 8:
+			serial_output("F19:INPUTS:AIL=%i,%i:ELEV=%i,%i:THROT=%i,%i:RUDD=%i,%i:\r\n",
+			    AILERON_INPUT_CHANNEL, AILERON_CHANNEL_REVERSED, ELEVATOR_INPUT_CHANNEL,ELEVATOR_CHANNEL_REVERSED,
+			    THROTTLE_INPUT_CHANNEL, THROTTLE_CHANNEL_REVERSED, RUDDER_INPUT_CHANNEL,RUDDER_CHANNEL_REVERSED );
 			break;
+        case 7:
+            serial_output("F25:OUTPUTS:AIL=%i:ELEV=%i:THROT=%i:RUDD=%i:\r\n",
+			    AILERON_OUTPUT_CHANNEL, ELEVATOR_OUTPUT_CHANNEL,THROTTLE_OUTPUT_CHANNEL, RUDDER_OUTPUT_CHANNEL);
+            break;
 		case 6:
 			serial_output("F14:WIND_EST=%i:GPS_TYPE=%i:DR=%i:BOARD_TYPE=%i:AIRFRAME=%i:"
 			              "RCON=0x%X:TRAP_FLAGS=0x%X:TRAP_SOURCE=0x%lX:ALARMS=%i:"

--- a/MatrixPilot/telemetry.c
+++ b/MatrixPilot/telemetry.c
@@ -608,11 +608,11 @@ void telemetry_output_8hz(void)
 			serial_output(ID_DIY_DRONES_URL);
 			serial_output(":\r\n");
 			break;
-#if ((FLIGHT_ANALYZER_TO_USE_NEUTUAL_DEFLECTION_VALUES == 1) && (AIRFRAME_TYPE == AIRFRAME_DELTA))
         case 10:
+#if ((FLIGHT_ANALYZER_TO_USE_NEUTUAL_DEFLECTION_VALUES == 1) && (AIRFRAME_TYPE == AIRFRAME_DELTA))
             serial_output("F24:AIL=%i:ELEV=%i:\r\n",AILERON_OUTPUT_CHANNEL_NEUTRAL_DEFLECTION,ELEVATOR_OUTPUT_CHANNEL_NEUTRAL_DEFLECTION);
-			break;
 #endif
+            break;
 		case 9:
 			serial_output("F17:FD_FWD=%5.3f:TR_NAV=%5.3f:TR_FBW=%5.3f:\r\n",
 			    turns.FeedForward, turns.TurnRateNav, turns.TurnRateFBW);

--- a/Tools/flight_analyzer/flan.pyw
+++ b/Tools/flight_analyzer/flan.pyw
@@ -1974,10 +1974,12 @@ class flight_log_book:
         self.F21 = "Empty"
         self.F22 = "Empty"
         self.F23 = "Empty"
+        self.F24 = "Empty"
         self.ardustation_pos = "Empty"
         self.rebase_time_to_race_time = False
         self.waypoints_in_telemetry = False
         self.nominal_cruise_speed = 0
+        self.gps_parse_errors = 0
 
 def calc_average_wind_speed(log_book):
     if log_book.racing_mode == 0 :
@@ -2117,6 +2119,7 @@ def create_log_book(options) :
     roll = 0  # only used with ardustation roll
     pitch = 0 # only used with ardustation pitch
     record_no = 0
+    an_F2_record_has_been_stored = False
     telemetry_restarts = 0 # Number of times we see telemetry re-start
     skip_entry = 3 # hack required as first F2 entry can have wrong status in telemetry
                             # e.g. first status 100 even though GPS is good, second entry will
@@ -2179,6 +2182,7 @@ def create_log_book(options) :
                 log.tm = flight_clock.synthesize(log.tm,record_no) # interpolate time between identical entries
                 if (miss_out_counter > miss_out_interval) :# only store log every X times for large datasets
                     log_book.entries.append(log)
+                    an_F2_record_has_been_stored = True
                     miss_out_counter = 0
         elif log.log_format == "F4" : # We have a type of options.h line
             # format of roll_stabilization has changed over time
@@ -2231,6 +2235,7 @@ def create_log_book(options) :
             log_book.dead_reckoning = log.dead_reckoning
             log_book.airframe = log.airframe
             log_book.flight_plan_type = log.flight_plan_type
+            log_book.board_type = log.board_type
             log_book.F14 = "Recorded"
             log_book.F11 = "Recorded"
         elif log.log_format == "F13" : # We have origin information from telemetry
@@ -2281,6 +2286,20 @@ def create_log_book(options) :
             pass # flan not using sensor values measured at boot up time
         elif log.log_format == "F23" :
             log_book.gps_parse_errors = log.gps_parse_errors
+            # logbook.entries[-1] is the last F2 entry in the log book
+            # In the following lines, the F23 fields are added onto the F2 fields in the log book.
+            if an_F2_record_has_been_stored :
+                log_book.entries[-1].gps_parse_errors = log.gps_parse_errors
+                log_book.entries[-1].vdop = log.vdop
+                log_book.entries[-1].rotation_error = log.rotation_error
+                log_book.entries[-1].tilt_error = log.tilt_error
+                log_book.entries[-1].desired_rotation = log.desired_rotation
+                log_book.entries[-1].omega_accum = log.omega_accum
+                log_book.entries[-1].desired_turn_rate = log.desired_turn_rate
+                log_book.entries[-1].elevator_loading_trim = log.elevator_loading_trim
+        elif log.log_format == "F24" :
+            log_book.aileron_channel_neutral = log.aileron_channel_neutral
+            log_book.elevator_channel_neutral = log.elevator_channel_neutral
         elif log.log_format == "ARDUSTATION+++" : # Intermediate Ardustation line
             roll = log.roll
             pitch = log.pitch
@@ -2345,16 +2364,63 @@ def wrap_kml_into_kmz(options):
 
 def write_csv(options,log_book):
     ### write out a csv file enabling analysis in Excel or OpenOffice
-   
+
+    AIRFRAME_STANDARD = 1
+    AIRFRAME_DELTA = 3
+    AIRFAME_GLIDER = 6
+    
+    # Need gyros scale for diferent boards to calculate some of the PID gains.
+    RED_BOARD =              1   # red board with vertical LISY gyros (deprecated)
+    GREEN_BOARD =            2   # green board with Analog Devices 75 degree/second gyros (deprecated)
+    UDB3_BOARD =             3   # red board with daughter boards 500 degree/second Invensense gyros (deprecated)
+    RUSTYS_BOARD =           4   # Red board with Rusty's IXZ-500_RAD2a patch board (deprecated)
+    UDB4_BOARD =             5   # board with dsPIC33 and integrally mounted 500 degree/second Invensense gyros
+    CAN_INTERFACE =          6   #
+    AUAV2_BOARD =            7   # Nick Arsov's AUAV2 with dsPIC33 and MPU6000
+    UDB5_BOARD =             8   # board with dsPIC33 and MPU6000
+    AUAV3_BOARD =            9   # Nick Arsov's AUAV3 with dsPIC33EP and MPU6000
+    AUAV4_BOARD =            10  # AUAV4 with PIC32MX
+    PX4_BOARD =              11  # PX4 with STM32F4xx
+
+    if (log_book.board_type == UDB5_BOARD) or \
+        (log_book.board_type == AUAV3_BOARD):
+        gyro_scale = 3.0016 # 500 degree / second range
+    elif log_book.board_type == UDB4_BOARD:
+        gyro_scale = 4.95
+    else:
+        print "Board Type:", log_book.board_type, "Unsupported by csv generator in flan.pyw"
+        print "PWM analysis of turns will not be correct (zero)."
+        gyro_scale = 0.0
+    RMAX = 16384
+
+    aileron_reversal_multiplier = 1
+    elevator_reversal_multiplier = 1
+    rudder_reversal_multiplier = 1
+    throttle_reversal_multiplier = 1
+    if log_book.aileron_output_reversed == 1:
+        aileron_reversal_multiplier = -1
+        print "Aileron Output noted as being reversed"
+    if log_book.elevator_output_reversed == 1:
+        elevator_reversal_multiplier = -1
+        print "Elevator Output noted as being reversed"
+    if log_book.rudder_output_reversed == 1: rudder_reversal_multiplier = -1
+    if log_book.throttle_output_reversed == 1: throttle_reversal_multiplier = -1
+
     f_csv = open(options.CSV_filename, 'w')
-    print >> f_csv, "GPS Time(secs),GPS Time(XML),Status,Lat,Lon,Waypoint,GPS Alt ASL,GPS Alt AO,",
+    print >> f_csv, "GPS_Time,GPS Time(XML),Status,Lat,Lon,Waypoint,GPS_Alt_ASL,GPS_Alt_AO,",
     print >> f_csv, "Rmat0,Rmat1,Rmat2,Rmat3,Rmat4,Rmat5,Rmat6,Rmat7,Rmat8,",
-    print >> f_csv, "Pitch,Roll,Heading, COG, SOG, CPU, SVS, VDOP, HDOP,",
-    print >> f_csv, "Est AirSpd,Est X Wind,Est Y Wind,Est Z Wind,IN1,IN2,IN3,IN4,",
+    print >> f_csv, "Pitch,Roll,Heading,COG,SOG,CPU,SVS,VDOP,HDOP,",
+    print >> f_csv, "EstAirSpd,EstXWind,EstYWind,EstZWind,IN1,IN2,IN3,IN4,",
     print >> f_csv, "IN5,IN6,IN7,IN8,OUT1,OUT2,OUT3,OUT4,",
-    print >> f_csv, "OUT5,OUT6,OUT7,OUT8,LEX,LEY,LEZ,IMU X,IMU Y,IMU Z,Desired Height,Bar Tmp,Bar Prs,Bar Alt ASL,Bar Alt AO,MAG W,MAG N,MAG Z,",
+    print >> f_csv, "OUT5,OUT6,OUT7,OUT8,OUT_AIL,OUT_ELEV,OUT_RUDD,OUT_THROT,DesTurnRate,",
+    print >> f_csv, "RotErrX,TiltErrX,DesRotX,RotErrY,TiltErrY,DesRotY,RotErrZ,TiltErrZ,DesRotZ,",
+    print >> f_csv, "RotErrX_PWM,TiltErrX_PWM,DesRotX_PWM,X_PWM_TOT,",
+    print >> f_csv, "RotErrY_PWM,TiltErrY_PWM,DesRotY_PWM,Y_PWM_TOT,",
+    print >> f_csv, "RotErrZ_PWM,TiltErrZ_PWM,DesRotZ_PWM,Z_PWM_TOT,",
+    print >> f_csv, "ElevLoadTrim,",
+    print >> f_csv, "LEX,LEY,LEZ,IMU X,IMU Y,IMU Z,Desired_Height,Bar_Tmp,Bar_Prs,Bar_Alt_ASL,Bar_Alt_AO,MAG_W,MAG_N,MAG_Z,",
     print >> f_csv, "Waypoint X,WaypointY,WaypointZ,IMUvelocityX,IMUvelocityY,IMUvelocityZ,",
-    print >> f_csv, "Flags Dec,Flags Hex,Sonar Dst,ALT_SONAR, Aero X, Aero Y, Aero Z, AoI,Wing Load, AoA Pitch,",
+    print >> f_csv, "Flags Dec,Flags Hex,Sonar Dst,ALT_SONAR,AeroX,AeroY,AeroZ,OmegaX,OmegaY,OmegaZ,AoI,WingLoad,AoA_Pitch,",
     print >> f_csv, "Volts,Amps,mAh"
     
     counter = 0
@@ -2418,19 +2484,39 @@ def write_csv(options,log_book):
             elevator_without_trim = elevator_reversal_multiplier * \
                    (entry.pwm_output[log_book.elevator_output_channel] - elevator_trim_pwm_value)
         elif log_book.airframe == 3: # Delta Wing, unmix elevator and aileron
-            elevator_without_trim = (( elevator_reversal_multiplier * \
-                   (entry.pwm_output[log_book.elevator_output_channel] - elevator_trim_pwm_value)) + \
-                   (aileron_reversal_multiplier * \
-                   (entry.pwm_output[log_book.aileron_output_channel] - aileron_trim_pwm_value)) / 2)
+            elevator_without_trim = elevator_reversal_multiplier * \
+                   ((entry.pwm_output[log_book.elevator_output_channel] - elevator_trim_pwm_value) + \
+                   (entry.pwm_output[log_book.aileron_output_channel] - aileron_trim_pwm_value) / 2)
         else :
             print "Warning using Airframe type that is not yet supported", log_book.airframe
         
         if is_level_flight_data(entry, centimeter_cruise_speed):
             aoa_using_pitch_list.append(aoa_using_pitch)
             aoa_using_velocity_list.append(aoa_using_velocity)
+            
             wing_loading_list.append(relative_wing_loading)
             elevator_with_trim_removed.append(float(elevator_without_trim) / 1000)
-        
+
+        elevator_pwm_out = elevator_reversal_multiplier * (entry.pwm_output[log_book.elevator_output_channel] - log_book.channel_trim_values[log_book.elevator_output_channel])
+        aileron_pwm_out =  aileron_reversal_multiplier  * (entry.pwm_output[log_book.aileron_output_channel]  - log_book.channel_trim_values[log_book.aileron_output_channel] )
+        if log_book.airframe == AIRFRAME_DELTA :
+            elevator_temp = (elevator_pwm_out + aileron_pwm_out) / 2
+            aileron_temp =  (elevator_pwm_out - aileron_pwm_out) / 2
+            elevator_pwm_out = elevator_temp
+            aileron_pwm_out = aileron_temp
+        INTEGER_SCALE = 65536 #take account of RMAX for integer method of floating point in firmware
+        rotation_error_x_pwm =int((entry.rotation_error[0] * log_book.pitchkd * RMAX * gyro_scale) / INTEGER_SCALE)
+        tilt_error_x_pwm = int((entry.tilt_error[0] * log_book.pitchgain * RMAX) / INTEGER_SCALE)
+        desired_rotation_x_pwm = int((-entry.desired_rotation[0] * log_book.pitchgain * RMAX * log_book.feed_forward) / INTEGER_SCALE)
+        rotation_error_y_pwm = int((-entry.rotation_error[1] * log_book.rollkd * RMAX * gyro_scale) / INTEGER_SCALE)
+        tilt_error_y_pwm = int((-entry.tilt_error[1] * log_book.rollkp * RMAX) / INTEGER_SCALE)
+        desired_rotation_y_pwm = int((entry.desired_rotation[1] * log_book.rollkp * RMAX * log_book.feed_forward) / INTEGER_SCALE)
+        rotation_error_z_pwm = int((-entry.rotation_error[2] * log_book.yawkd_rudder * RMAX * gyro_scale) / INTEGER_SCALE)
+        tilt_error_z_pwm = int((-entry.tilt_error[2] * log_book.yawkp_rudder * RMAX) / INTEGER_SCALE)
+        desired_rotation_z_pwm = int((entry.desired_rotation[2] * log_book.yawkp_rudder * RMAX * log_book.feed_forward) / INTEGER_SCALE)
+        pwm_x_tot = rotation_error_x_pwm + tilt_error_x_pwm + desired_rotation_x_pwm
+        pwm_y_tot = rotation_error_y_pwm + tilt_error_y_pwm + desired_rotation_y_pwm
+        pwm_z_tot = rotation_error_z_pwm + tilt_error_z_pwm + desired_rotation_z_pwm
         print >> f_csv, entry.tm / 1000.0, ",",\
               flight_clock.convert(entry.tm, log_book), ",", \
               entry.status, "," , \
@@ -2441,7 +2527,7 @@ def write_csv(options,log_book):
               entry.rmat3, "," , entry.rmat4, "," , entry.rmat5 , "," ,\
               entry.rmat6, "," , entry.rmat7, "," , entry.rmat8 , "," ,\
               "{0:.2f}".format(-entry.pitch), ",", "{0:.2f}".format(-entry.roll), \
-                              ",", "{0:.2f}".format(entry.heading_degrees), "," , \
+              ",", "{0:.2f}".format(entry.heading_degrees), "," , \
               entry.cog / 100.0 , "," , entry.sog / 100.0,",", entry.cpu,",", entry.svs, \
               ",", entry.vdop, ",", entry.hdop, "," , \
               "{0:.2f}".format(entry.est_airspeed /100.0), "," , "{0:.2f}".format(entry.est_wind_x / 100.0), "," ,  \
@@ -2450,6 +2536,27 @@ def write_csv(options,log_book):
               entry.pwm_input[5], "," , entry.pwm_input[6], "," , entry.pwm_input[7], "," , entry.pwm_input[8], "," , \
               entry.pwm_output[1], "," , entry.pwm_output[2], "," , entry.pwm_output[3], "," , entry.pwm_output[4], "," , \
               entry.pwm_output[5], "," , entry.pwm_output[6], "," , entry.pwm_output[7], "," , entry.pwm_output[8], "," , \
+              aileron_pwm_out, ",", \
+              elevator_pwm_out, ",", \
+              rudder_reversal_multiplier * (entry.pwm_output[log_book.rudder_output_channel] - log_book.channel_trim_values[log_book.rudder_output_channel]), ",", \
+              throttle_reversal_multiplier * (entry.pwm_output[log_book.throttle_output_channel] - log_book.channel_trim_values[log_book.throttle_output_channel]), ",", \
+              entry.desired_turn_rate, ",", \
+              entry.rotation_error[0], ",", entry.tilt_error[0], ",", entry.desired_rotation[0], ",",                                                       \
+              entry.rotation_error[1], ",", entry.tilt_error[1], ",", entry.desired_rotation[1], ",",                                                       \
+              entry.rotation_error[2], ",", entry.tilt_error[2], ",", entry.desired_rotation[2], ",",                                                       \
+              rotation_error_x_pwm, ",",   \
+              tilt_error_x_pwm, ",",       \
+              desired_rotation_x_pwm, ",", \
+              pwm_x_tot, ",",              \
+              rotation_error_y_pwm, ",",   \
+              tilt_error_y_pwm, ",",       \
+              desired_rotation_y_pwm, ",", \
+              pwm_y_tot, ",",              \
+              rotation_error_z_pwm, ",",   \
+              tilt_error_z_pwm, ",",       \
+              desired_rotation_z_pwm, ",", \
+              pwm_z_tot, ",",              \
+              entry.elevator_loading_trim, ",",                                                                                                             \
               entry.lex, "," , entry.ley , "," , entry.lez, ",", \
               entry.IMUlocationx_W1, ",", entry.IMUlocationy_W1, ",", entry.IMUlocationz_W1, "," , entry.desired_height, ",",\
               entry.barometer_temperature / 10.0, ",",entry.barometer_pressure / 100.0, ",", \
@@ -2460,7 +2567,9 @@ def write_csv(options,log_book):
               "{0:.2f}".format(entry.IMUvelocityx / 100.0), ",", "{0:.2f}".format(entry.IMUvelocityy / 100.0), ",", \
               "{0:.2f}".format(entry.IMUvelocityz / 100.0), ",", \
               entry.flags, ",",hex(entry.flags),",", entry.sonar_direct, ",",  entry.alt_sonar, ",", \
-              entry.aero_force_x, ",", entry.aero_force_y, ",", entry.aero_force_z,",","{0:.2f}".format(incidence), \
+              entry.aero_force_x, ",", entry.aero_force_y, ",", entry.aero_force_z,",", \
+              entry.omega_accum[0], ",", entry.omega_accum[1], ",", entry.omega_accum[2], ",", \
+              "{0:.2f}".format(incidence), \
               ",","{0:.4f}".format(relative_wing_loading),",","{0:.2f}".format(aoa_using_pitch), \
               ",","{0:.3f}".format(entry.battery_voltage/10),",","{0:.3f}".format(entry.battery_ampage/10), \
               ",","{0:.3f}".format(entry.battery_amphours)

--- a/Tools/flight_analyzer/matrixpilot_lib.py
+++ b/Tools/flight_analyzer/matrixpilot_lib.py
@@ -227,8 +227,11 @@ class base_telemetry :
         self.alarms = 0
         self.clock_type = 0
         self.flight_plan_type = 0
-        self.rollkd_rudder = 0
-        self.rollkp_rudder = 0
+        self.rollkd_rudder = 0.0
+        self.rollkp_rudder = 0.0
+        self.rollkp = 0.0
+        self.rollkd = 0.0
+        self.pitchgain = 0.0
         self.IMUvelocityx = 0
         self.IMUvelocityy = 0
         self.IMUvelocityz = 0
@@ -242,11 +245,11 @@ class base_telemetry :
         self.feed_forward = 0.0
         self.navigation_max_earth_vertical_axis_rotation_rate = 0.0
         self.fly_by_wire_max_earth_vertical_axis_rotation_rate = 0.0
-        self.angle_of_attack_normal = 0
-        self.angle_of_attack_inverted = 0
-        self.elevator_trim_normal = 0
-        self.elevator_trim_inverted = 0
-        self.nominal_cruise_speed = 0
+        self.angle_of_attack_normal = 0.0
+        self.angle_of_attack_inverted = 0.0
+        self.elevator_trim_normal = 0.0
+        self.elevator_trim_inverted = 0.0
+        self.nominal_cruise_speed = 0.0
         self.aileron_output_channel  = 0
         self.elevator_output_channel = 0
         self.throttle_output_channel = 0
@@ -266,7 +269,15 @@ class base_telemetry :
         self.desired_height = 0
         self.memory_stack_free = 0
         self.gps_parse_errors = 0
-
+        self.aileron_channel_neutral = 0
+        self.elevator_channel_neutral = 0
+        self.rotation_error = [0,0,0]
+        self.tilt_error = [0,0,0]
+        self.desired_rotation = [0,0,0]
+        self.omega_accum = [0,0,0]
+        self.desired_turn_rate = 0
+        self.elevator_loading_trim = 0
+        
 class mavlink_telemetry(base_telemetry):
     """Parse a single binary mavlink message record"""
     def parse(self,telemetry_file,record_no, max_tm_actual) :
@@ -1725,9 +1736,7 @@ class ascii_telemetry(base_telemetry):
                 self.origin_altitude = int (match.group(1))
             else :
                 print "Failure parsing Origin Altitude at line", line_no
-                return "Error"
-
-            
+                return "Error"            
             # line was parsed without Errors
             return "F13"
 
@@ -1949,8 +1958,10 @@ class ascii_telemetry(base_telemetry):
                 print "Failure parsing NUMBER OF INPUT CHANNELS at line", line_no
             # Only Trim values will match in the follwoing iterative line. Here is an example:
             # F20:NUM_IN=5:TRIM=2992,3000,2057,2989,2043,:
+            trim_index = 1
             for match in re.finditer('([0-9]*?),',line):
-                self.channel_trim_values.append(int(match.group(1)))
+                self.channel_trim_values[trim_index] = int(match.group(1))
+                trim_index += 1
             return "F20"
 
 
@@ -1978,7 +1989,71 @@ class ascii_telemetry(base_telemetry):
                 self.gps_parse_errors  = int(match.group(1))
             else :
                 print "Failure parsing gps_parse_errors at line", line_no
-            return "F23"       
+            match = re.match(".*:V([-0-9]*?):",line) # Vertical Dilution of Precision
+            if match :
+                try:
+                    self.vdop = int(match.group(1))
+                except:
+                    pass
+            match = re.match(".*:RE([-0-9]*?),([-0-9]*?),([-0-9]*?):",line) #RE is Rotation Error
+            if match :
+                self.rotation_error[0] = int(match.group(1))
+                self.rotation_error[1] = int(match.group(2))
+                self.rotation_error[2] = int(match.group(3))
+            else:
+                print "Failure parsing helical turn rotation_error at", line_no
+            match = re.match(".*:TE([-0-9]*?),([-0-9]*?),([-0-9]*?):",line) #TE is Tilt Error
+            if match :
+                self.tilt_error[0] = int(match.group(1))
+                self.tilt_error[1] = int(match.group(2))
+                self.tilt_error[2] = int(match.group(3))
+            else:
+                print "Failure parsing helical turn tilt_error at", line_no
+            match = re.match(".*:DR([-0-9]*?),([-0-9]*?),([-0-9]*?):",line) #DR is Desired Rotation
+            if match :
+                self.desired_rotation[0] = int(match.group(1))
+                self.desired_rotation[1] = int(match.group(2))
+                self.desired_rotation[2] = int(match.group(3))
+            else:
+                print "Failure parsing helical turn desired_rotation_rate at", line_no
+            match = re.match(".*:OM([-0-9]*?),([-0-9]*?),([-0-9]*?):",line) #OM, Omega is gyro rates
+            if match :
+                self.omega_accum[0] = int(match.group(1))
+                self.omega_accum[1] = int(match.group(2))
+                self.omega_accum[2] = int(match.group(3))
+            else:
+                print "Failure parsing omega_accum gyros rates at", line_no
+            match = re.match(".*:DT([-0-9]*?):",line) # Desired Turn Rate in the Earth Z Axis
+            if match :
+                try:
+                    self.desired_turn_rate = int(match.group(1))
+                except:
+                    pass
+            match = re.match(".*:EL([-0-9]*?):",line) # Elevator Trim as a reault Main Wing Loading
+            if match :
+                try:
+                    self.elevator_loading_trim = int(match.group(1))
+                except:
+                    pass
+                
+            return "F23"
+
+        #################################################################
+        # Try Another format of telemetry
+        match = re.match("^F24:",line) # If line starts with F24 (Delta Wing elevon neutral value)
+        if match :
+            # Parse the line for options.h values
+            match = re.match(".*:AIL=([0-9]*?):",line)   # Aileron Channel
+            if match :
+                self.aileron_channel_neutral  = int(match.group(1))
+            else :
+                print "Failure parsing Delta Wing Neutral values for AILERON CHANNEL at line", line_no
+            match = re.match(".*:ELEV=([0-9]*?):",line)  # Elevator Channel
+            if match :
+                self.elevator_channel_neutral   = int(match.group(1))
+            else :
+                print "Failure parsing ELEVATOR CHANNEL at line", line_no 
+            return "F24"
         
         #################################################################
         # Try Another format of telemetry

--- a/Tools/flight_analyzer/matrixpilot_lib.py
+++ b/Tools/flight_analyzer/matrixpilot_lib.py
@@ -254,10 +254,14 @@ class base_telemetry :
         self.elevator_output_channel = 0
         self.throttle_output_channel = 0
         self.rudder_output_channel   = 0
-        self.aileron_output_reversed  = 0
-        self.elevator_output_reversed = 0
-        self.throttle_output_reversed = 0
-        self.rudder_output_reversed   = 0
+        self.aileron_input_channel  = 0
+        self.elevator_input_channel = 0
+        self.throttle_input_channel = 0
+        self.rudder_input_channel   = 0
+        self.aileron_input_reversed  = 0
+        self.elevator_input_reversed = 0
+        self.throttle_input_reversed = 0
+        self.rudder_input_reversed   = 0
         self.number_of_input_channels = 0
         self.channel_trim_values = [0,0,0,0,0,0,0,0,0,0,0,0,0]
         self.barometer_temperature = 0
@@ -501,13 +505,13 @@ class mavlink_telemetry(base_telemetry):
 
         elif telemetry_file.msg.get_type() == 'SERIAL_UDB_EXTRA_F19' :
             self.aileron_output_channel = telemetry_file.msg.sue_aileron_output_channel
-            self.aileron_output_reversed = telemetry_file.msg.sue_aileron_reversed
+            self.aileron_input_reversed = telemetry_file.msg.sue_aileron_reversed
             self.elevator_output_channel = telemetry_file.msg.sue_elevator_output_channel
-            self.elevator_output_reversed = telemetry_file.msg.sue_elevator_reversed
+            self.elevator_input_reversed = telemetry_file.msg.sue_elevator_reversed
             self.throttle_output_channel = telemetry_file.msg.sue_throttle_output_channel
-            self.throttle_output_reversed = telemetry_file.msg.sue_throttle_reversed
+            self.throttle_input_reversed = telemetry_file.msg.sue_throttle_reversed
             self.rudder_output_channel = telemetry_file.msg.sue_rudder_output_channel
-            self.rudder_output_reversed = telemetry_file.msg.sue_rudder_reversed
+            self.rudder_input_reversed = telemetry_file.msg.sue_rudder_reversed
 
             return('F19')
 
@@ -1920,28 +1924,28 @@ class ascii_telemetry(base_telemetry):
         match = re.match("^F19:",line) # If line starts with F19
         if match :
             # Parse the line for options.h values
-            match = re.match(".*:AIL=([0-9]*?),([0-9]*?):",line)   # Aileron Channel, and reversal 
+            match = re.match(".*:AIL=([0-9]*?),([0-9]*?):",line)   # Aileron Input Channel, and reversal 
             if match :
-                self.aileron_output_channel  = int(match.group(1))
-                self.aileron_output_reversed = int(match.group(2))
+                self.aileron_input_channel  = int(match.group(1))
+                self.aileron_input_reversed = int(match.group(2))
             else :
                 print "Failure parsing AILERON CHANNEL at line", line_no
-            match = re.match(".*:ELEV=([0-9]*?),([0-9]*?):",line)  # Elevator Channel, and reversal 
+            match = re.match(".*:ELEV=([0-9]*?),([0-9]*?):",line)  # Elevator Input Channel, and reversal 
             if match :
-                self.elevator_output_channel   = int(match.group(1))
-                self.elevator_output_reversed = int(match.group(2))
+                self.elevator_input_channel   = int(match.group(1))
+                self.elevator_input_reversed = int(match.group(2))
             else :
                 print "Failure parsing ELEVATOR CHANNEL at line", line_no
-            match = re.match(".*:THROT=([0-9]*?),([0-9]*?):",line) # Throttle Channel, and reversal 
+            match = re.match(".*:THROT=([0-9]*?),([0-9]*?):",line) # Throttle Input Channel, and reversal 
             if match :
-                self.throttle_output_channel  = int(match.group(1))
-                self.throttle_output_reversed = int(match.group(2))
+                self.throttle_input_channel  = int(match.group(1))
+                self.throttle_input_reversed = int(match.group(2))
             else :
                 print "Failure parsing THROTTLE CHANNEL at line", line_no
-            match = re.match(".*:RUDD=([0-9]*?),([0-9]*?):",line) # Rudder Channel, and reversal 
+            match = re.match(".*:RUDD=([0-9]*?),([0-9]*?):",line) # Rudder Input Channel, and reversal 
             if match :
-                self.rudder_output_channel  = int(match.group(1))
-                self.rudder_output_reversed = int(match.group(2))
+                self.rudder_input_channel  = int(match.group(1))
+                self.rudder_input_reversed = int(match.group(2))
             else :
                 print "Failure parsing RUDDER CHANNEL at line", line_no
             return "F19"
@@ -2054,6 +2058,34 @@ class ascii_telemetry(base_telemetry):
             else :
                 print "Failure parsing ELEVATOR CHANNEL at line", line_no 
             return "F24"
+        
+        #################################################################
+        # Try Another format of telemetry
+
+        match = re.match("^F25:",line) # If line starts with 25
+        if match :
+            # Parse the line for options.h values
+            match = re.match(".*:AIL=([0-9]*?):",line)   # Aileron Output Channel
+            if match :
+                self.aileron_output_channel  = int(match.group(1))
+            else :
+                print "Failure parsing AILERON CHANNEL at line", line_no
+            match = re.match(".*:ELEV=([0-9]*?):",line)  # Elevator Output Channel
+            if match :
+                self.elevator_output_channel   = int(match.group(1))
+            else :
+                print "Failure parsing ELEVATOR CHANNEL at line", line_no
+            match = re.match(".*:THROT=([0-9]*?):",line) # Throttle Output Channel
+            if match :
+                self.throttle_output_channel  = int(match.group(1))
+            else :
+                print "Failure parsing THROTTLE CHANNEL at line", line_no
+            match = re.match(".*:RUDD=([0-9]*?):",line) # Rudder Output Channel 
+            if match :
+                self.rudder_output_channel  = int(match.group(1))
+            else :
+                print "Failure parsing RUDDER CHANNEL at line", line_no
+            return "F25"
         
         #################################################################
         # Try Another format of telemetry


### PR DESCRIPTION
I am ambivalent about adding these changes to master, as I have not seen much interest in them so far. But I'm going to post this Pull Request here for now, to see if anyone actually would like this facility.

This set of changes allows the effects of PID flight control gains to be analyzed in more detail; either using a csv file / spreadsheet, or using a [graphing tool within an inflight video. ](https://vimeo.com/264754315). I have used "racerenderer" and I could add the templates for racerender to pick up the data from the csv file, and to layout the graphs on the video. I think it is quite useful for seeing whether the Tilt error, Rate of rotation error, or Desired Rotation, or dynamic Trim, is responsible at any moment, for moving the ailerons, rudder or elevator.

I have tested this on my sonic mini flying wing. And now hope to test it also on my Alpha Axion trainer (standard airframe).

The only downside of this request, is that the F23: format statement in the SUE telemetry will be longer, and so your SD card in the OpenLog will need to be fast enough to keep up with saving the data. Mine does. But I know that historically, some people have slower SD cards, and might start to drop data.