### PR TITLE
Fix radio in

### DIFF
--- a/Tools/MatrixPilot-SIL/SIL-udb.c
+++ b/Tools/MatrixPilot-SIL/SIL-udb.c
@@ -89,9 +89,9 @@ inline int gettimeofday(struct timeval* p, void* tz /* IGNORED */)
 uint16_t udb_heartbeat_counter;
 uint16_t udb_pulse_counter;
 
-int16_t udb_pwIn[MAX_INPUTS+1];   // pulse widths of radio inputs
-int16_t udb_pwTrim[MAX_INPUTS+1]; // initial pulse widths for trimming
-int16_t udb_pwOut[MAX_OUTPUTS+1]; // pulse widths for servo outputs
+uint16_t udb_pwIn[MAX_INPUTS+1];   // pulse widths of radio inputs
+uint16_t udb_pwTrim[MAX_INPUTS+1]; // initial pulse widths for trimming
+uint16_t udb_pwOut[MAX_OUTPUTS+1]; // pulse widths for servo outputs
 
 union udb_fbts_byte udb_flags;
 

--- a/libUDB/libUDB.h
+++ b/libUDB/libUDB.h
@@ -182,19 +182,19 @@ void cpu_load_calc(void);
 //! These are the values of the radio input channels.  Each channel will be a
 //! value between approximately 2000 and 4000, with 3000 being the center.
 //! Treat udb_pwIn values as readonly.
-extern int16_t udb_pwIn[];                  // pulse widths of radio inputs
+extern uint16_t udb_pwIn[];                  // pulse widths of radio inputs
 
 //! These are the recorded trim values of the radio input channels.
 //! These values are recorded when you call the udb_servo_record_trims()
 //! function.
 //! Each channel will be a value between approximately 2000 and 4000.
 //! Treat udb_pwTrim values as readonly.
-extern int16_t udb_pwTrim[];                // initial pulse widths for trimming
+extern uint16_t udb_pwTrim[];                // initial pulse widths for trimming
 
 //! These are the servo channel values that will be sent out to the servos.
 //! Set these values in your implementation of the udb_heartbeat_callback()
 //! Each channel should be set to a value between 2000 and 4000.
-extern int16_t udb_pwOut[];                 // pulse widths for servo outputs
+extern uint16_t udb_pwOut[];                 // pulse widths for servo outputs
 
 //! This read-only value holds flags that tell you, among other things,
 //! whether the receiver is currently receiving values from the transmitter.

--- a/libUDB/radioIn.c
+++ b/libUDB/radioIn.c
@@ -64,8 +64,8 @@
 // The pulse width inputs can be directly converted to units of pulse width outputs to control
 // the servos by simply dividing by 2. (need to check validity of this statement - RobD)
 
-int16_t udb_pwIn[NUM_INPUTS+1];     // pulse widths of radio inputs
-int16_t udb_pwTrim[NUM_INPUTS+1];   // initial pulse widths for trimming
+uint16_t udb_pwIn[NUM_INPUTS+1];     // pulse widths of radio inputs
+uint16_t udb_pwTrim[NUM_INPUTS+1];   // initial pulse widths for trimming
 
 static int16_t goodPWMPulseCount = 0;
 static int16_t badPWMPulseCount = 0;
@@ -178,9 +178,17 @@ void radioIn_bad_pulse_count_reset(void)
 }
 
 #if (NORADIO != 1)
-static void set_udb_pwIn(int pwm, int index)
+static void set_udb_pwIn(uint16_t pwm, uint16_t index)
 {
-	pwm = pwm * TMR_FACTOR / 2; // yes we are scaling the parameter up front
+#if (TMR_FACTOR == 1 )
+	pwm = pwm / 2 ;
+#elif (TMR_FACTOR == 2 )
+	// pwm does not need to be scaled
+#elif (TMR_FACTOR == 4 )
+	pwm = pwm * 2 ;
+#else
+#error "invalid TMR_FACTOR, check MIPS setting"
+#endif // TMR_FACTOR 
 
 	if (FAILSAFE_INPUT_CHANNEL == index)
 	{

--- a/libUDB/servoOut.c
+++ b/libUDB/servoOut.c
@@ -37,7 +37,7 @@
 #error Invalid MIPS Configuration
 #endif
 
-int16_t udb_pwOut[NUM_OUTPUTS+1];   // pulse widths for servo outputs
+uint16_t udb_pwOut[NUM_OUTPUTS+1];   // pulse widths for servo outputs
 static volatile int16_t outputNum;
 
 

--- a/libUDB/servoOut.h
+++ b/libUDB/servoOut.h
@@ -20,7 +20,7 @@
 
 //	routines to drive the PWM pins for the servos,
 
-extern int16_t udb_pwOut[]; // pulse widths for servo outputs
+extern uint16_t udb_pwOut[]; // pulse widths for servo outputs
 
 
 //void udb_init_pwm(void)

--- a/libUDB/sonarIn.c
+++ b/libUDB/sonarIn.c
@@ -25,11 +25,11 @@
 
 #if (USE_SONAR_INPUT != 0)
 
-int16_t udb_pwm_sonar;          // pulse width of sonar signal
-static int16_t udb_pwm_sonar_rise;
+uint16_t udb_pwm_sonar;          // pulse width of sonar signal
+static uint16_t udb_pwm_sonar_rise;
 static uint16_t sonar_pwm_count;
 
-int16_t get_sonar_value(void)
+uint16_t get_sonar_value(void)
 {
 	return udb_pwm_sonar;
 }

--- a/libUDB/sonarIn.h
+++ b/libUDB/sonarIn.h
@@ -19,8 +19,8 @@
 // along with MatrixPilot.  If not, see <http://www.gnu.org/licenses/>.
 
 
-//extern int16_t udb_pwm_sonar;          // pulse width of sonar signal
+//extern uint16_t udb_pwm_sonar;          // pulse width of sonar signal
 
-int16_t get_sonar_value(void);   // Get the raw pwm units from the sonar device driver
+uint16_t get_sonar_value(void);   // Get the raw pwm units from the sonar device driver
 uint16_t get_sonar_count(void);
 void udb_init_sonar(void);


### PR DESCRIPTION
Two minor improvements to pwm computations:

Changed a pwm argument to a subroutine from int16_t to uint16_t. This increases range by one bit.
Changed scaling computation to avoid losing one bit in some situations.
These changes have no effect in most cases. However, if the pwm routines are used to measure pulses coming from other sources, such as SONAR or LIDAR, then the changes are useful.