### PR TITLE
flightplan-waypoints.c: Fix navigation glitch 

### DIFF
--- a/MatrixPilot/flightplan-waypoints.c
+++ b/MatrixPilot/flightplan-waypoints.c
@@ -348,10 +348,8 @@ static void next_waypoint(void)
 	else
 	{
 		navigate_set_goal(GPSlocation, current_waypoint.loc);
-#if (DEADRECKONING == 0)
-		navigate_compute_bearing_to_goal();
-#endif
 	}
+    navigate_compute_bearing_to_goal();
 }
 
 //void run_flightplan(void)


### PR DESCRIPTION
When working on a landing flight plan at a soccer field for his Easystar, Bill discovered that on occasion there was a 1/40th of a second glitch in the interpolated calculation of desiredHeight only when a new waypoint was selected in Autonomous mode.  The interpolated desiredHeight becomes the new waypoint desiredHeight  for 1/40th of a second. i.e. desiredHeight  is not interpolated until the next flightcontrol frame runs, and there after everything is correct until the next waypoint is reached.

I have since replicated the bug in HILSIM which can be seen for every waypoint where the requested altitude is different (only seen consistently when telemetry is printed out at 40Hz).

This bug does not occur when using Logo, as the Logo code specifically re-calls navigation_compute_bearing_to_goal() when the location of the Turtle (waypoint) changes. This did not happen for the traditional waypoint system. 

Bill, and I have discussed a couple of alternatives for the fix, and this is the one that we have settled on. With this fix, whenever a new waypoint is selected, navigation_compute_bearing_to_goal() is called immediately.

Best wishes, Pete
